### PR TITLE
Add ControlPlaneExposure support from ButlerConfig

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/butlerdotdev/butler-controller
 go 1.24.6
 
 require (
-	github.com/butlerdotdev/butler-api v0.1.4-0.20260123161832-70a3a7e0517a
+	github.com/butlerdotdev/butler-api v0.1.4-0.20260205213833-c2006174e0a9
 	github.com/onsi/ginkgo/v2 v2.22.0
 	github.com/onsi/gomega v1.36.1
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
-github.com/butlerdotdev/butler-api v0.1.4-0.20260123161832-70a3a7e0517a h1:7w0qOhZfNcrkoH3dwrSpWrY6oFtfs316UvuAae6FdnU=
-github.com/butlerdotdev/butler-api v0.1.4-0.20260123161832-70a3a7e0517a/go.mod h1:q/RjPFM/r2ELq4DqR78OiAxerKBvH5D4nTGsVLKbjqY=
+github.com/butlerdotdev/butler-api v0.1.4-0.20260205213833-c2006174e0a9 h1:1duOa/QR6kF4eKMIFCU2Uc+8S4mAxL5BQIVfW/aqeYc=
+github.com/butlerdotdev/butler-api v0.1.4-0.20260205213833-c2006174e0a9/go.mod h1:q/RjPFM/r2ELq4DqR78OiAxerKBvH5D4nTGsVLKbjqY=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/internal/capi/builder.go
+++ b/internal/capi/builder.go
@@ -66,6 +66,7 @@ type ResourceSet struct {
 type Builder struct {
 	tc             *butlerv1alpha1.TenantCluster
 	providerConfig *butlerv1alpha1.ProviderConfig
+	butlerConfig   *butlerv1alpha1.ButlerConfig
 	namespace      string
 	nutanixCreds   *NutanixCredentials
 }
@@ -92,6 +93,13 @@ func (b *Builder) WithNutanixCredentials(username, password string) *Builder {
 		Username: username,
 		Password: password,
 	}
+	return b
+}
+
+// WithButlerConfig sets the ButlerConfig for platform-level settings.
+// This enables reading ControlPlaneExposure for tcp-proxy auto-enablement.
+func (b *Builder) WithButlerConfig(bc *butlerv1alpha1.ButlerConfig) *Builder {
+	b.butlerConfig = bc
 	return b
 }
 
@@ -251,10 +259,74 @@ func (b *Builder) buildStewardControlPlane(name string) *unstructured.Unstructur
 		dataStoreName = b.tc.Spec.ControlPlane.DataStoreRef.Name
 	}
 
-	// Get service type
+	// Determine exposure mode and service type from ButlerConfig (platform-level)
+	// Default to LoadBalancer if ButlerConfig not provided
+	exposureMode := butlerv1alpha1.ControlPlaneExposureModeLoadBalancer
+	var exposureHostname string
+	var gatewayRef string
+	var ingressClassName string
+
+	if b.butlerConfig != nil {
+		exposureMode = b.butlerConfig.GetControlPlaneExposureMode()
+		exposureHostname = b.butlerConfig.GetControlPlaneExposureHostname()
+		gatewayRef = b.butlerConfig.GetControlPlaneExposureGatewayRef()
+		ingressClassName = b.butlerConfig.GetControlPlaneExposureIngressClassName()
+	}
+
+	// Map exposure mode to service type
 	serviceType := "LoadBalancer"
+	if exposureMode == butlerv1alpha1.ControlPlaneExposureModeIngress ||
+		exposureMode == butlerv1alpha1.ControlPlaneExposureModeGateway {
+		serviceType = "ClusterIP"
+	}
+
+	// TenantCluster serviceType override (should be rare, but allowed)
 	if b.tc.Spec.ControlPlane.ServiceType != "" {
 		serviceType = b.tc.Spec.ControlPlane.ServiceType
+	}
+
+	// Build addons map - always include core addons
+	addons := map[string]interface{}{
+		"coreDNS":      map[string]interface{}{},
+		"kubeProxy":    map[string]interface{}{},
+		"konnectivity": map[string]interface{}{},
+	}
+
+	// AUTO-ENABLE tcp-proxy for non-LoadBalancer modes
+	// tcp-proxy rewrites kubernetes.default.svc EndpointSlice for in-cluster API access
+	if exposureMode == butlerv1alpha1.ControlPlaneExposureModeIngress ||
+		exposureMode == butlerv1alpha1.ControlPlaneExposureModeGateway {
+		addons["tcpProxy"] = map[string]interface{}{}
+	}
+
+	// Build network configuration
+	network := map[string]interface{}{
+		"serviceType": serviceType,
+	}
+
+	// Configure Ingress mode
+	if exposureMode == butlerv1alpha1.ControlPlaneExposureModeIngress && exposureHostname != "" {
+		tenantHostname := b.generateTenantHostname(exposureHostname)
+		ingressConfig := map[string]interface{}{
+			"hostname": tenantHostname,
+		}
+		if ingressClassName != "" {
+			ingressConfig["className"] = ingressClassName
+		}
+		network["ingress"] = ingressConfig
+	}
+
+	// Configure Gateway mode
+	if exposureMode == butlerv1alpha1.ControlPlaneExposureModeGateway && exposureHostname != "" {
+		tenantHostname := b.generateTenantHostname(exposureHostname)
+		gatewayConfig := map[string]interface{}{
+			"hostname": tenantHostname,
+		}
+		if gatewayRef != "" {
+			// Parse gatewayRef "namespace/name" format
+			gatewayConfig["parentRefs"] = b.buildGatewayParentRefs(gatewayRef)
+		}
+		network["gateway"] = gatewayConfig
 	}
 
 	// See: https://steward.butlerlabs.dev/cluster-api/kamaji-control-plane-provider/
@@ -262,14 +334,7 @@ func (b *Builder) buildStewardControlPlane(name string) *unstructured.Unstructur
 		"version":       b.tc.Spec.KubernetesVersion,
 		"replicas":      replicas,
 		"dataStoreName": dataStoreName,
-
-		// Addons - Kamaji manages these automatically
-		// konnectivity is enabled by default, version matched automatically
-		"addons": map[string]interface{}{
-			"coreDNS":      map[string]interface{}{},
-			"kubeProxy":    map[string]interface{}{},
-			"konnectivity": map[string]interface{}{},
-		},
+		"addons":        addons,
 
 		// Kubelet configuration for Rocky Linux / systemd
 		"kubelet": map[string]interface{}{
@@ -282,9 +347,7 @@ func (b *Builder) buildStewardControlPlane(name string) *unstructured.Unstructur
 		},
 
 		// Network configuration
-		"network": map[string]interface{}{
-			"serviceType": serviceType,
-		},
+		"network": network,
 	}
 
 	// Add certSANs if specified
@@ -298,6 +361,29 @@ func (b *Builder) buildStewardControlPlane(name string) *unstructured.Unstructur
 
 	kcp.Object["spec"] = spec
 	return kcp
+}
+
+// generateTenantHostname creates a tenant-specific hostname from a wildcard pattern.
+// Pattern "*.k8s.example.com" becomes "clustername.namespace.k8s.example.com"
+func (b *Builder) generateTenantHostname(pattern string) string {
+	base := strings.TrimPrefix(pattern, "*.")
+	return fmt.Sprintf("%s.%s.%s", b.tc.Name, b.namespace, base)
+}
+
+// buildGatewayParentRefs constructs Gateway API parentRefs from a "namespace/name" reference.
+func (b *Builder) buildGatewayParentRefs(gatewayRef string) []interface{} {
+	parts := strings.Split(gatewayRef, "/")
+	if len(parts) != 2 {
+		return nil
+	}
+	return []interface{}{
+		map[string]interface{}{
+			"group":     "gateway.networking.k8s.io",
+			"kind":      "Gateway",
+			"namespace": parts[0],
+			"name":      parts[1],
+		},
+	}
 }
 
 // buildKubevirtMachineTemplate constructs the KubevirtMachineTemplate resource.

--- a/internal/controller/tenantcluster/tenantcluster_controller.go
+++ b/internal/controller/tenantcluster/tenantcluster_controller.go
@@ -145,7 +145,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		}
 	}
 
-	result, err := r.reconcileInfrastructure(ctx, tc)
+	result, err := r.reconcileInfrastructure(ctx, tc, butlerConfig)
 	if err != nil {
 		logger.Error(err, "failed to reconcile infrastructure")
 		return r.setFailedStatus(ctx, tc, ReasonCAPIResourceError, err.Error())
@@ -172,7 +172,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	return ctrl.Result{RequeueAfter: r.calculateRequeueInterval(tc)}, nil
 }
 
-func (r *Reconciler) reconcileInfrastructure(ctx context.Context, tc *butlerv1alpha1.TenantCluster) (ctrl.Result, error) {
+func (r *Reconciler) reconcileInfrastructure(ctx context.Context, tc *butlerv1alpha1.TenantCluster, butlerConfig *butlerv1alpha1.ButlerConfig) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
 
 	// Already ready, nothing to do
@@ -189,7 +189,11 @@ func (r *Reconciler) reconcileInfrastructure(ctx context.Context, tc *butlerv1al
 		return ctrl.Result{}, err
 	}
 
-	builder := capi.NewBuilder(tc, providerConfig, tc.Status.TenantNamespace)
+	// Build CAPI resources with ButlerConfig for platform-level settings
+	// ButlerConfig provides ControlPlaneExposure settings (LoadBalancer/Ingress/Gateway mode)
+	// which enables auto-enabling tcp-proxy for non-LoadBalancer modes
+	builder := capi.NewBuilder(tc, providerConfig, tc.Status.TenantNamespace).
+		WithButlerConfig(butlerConfig)
 	resourceSet, err := builder.Build()
 	if err != nil {
 		r.setCondition(tc, butlerv1alpha1.TenantClusterConditionInfrastructureReady,


### PR DESCRIPTION
- Read exposure mode from ButlerConfig singleton in CAPI builder
- Auto-enable tcpProxy addon for Ingress/Gateway modes
- Generate tenant-specific hostnames from wildcard pattern
- Configure gateway parentRefs when Gateway mode is active
- Update tenantcluster controller to pass ButlerConfig to builder

This enables platform-level control plane exposure configuration where all TenantClusters inherit the network mode from ButlerConfig.