### PR TITLE
feat: add Ingress mode support for TenantCluster control planes

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,6 +2,11 @@
 # Ignore everything by default and re-include only needed files
 **
 
+# Re-include necessary directories
+!cmd/
+!internal/
+!api/
+!pkg/
 # Re-include Go source files (but not *_test.go)
 !**/*.go
 **/*_test.go

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN go mod download
 # Copy the Go source (relies on .dockerignore to filter)
 COPY . .
 # Build
-RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager cmd/main.go
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager ./cmd/main.go
 
 # Final image with tools
 FROM alpine:3.21

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/butlerdotdev/butler-controller
 go 1.24.6
 
 require (
-	github.com/butlerdotdev/butler-api v0.1.4-0.20260205213833-c2006174e0a9
+	github.com/butlerdotdev/butler-api v0.1.4-0.20260205235822-10d3155f4db2
 	github.com/onsi/ginkgo/v2 v2.22.0
 	github.com/onsi/gomega v1.36.1
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
-github.com/butlerdotdev/butler-api v0.1.4-0.20260205213833-c2006174e0a9 h1:1duOa/QR6kF4eKMIFCU2Uc+8S4mAxL5BQIVfW/aqeYc=
-github.com/butlerdotdev/butler-api v0.1.4-0.20260205213833-c2006174e0a9/go.mod h1:q/RjPFM/r2ELq4DqR78OiAxerKBvH5D4nTGsVLKbjqY=
+github.com/butlerdotdev/butler-api v0.1.4-0.20260205235822-10d3155f4db2 h1:qqCtDDALiRza9gp3EO6i4xBCHtqnBC0bezMx+7fOUHg=
+github.com/butlerdotdev/butler-api v0.1.4-0.20260205235822-10d3155f4db2/go.mod h1:q/RjPFM/r2ELq4DqR78OiAxerKBvH5D4nTGsVLKbjqY=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/internal/addons/installer.go
+++ b/internal/addons/installer.go
@@ -19,8 +19,10 @@ package addons
 import (
 	"context"
 	"fmt"
+	"net"
 	"os"
 	"os/exec"
+	"strings"
 
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
@@ -124,8 +126,36 @@ func (i *Installer) ensurePrivilegedNamespace(ctx context.Context, kubeconfigPat
 	return nil
 }
 
+// CiliumConfig contains the configuration for installing Cilium.
+type CiliumConfig struct {
+	// Version is the Cilium version to install.
+	Version string
+	// APIServerHost is the hostname or IP of the API server.
+	APIServerHost string
+	// APIServerPort is the port of the API server.
+	APIServerPort string
+	// IngressIP is the IP address of the Ingress controller (for hostAlias).
+	// Only used when using Ingress mode with a hostname.
+	IngressIP string
+}
+
 // InstallCilium installs Cilium CNI configured for hosted control planes.
-func (i *Installer) InstallCilium(ctx context.Context, kubeconfig []byte, version string, apiServerHost string, apiServerPort string) error {
+//
+// For Ingress/Gateway mode (hostname-based API access):
+// Uses "Template-Patch-Apply" pattern to solve the DNS bootstrap problem.
+// CoreDNS needs CNI (Cilium) to run, but Cilium pods need DNS to resolve
+// the API server hostname. We solve this by:
+// 1. Using `helm template` to render manifests (no cluster contact)
+// 2. Patching hostAliases directly into the rendered manifests
+// 3. Applying with `kubectl apply` - pods start with hostAliases from the beginning
+// 4. Waiting for rollout completion
+//
+// This ensures pods NEVER attempt to resolve the hostname without hostAliases,
+// avoiding progressDeadlineSeconds failures.
+//
+// For LoadBalancer mode: Cilium connects directly to the LoadBalancer IP,
+// no hostname resolution needed, so we use standard `helm upgrade --install --wait`.
+func (i *Installer) InstallCilium(ctx context.Context, kubeconfig []byte, cfg CiliumConfig) error {
 	logger := log.FromContext(ctx)
 
 	kubeconfigPath, cleanup, err := i.writeKubeconfig(kubeconfig)
@@ -134,13 +164,24 @@ func (i *Installer) InstallCilium(ctx context.Context, kubeconfig []byte, versio
 	}
 	defer cleanup()
 
+	version := cfg.Version
 	if version == "" {
 		version = DefaultCiliumVersion
 	}
 
-	logger.Info("installing Cilium for tenant cluster", "version", version)
+	// Determine if we need hostAlias (Ingress/Gateway mode with hostname)
+	needsHostAlias := cfg.IngressIP != "" && !isIPAddress(cfg.APIServerHost)
 
-	i.ensurePrivilegedNamespace(ctx, kubeconfigPath, "kube-system")
+	logger.Info("installing Cilium for tenant cluster",
+		"version", version,
+		"apiServerHost", cfg.APIServerHost,
+		"apiServerPort", cfg.APIServerPort,
+		"ingressIP", cfg.IngressIP,
+		"needsHostAlias", needsHostAlias)
+
+	if err := i.ensurePrivilegedNamespace(ctx, kubeconfigPath, "kube-system"); err != nil {
+		return fmt.Errorf("failed to ensure kube-system namespace: %w", err)
+	}
 
 	if err := i.runHelm(ctx, kubeconfigPath, "repo", "add", "cilium", "https://helm.cilium.io/"); err != nil {
 		logger.V(1).Info("helm repo add failed (may already exist)", "error", err)
@@ -149,8 +190,7 @@ func (i *Installer) InstallCilium(ctx context.Context, kubeconfig []byte, versio
 		logger.V(1).Info("helm repo update failed", "error", err)
 	}
 
-	args := []string{
-		"upgrade", "--install", "cilium", "cilium/cilium",
+	baseArgs := []string{
 		"--version", version,
 		"--namespace", "kube-system",
 		"--set", "ipam.mode=kubernetes",
@@ -159,21 +199,161 @@ func (i *Installer) InstallCilium(ctx context.Context, kubeconfig []byte, versio
 		"--set", "securityContext.capabilities.cleanCiliumState={NET_ADMIN,SYS_ADMIN,SYS_RESOURCE}",
 		"--set", "cgroup.autoMount.enabled=false",
 		"--set", "cgroup.hostRoot=/sys/fs/cgroup",
-		"--set", "k8sServiceHost=kubernetes.default.svc.cluster.local",
-		"--set", "k8sServicePort=443",
 		"--set", "hubble.relay.enabled=true",
 		"--set", "hubble.ui.enabled=true",
-		"--set", fmt.Sprintf("k8sServiceHost=%s", apiServerHost),
-		"--set", fmt.Sprintf("k8sServicePort=%s", apiServerPort),
-		"--wait",
-		"--timeout", "10m",
+		"--set", fmt.Sprintf("k8sServiceHost=%s", cfg.APIServerHost),
+		"--set", fmt.Sprintf("k8sServicePort=%s", cfg.APIServerPort),
 	}
 
-	if err := i.runHelm(ctx, kubeconfigPath, args...); err != nil {
-		return fmt.Errorf("failed to install Cilium: %w", err)
+	if needsHostAlias {
+		// Ingress/Gateway mode: Template-Patch-Apply pattern
+		logger.Info("using Template-Patch-Apply pattern for Ingress/Gateway mode")
+
+		if err := i.installCiliumWithHostAlias(ctx, kubeconfigPath, baseArgs, cfg.APIServerHost, cfg.IngressIP); err != nil {
+			return fmt.Errorf("failed to install Cilium with hostAlias: %w", err)
+		}
+	} else {
+		// LoadBalancer mode: Standard helm install with --wait
+		args := append([]string{"upgrade", "--install", "cilium", "cilium/cilium"}, baseArgs...)
+		args = append(args, "--wait", "--timeout", "10m")
+
+		if err := i.runHelm(ctx, kubeconfigPath, args...); err != nil {
+			return fmt.Errorf("failed to install Cilium: %w", err)
+		}
 	}
 
 	logger.Info("Cilium installed successfully")
+	return nil
+}
+
+// installCiliumWithHostAlias uses helm template + kubectl apply to install Cilium
+// with hostAliases pre-configured. This ensures pods start with hostAliases from
+// the very first attempt, avoiding DNS resolution failures.
+func (i *Installer) installCiliumWithHostAlias(ctx context.Context, kubeconfigPath string, helmArgs []string, hostname, ip string) error {
+	logger := log.FromContext(ctx)
+
+	// Step 1: Render manifests with helm template
+	logger.Info("rendering Cilium manifests with helm template")
+	templateArgs := append([]string{"template", "cilium", "cilium/cilium"}, helmArgs...)
+
+	cmd := exec.CommandContext(ctx, i.helmPath, templateArgs...)
+	manifestBytes, err := cmd.Output()
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			return fmt.Errorf("helm template failed: %w, stderr: %s", err, string(exitErr.Stderr))
+		}
+		return fmt.Errorf("helm template failed: %w", err)
+	}
+
+	// Step 2: Patch manifests to add hostAliases
+	logger.Info("patching manifests with hostAliases", "hostname", hostname, "ip", ip)
+	patchedManifests := i.patchManifestsWithHostAlias(string(manifestBytes), hostname, ip)
+
+	// Step 3: Write patched manifests to temp file
+	manifestFile, err := os.CreateTemp("", "cilium-manifests-*.yaml")
+	if err != nil {
+		return fmt.Errorf("failed to create temp manifest file: %w", err)
+	}
+	defer os.Remove(manifestFile.Name())
+
+	if _, err := manifestFile.WriteString(patchedManifests); err != nil {
+		manifestFile.Close()
+		return fmt.Errorf("failed to write manifests: %w", err)
+	}
+	manifestFile.Close()
+
+	// Step 4: Apply manifests with kubectl apply
+	logger.Info("applying Cilium manifests with kubectl apply")
+	if err := i.runKubectl(ctx, kubeconfigPath,
+		"apply", "-f", manifestFile.Name(), "--server-side", "--force-conflicts",
+	); err != nil {
+		return fmt.Errorf("failed to apply Cilium manifests: %w", err)
+	}
+
+	// Step 5: Wait for rollout
+	logger.Info("waiting for Cilium rollout")
+	if err := i.waitForCiliumReady(ctx, kubeconfigPath); err != nil {
+		return fmt.Errorf("Cilium rollout failed: %w", err)
+	}
+
+	return nil
+}
+
+// patchManifestsWithHostAlias injects hostAliases into DaemonSet and Deployment specs.
+// This is a simple string-based patch that adds hostAliases to pod specs.
+func (i *Installer) patchManifestsWithHostAlias(manifests, hostname, ip string) string {
+	// The hostAliases block to inject (indented for pod spec)
+	hostAliasesBlock := fmt.Sprintf(`      hostAliases:
+      - hostnames:
+        - %s
+        ip: %s
+`, hostname, ip)
+
+	// Pattern to find the serviceAccountName line in pod specs and inject hostAliases before it
+	// This works because serviceAccountName is typically in the pod spec alongside hostAliases
+	result := manifests
+
+	// Patch all Cilium-related service accounts that might need API server access
+	// Note: helm template outputs quoted service account names like "cilium"
+	serviceAccounts := []string{
+		"cilium",          // Main Cilium agent DaemonSet
+		"cilium-envoy",    // Cilium Envoy DaemonSet
+		"cilium-operator", // Cilium Operator Deployment
+		"hubble-relay",    // Hubble Relay Deployment
+		"hubble-ui",       // Hubble UI Deployment
+	}
+
+	for _, sa := range serviceAccounts {
+		// Try quoted format first (helm template output)
+		result = strings.Replace(result,
+			fmt.Sprintf("      serviceAccountName: \"%s\"\n", sa),
+			hostAliasesBlock+fmt.Sprintf("      serviceAccountName: \"%s\"\n", sa),
+			-1)
+		// Also try unquoted format (for compatibility)
+		result = strings.Replace(result,
+			fmt.Sprintf("      serviceAccountName: %s\n", sa),
+			hostAliasesBlock+fmt.Sprintf("      serviceAccountName: %s\n", sa),
+			-1)
+	}
+
+	return result
+}
+
+// isIPAddress returns true if the given string is an IP address.
+func isIPAddress(s string) bool {
+	return net.ParseIP(s) != nil
+}
+
+// waitForCiliumReady waits for Cilium DaemonSet and Operator Deployment to be ready.
+// For operator: waits until at least 1 pod is Ready (handles single-node clusters where
+// only 1 of 2 replicas can be scheduled due to pod anti-affinity).
+// For agent: uses DaemonSet rollout status which works correctly for node-scoped resources.
+func (i *Installer) waitForCiliumReady(ctx context.Context, kubeconfigPath string) error {
+	logger := log.FromContext(ctx)
+
+	// Wait for DaemonSet rollout (this works correctly for DaemonSets)
+	logger.Info("waiting for Cilium agent DaemonSet")
+	if err := i.runKubectl(ctx, kubeconfigPath,
+		"rollout", "status", "daemonset/cilium",
+		"-n", "kube-system",
+		"--timeout=10m",
+	); err != nil {
+		return fmt.Errorf("Cilium DaemonSet rollout failed: %w", err)
+	}
+
+	// For the operator, wait until deployment has Available=True condition
+	// This checks MinimumReplicasAvailable which is what we care about
+	// (not Progressing which may have stale ProgressDeadlineExceeded)
+	logger.Info("waiting for Cilium Operator to be Available")
+	if err := i.runKubectl(ctx, kubeconfigPath,
+		"wait", "--for=condition=Available", "deployment/cilium-operator",
+		"-n", "kube-system",
+		"--timeout=5m",
+	); err != nil {
+		return fmt.Errorf("Cilium Operator not available: %w", err)
+	}
+
+	logger.Info("Cilium is Ready")
 	return nil
 }
 

--- a/internal/capi/builder.go
+++ b/internal/capi/builder.go
@@ -306,7 +306,24 @@ func (b *Builder) buildStewardControlPlane(name string) *unstructured.Unstructur
 	// tcp-proxy rewrites kubernetes.default.svc EndpointSlice for in-cluster API access
 	if exposureMode == butlerv1alpha1.ControlPlaneExposureModeIngress ||
 		exposureMode == butlerv1alpha1.ControlPlaneExposureModeGateway {
-		addons["tcpProxy"] = map[string]interface{}{}
+		tcpProxyConfig := map[string]interface{}{}
+
+		// Add hostAliases for DNS resolution before CoreDNS is ready
+		// tcp-proxy uses hostNetwork and needs to resolve the API server hostname
+		if b.ingressIP != "" && exposureHostname != "" {
+			tenantHostname := b.generateTenantHostname(exposureHostname)
+			// Konnectivity uses a parallel hostname by replacing ".k8s." with ".konnectivity."
+			konnectivityHostname := strings.Replace(tenantHostname, ".k8s.", ".konnectivity.", 1)
+
+			tcpProxyConfig["hostAliases"] = []interface{}{
+				map[string]interface{}{
+					"ip":        b.ingressIP,
+					"hostnames": []interface{}{tenantHostname, konnectivityHostname},
+				},
+			}
+		}
+
+		addons["tcpProxy"] = tcpProxyConfig
 	}
 
 	// Build network configuration
@@ -865,8 +882,9 @@ func (b *Builder) buildRockyLinuxBootstrapCommands(k8sMinorVersion string) []int
 
 	// For Ingress/Gateway modes, add /etc/hosts entry first (before any k8s commands)
 	// This allows the worker to resolve the control plane hostname via the Ingress IP
+	// Note: We use /tmp/ because it always exists, unlike /etc/hosts.d/ which cloud-init may not create
 	if b.needsIngressHostsEntry() {
-		commands = append(commands, "cat /etc/hosts.d/ingress >> /etc/hosts")
+		commands = append(commands, "cat /tmp/ingress-hosts >> /etc/hosts")
 	}
 
 	// Kernel modules for container networking
@@ -937,13 +955,17 @@ net.ipv4.ip_forward                 = 1
 		},
 	}
 
-	// For Ingress/Gateway modes, add /etc/hosts entry to resolve control plane hostname
+	// For Ingress/Gateway modes, add /etc/hosts entries to resolve control plane hostnames
+	// Both the API server hostname and konnectivity hostname need to resolve to the Ingress IP
+	// Note: We use /tmp/ because it always exists - cloud-init may not create /etc/hosts.d/
 	if b.needsIngressHostsEntry() {
 		hostname := b.generateTenantHostname(b.butlerConfig.GetControlPlaneExposureHostname())
+		// Konnectivity uses a parallel hostname by replacing ".k8s." with ".konnectivity."
+		konnectivityHostname := strings.Replace(hostname, ".k8s.", ".konnectivity.", 1)
 		files = append(files, map[string]interface{}{
-			"path":        "/etc/hosts.d/ingress",
+			"path":        "/tmp/ingress-hosts",
 			"permissions": "0644",
-			"content":     fmt.Sprintf("%s %s\n", b.ingressIP, hostname),
+			"content":     fmt.Sprintf("%s %s\n%s %s\n", b.ingressIP, hostname, b.ingressIP, konnectivityHostname),
 		})
 	}
 

--- a/internal/capi/builder.go
+++ b/internal/capi/builder.go
@@ -265,12 +265,14 @@ func (b *Builder) buildStewardControlPlane(name string) *unstructured.Unstructur
 	var exposureHostname string
 	var gatewayRef string
 	var ingressClassName string
+	var controllerType string
 
 	if b.butlerConfig != nil {
 		exposureMode = b.butlerConfig.GetControlPlaneExposureMode()
 		exposureHostname = b.butlerConfig.GetControlPlaneExposureHostname()
 		gatewayRef = b.butlerConfig.GetControlPlaneExposureGatewayRef()
 		ingressClassName = b.butlerConfig.GetControlPlaneExposureIngressClassName()
+		controllerType = b.butlerConfig.GetControlPlaneExposureControllerType()
 	}
 
 	// Map exposure mode to service type
@@ -312,6 +314,9 @@ func (b *Builder) buildStewardControlPlane(name string) *unstructured.Unstructur
 		}
 		if ingressClassName != "" {
 			ingressConfig["className"] = ingressClassName
+		}
+		if controllerType != "" {
+			ingressConfig["controllerType"] = controllerType
 		}
 		network["ingress"] = ingressConfig
 	}

--- a/internal/capi/builder.go
+++ b/internal/capi/builder.go
@@ -69,6 +69,7 @@ type Builder struct {
 	butlerConfig   *butlerv1alpha1.ButlerConfig
 	namespace      string
 	nutanixCreds   *NutanixCredentials
+	ingressIP      string // External IP for Ingress/Gateway mode TLS passthrough
 }
 
 // NutanixCredentials holds Nutanix Prism Central credentials.
@@ -100,6 +101,13 @@ func (b *Builder) WithNutanixCredentials(username, password string) *Builder {
 // This enables reading ControlPlaneExposure for tcp-proxy auto-enablement.
 func (b *Builder) WithButlerConfig(bc *butlerv1alpha1.ButlerConfig) *Builder {
 	b.butlerConfig = bc
+	return b
+}
+
+// WithIngressIP sets the external Ingress IP for TLS passthrough.
+// This is used for Ingress/Gateway modes to configure worker /etc/hosts.
+func (b *Builder) WithIngressIP(ip string) *Builder {
+	b.ingressIP = ip
 	return b
 }
 
@@ -853,8 +861,16 @@ func (b *Builder) buildKubeadmConfigTemplate(name string) *unstructured.Unstruct
 
 // buildRockyLinuxBootstrapCommands returns the preKubeadmCommands for Rocky Linux k8s node bootstrap.
 func (b *Builder) buildRockyLinuxBootstrapCommands(k8sMinorVersion string) []interface{} {
-	return []interface{}{
-		// Kernel modules for container networking
+	commands := []interface{}{}
+
+	// For Ingress/Gateway modes, add /etc/hosts entry first (before any k8s commands)
+	// This allows the worker to resolve the control plane hostname via the Ingress IP
+	if b.needsIngressHostsEntry() {
+		commands = append(commands, "cat /etc/hosts.d/ingress >> /etc/hosts")
+	}
+
+	// Kernel modules for container networking
+	commands = append(commands,
 		"modprobe overlay",
 		"modprobe br_netfilter",
 
@@ -902,12 +918,14 @@ EOF`, k8sMinorVersion, k8sMinorVersion),
 
 		// Disable firewalld (CNI manages networking)
 		"systemctl disable --now firewalld || true",
-	}
+	)
+
+	return commands
 }
 
 // buildBootstrapFiles returns additional files to create during bootstrap.
 func (b *Builder) buildBootstrapFiles(k8sMinorVersion string) []interface{} {
-	return []interface{}{
+	files := []interface{}{
 		// Sysctl configuration for k8s networking
 		map[string]interface{}{
 			"path":        "/etc/sysctl.d/k8s.conf",
@@ -918,6 +936,29 @@ net.ipv4.ip_forward                 = 1
 `,
 		},
 	}
+
+	// For Ingress/Gateway modes, add /etc/hosts entry to resolve control plane hostname
+	if b.needsIngressHostsEntry() {
+		hostname := b.generateTenantHostname(b.butlerConfig.GetControlPlaneExposureHostname())
+		files = append(files, map[string]interface{}{
+			"path":        "/etc/hosts.d/ingress",
+			"permissions": "0644",
+			"content":     fmt.Sprintf("%s %s\n", b.ingressIP, hostname),
+		})
+	}
+
+	return files
+}
+
+// needsIngressHostsEntry returns true if the cluster uses Ingress/Gateway mode
+// and needs a hosts entry to resolve the control plane hostname.
+func (b *Builder) needsIngressHostsEntry() bool {
+	if b.butlerConfig == nil || b.ingressIP == "" {
+		return false
+	}
+	mode := b.butlerConfig.GetControlPlaneExposureMode()
+	return mode == butlerv1alpha1.ControlPlaneExposureModeIngress ||
+		mode == butlerv1alpha1.ControlPlaneExposureModeGateway
 }
 
 // buildMachineDeployment constructs the MachineDeployment resource.

--- a/internal/controller/tenantcluster/tenantcluster_controller.go
+++ b/internal/controller/tenantcluster/tenantcluster_controller.go
@@ -194,6 +194,20 @@ func (r *Reconciler) reconcileInfrastructure(ctx context.Context, tc *butlerv1al
 	// which enables auto-enabling tcp-proxy for non-LoadBalancer modes
 	builder := capi.NewBuilder(tc, providerConfig, tc.Status.TenantNamespace).
 		WithButlerConfig(butlerConfig)
+
+	// For Ingress/Gateway modes, get the Ingress controller IP for worker /etc/hosts
+	if butlerConfig != nil {
+		mode := butlerConfig.GetControlPlaneExposureMode()
+		if mode == butlerv1alpha1.ControlPlaneExposureModeIngress ||
+			mode == butlerv1alpha1.ControlPlaneExposureModeGateway {
+			if ingressIP, err := r.getIngressControllerIP(ctx, butlerConfig); err != nil {
+				logger.Error(err, "failed to get Ingress controller IP, workers may not resolve control plane hostname")
+			} else if ingressIP != "" {
+				builder.WithIngressIP(ingressIP)
+			}
+		}
+	}
+
 	resourceSet, err := builder.Build()
 	if err != nil {
 		r.setCondition(tc, butlerv1alpha1.TenantClusterConditionInfrastructureReady,
@@ -239,7 +253,7 @@ func (r *Reconciler) reconcileInfrastructure(ctx context.Context, tc *butlerv1al
 		logger.Error(err, "failed to check infrastructure status")
 	}
 
-	patched, err := r.handleKamajiHarvesterCompatibility(ctx, tc)
+	patched, err := r.handleKamajiHarvesterCompatibility(ctx, tc, butlerConfig)
 	if err != nil {
 		logger.Error(err, "failed to handle Kamaji compatibility")
 	}
@@ -272,10 +286,10 @@ func (r *Reconciler) reconcileInfrastructure(ctx context.Context, tc *butlerv1al
 		}
 
 		// Check if control plane is accessible by trying to get kubeconfig
-		_, err := r.getTenantKubeconfig(ctx, tc)
+		_, err := r.getTenantKubeconfig(ctx, tc, butlerConfig)
 		if err == nil {
 			logger.Info("control plane accessible and workers provisioned, proceeding to addon installation")
-			return r.reconcileAddons(ctx, tc)
+			return r.reconcileAddons(ctx, tc, butlerConfig)
 		}
 		logger.V(1).Info("waiting for control plane kubeconfig", "error", err)
 	}
@@ -293,7 +307,7 @@ func (r *Reconciler) reconcileInfrastructure(ctx context.Context, tc *butlerv1al
 // reconcileAddons installs required addons for a functional tenant cluster.
 // These are infrastructure requirements, not optional features.
 // Addons are installed monotonically - they are added but never removed via spec changes.
-func (r *Reconciler) reconcileAddons(ctx context.Context, tc *butlerv1alpha1.TenantCluster) (ctrl.Result, error) {
+func (r *Reconciler) reconcileAddons(ctx context.Context, tc *butlerv1alpha1.TenantCluster, butlerConfig *butlerv1alpha1.ButlerConfig) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
 
 	if tc.Status.Phase != butlerv1alpha1.TenantClusterPhaseInstalling {
@@ -303,7 +317,7 @@ func (r *Reconciler) reconcileAddons(ctx context.Context, tc *butlerv1alpha1.Ten
 		}
 	}
 
-	kubeconfigData, err := r.getTenantKubeconfig(ctx, tc)
+	kubeconfigData, err := r.getTenantKubeconfig(ctx, tc, butlerConfig)
 	if err != nil {
 		logger.Error(err, "failed to get tenant kubeconfig")
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
@@ -416,7 +430,7 @@ func (r *Reconciler) reconcileAddons(ctx context.Context, tc *butlerv1alpha1.Ten
 	return ctrl.Result{}, nil
 }
 
-func (r *Reconciler) getTenantKubeconfig(ctx context.Context, tc *butlerv1alpha1.TenantCluster) ([]byte, error) {
+func (r *Reconciler) getTenantKubeconfig(ctx context.Context, tc *butlerv1alpha1.TenantCluster, butlerConfig *butlerv1alpha1.ButlerConfig) ([]byte, error) {
 	secretName := fmt.Sprintf("%s-admin-kubeconfig", tc.Name)
 
 	secret := &corev1.Secret{}
@@ -427,9 +441,25 @@ func (r *Reconciler) getTenantKubeconfig(ctx context.Context, tc *butlerv1alpha1
 		return nil, fmt.Errorf("failed to get kubeconfig secret: %w", err)
 	}
 
-	kubeconfigData, ok := secret.Data["admin.conf"]
+	// Determine which kubeconfig key to use based on control plane exposure mode
+	// For Ingress/Gateway modes, use admin.svc (internal service endpoint) since the external
+	// hostname isn't resolvable from within the management cluster
+	kubeconfigKey := "admin.conf"
+	if butlerConfig != nil {
+		mode := butlerConfig.GetControlPlaneExposureMode()
+		if mode == butlerv1alpha1.ControlPlaneExposureModeIngress ||
+			mode == butlerv1alpha1.ControlPlaneExposureModeGateway {
+			kubeconfigKey = "admin.svc"
+		}
+	}
+
+	kubeconfigData, ok := secret.Data[kubeconfigKey]
 	if !ok {
-		return nil, fmt.Errorf("kubeconfig secret missing admin.conf key")
+		// Fallback to admin.conf if preferred key doesn't exist
+		kubeconfigData, ok = secret.Data["admin.conf"]
+		if !ok {
+			return nil, fmt.Errorf("kubeconfig secret missing %s and admin.conf keys", kubeconfigKey)
+		}
 	}
 
 	return kubeconfigData, nil
@@ -626,7 +656,7 @@ func (r *Reconciler) reconcileMachineDeploymentReplicas(ctx context.Context, tc 
 	return nil
 }
 
-func (r *Reconciler) handleKamajiHarvesterCompatibility(ctx context.Context, tc *butlerv1alpha1.TenantCluster) (bool, error) {
+func (r *Reconciler) handleKamajiHarvesterCompatibility(ctx context.Context, tc *butlerv1alpha1.TenantCluster, butlerConfig *butlerv1alpha1.ButlerConfig) (bool, error) {
 	logger := log.FromContext(ctx)
 
 	kcp := &unstructured.Unstructured{}
@@ -666,18 +696,47 @@ func (r *Reconciler) handleKamajiHarvesterCompatibility(ctx context.Context, tc 
 		return false, err
 	}
 
-	serviceStatus, found, _ := unstructured.NestedMap(tcp.Object, "status", "kubernetesResources", "service")
-	var loadBalancerIP string
-	if found {
-		ingress, found, _ := unstructured.NestedSlice(serviceStatus, "loadBalancer", "ingress")
-		if found && len(ingress) > 0 {
-			if ingressEntry, ok := ingress[0].(map[string]interface{}); ok {
-				loadBalancerIP, _, _ = unstructured.NestedString(ingressEntry, "ip")
+	// Determine the control plane endpoint based on exposure mode
+	var endpointHost string
+	var endpointPort int64
+
+	exposureMode := butlerv1alpha1.ControlPlaneExposureModeLoadBalancer
+	if butlerConfig != nil {
+		exposureMode = butlerConfig.GetControlPlaneExposureMode()
+	}
+
+	switch exposureMode {
+	case butlerv1alpha1.ControlPlaneExposureModeIngress, butlerv1alpha1.ControlPlaneExposureModeGateway:
+		// For Ingress/Gateway modes, use the generated hostname and port 443
+		if butlerConfig != nil {
+			hostnamePattern := butlerConfig.GetControlPlaneExposureHostname()
+			if hostnamePattern != "" {
+				// Generate tenant-specific hostname: "clustername.namespace.k8s.example.com" from "*.k8s.example.com"
+				base := strings.TrimPrefix(hostnamePattern, "*.")
+				endpointHost = fmt.Sprintf("%s.%s.%s", tc.Name, tc.Status.TenantNamespace, base)
+				endpointPort = 443
+				logger.V(1).Info("using Ingress/Gateway hostname for controlPlaneEndpoint",
+					"mode", exposureMode, "hostname", endpointHost)
+			}
+		}
+	default:
+		// LoadBalancer mode: get IP from service status, port 6443
+		serviceStatus, found, _ := unstructured.NestedMap(tcp.Object, "status", "kubernetesResources", "service")
+		if found {
+			ingress, found, _ := unstructured.NestedSlice(serviceStatus, "loadBalancer", "ingress")
+			if found && len(ingress) > 0 {
+				if ingressEntry, ok := ingress[0].(map[string]interface{}); ok {
+					endpointHost, _, _ = unstructured.NestedString(ingressEntry, "ip")
+					endpointPort = 6443
+					logger.V(1).Info("using LoadBalancer IP for controlPlaneEndpoint",
+						"ip", endpointHost)
+				}
 			}
 		}
 	}
 
-	if loadBalancerIP != "" {
+	// Patch Cluster controlPlaneEndpoint if we have a valid endpoint
+	if endpointHost != "" {
 		cluster := &unstructured.Unstructured{}
 		cluster.SetGroupVersionKind(schema.GroupVersionKind{
 			Group:   capi.ClusterAPIGroup,
@@ -689,17 +748,17 @@ func (r *Reconciler) handleKamajiHarvesterCompatibility(ctx context.Context, tc 
 			Namespace: tc.Status.TenantNamespace,
 		}, cluster); err == nil {
 			currentHost, _, _ := unstructured.NestedString(cluster.Object, "spec", "controlPlaneEndpoint", "host")
-			if currentHost != loadBalancerIP {
-				logger.Info("patching Cluster controlPlaneEndpoint", "currentHost", currentHost, "newHost", loadBalancerIP)
+			if currentHost != endpointHost {
+				logger.Info("patching Cluster controlPlaneEndpoint", "currentHost", currentHost, "newHost", endpointHost, "port", endpointPort)
 
-				if err := unstructured.SetNestedField(cluster.Object, loadBalancerIP, "spec", "controlPlaneEndpoint", "host"); err != nil {
+				if err := unstructured.SetNestedField(cluster.Object, endpointHost, "spec", "controlPlaneEndpoint", "host"); err != nil {
 					logger.Error(err, "failed to set controlPlaneEndpoint.host")
-				} else if err := unstructured.SetNestedField(cluster.Object, int64(6443), "spec", "controlPlaneEndpoint", "port"); err != nil {
+				} else if err := unstructured.SetNestedField(cluster.Object, endpointPort, "spec", "controlPlaneEndpoint", "port"); err != nil {
 					logger.Error(err, "failed to set controlPlaneEndpoint.port")
 				} else if err := r.Update(ctx, cluster); err != nil {
 					logger.Error(err, "failed to update Cluster controlPlaneEndpoint")
 				} else {
-					logger.Info("successfully patched Cluster controlPlaneEndpoint", "host", loadBalancerIP)
+					logger.Info("successfully patched Cluster controlPlaneEndpoint", "host", endpointHost, "port", endpointPort)
 					return true, nil
 				}
 			}
@@ -1118,6 +1177,76 @@ func extractAPIServerEndpoint(kubeconfig []byte) (string, string) {
 		return parts[0], parts[1]
 	}
 	return parts[0], "6443"
+}
+
+// getIngressControllerIP returns the external IP of the Ingress controller service.
+// For Ingress/Gateway modes, worker VMs need this IP to resolve the API server hostname
+// before DNS is available (via /etc/hosts entry).
+func (r *Reconciler) getIngressControllerIP(ctx context.Context, butlerConfig *butlerv1alpha1.ButlerConfig) (string, error) {
+	logger := log.FromContext(ctx)
+
+	// Determine the controller type to find the right service
+	controllerType := "traefik" // default
+	if butlerConfig != nil && butlerConfig.Spec.ControlPlaneExposure != nil {
+		if ct := butlerConfig.Spec.ControlPlaneExposure.ControllerType; ct != "" {
+			controllerType = ct
+		}
+	}
+
+	// Map controller type to namespace and service name patterns
+	// Each ingress controller has different naming conventions
+	var namespace, serviceName string
+	switch controllerType {
+	case "traefik":
+		namespace = "traefik"
+		serviceName = "traefik"
+	case "nginx":
+		namespace = "ingress-nginx"
+		serviceName = "ingress-nginx-controller"
+	case "haproxy":
+		namespace = "haproxy-controller"
+		serviceName = "haproxy-kubernetes-ingress"
+	default:
+		// For generic or unknown types, try traefik as fallback
+		namespace = "traefik"
+		serviceName = "traefik"
+	}
+
+	// Look up the service
+	svc := &corev1.Service{}
+	if err := r.Get(ctx, types.NamespacedName{Name: serviceName, Namespace: namespace}, svc); err != nil {
+		if apierrors.IsNotFound(err) {
+			logger.V(1).Info("ingress controller service not found",
+				"namespace", namespace, "service", serviceName, "controllerType", controllerType)
+			return "", nil
+		}
+		return "", fmt.Errorf("failed to get ingress controller service: %w", err)
+	}
+
+	// Extract external IP from LoadBalancer status
+	if svc.Spec.Type != corev1.ServiceTypeLoadBalancer {
+		logger.V(1).Info("ingress controller service is not LoadBalancer type",
+			"type", svc.Spec.Type, "namespace", namespace, "service", serviceName)
+		return "", nil
+	}
+
+	for _, ingress := range svc.Status.LoadBalancer.Ingress {
+		if ingress.IP != "" {
+			logger.V(1).Info("found ingress controller IP",
+				"ip", ingress.IP, "namespace", namespace, "service", serviceName)
+			return ingress.IP, nil
+		}
+		if ingress.Hostname != "" {
+			// Some cloud providers use hostname instead of IP
+			logger.V(1).Info("found ingress controller hostname (no IP)",
+				"hostname", ingress.Hostname, "namespace", namespace, "service", serviceName)
+			return ingress.Hostname, nil
+		}
+	}
+
+	logger.V(1).Info("ingress controller service has no external IP yet",
+		"namespace", namespace, "service", serviceName)
+	return "", nil
 }
 
 func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {

--- a/internal/controller/tenantcluster/tenantcluster_controller.go
+++ b/internal/controller/tenantcluster/tenantcluster_controller.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -196,15 +197,38 @@ func (r *Reconciler) reconcileInfrastructure(ctx context.Context, tc *butlerv1al
 		WithButlerConfig(butlerConfig)
 
 	// For Ingress/Gateway modes, get the Ingress controller IP for worker /etc/hosts
+	// CRITICAL: If Ingress/Gateway mode is enabled but the Ingress controller doesn't have
+	// an external IP yet, we MUST wait. Otherwise, KubeadmConfigTemplate will be created
+	// without the /etc/hosts entry, and workers won't be able to resolve the API server hostname.
 	if butlerConfig != nil {
 		mode := butlerConfig.GetControlPlaneExposureMode()
+		hostname := butlerConfig.GetControlPlaneExposureHostname()
+		logger.V(1).Info("ButlerConfig exposure settings",
+			"mode", mode,
+			"hostname", hostname)
 		if mode == butlerv1alpha1.ControlPlaneExposureModeIngress ||
 			mode == butlerv1alpha1.ControlPlaneExposureModeGateway {
-			if ingressIP, err := r.getIngressControllerIP(ctx, butlerConfig); err != nil {
-				logger.Error(err, "failed to get Ingress controller IP, workers may not resolve control plane hostname")
-			} else if ingressIP != "" {
-				builder.WithIngressIP(ingressIP)
+			ingressIP, err := r.getIngressControllerIP(ctx, butlerConfig)
+			if err != nil {
+				logger.Error(err, "failed to get Ingress controller IP")
+				r.setCondition(tc, butlerv1alpha1.TenantClusterConditionInfrastructureReady,
+					metav1.ConditionFalse, ReasonInfraProvisioning, "Waiting for Ingress controller")
+				if err := r.Status().Update(ctx, tc); err != nil {
+					return ctrl.Result{}, err
+				}
+				return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
 			}
+			if ingressIP == "" {
+				logger.Info("Ingress/Gateway mode requires Ingress controller external IP, waiting")
+				r.setCondition(tc, butlerv1alpha1.TenantClusterConditionInfrastructureReady,
+					metav1.ConditionFalse, ReasonInfraProvisioning, "Waiting for Ingress controller external IP")
+				if err := r.Status().Update(ctx, tc); err != nil {
+					return ctrl.Result{}, err
+				}
+				return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
+			}
+			logger.Info("Ingress mode detected, setting ingressIP on builder", "ingressIP", ingressIP)
+			builder.WithIngressIP(ingressIP)
 		}
 	}
 
@@ -273,13 +297,9 @@ func (r *Reconciler) reconcileInfrastructure(ctx context.Context, tc *butlerv1al
 	if controlPlaneReady {
 		r.setCondition(tc, butlerv1alpha1.TenantClusterConditionControlPlaneReady,
 			metav1.ConditionTrue, ReasonControlPlaneReady, "Control plane is ready")
-	} else {
-		r.setCondition(tc, butlerv1alpha1.TenantClusterConditionControlPlaneReady,
-			metav1.ConditionFalse, ReasonInfraProvisioning, "Control plane is provisioning")
-	}
 
-	if workersReady {
-
+		// Install addons as soon as control plane is accessible
+		// Don't wait for workers - Cilium has tolerations for not-ready nodes
 		// Skip installation if already ready
 		if tc.Status.Phase == butlerv1alpha1.TenantClusterPhaseReady {
 			return ctrl.Result{}, nil
@@ -288,14 +308,22 @@ func (r *Reconciler) reconcileInfrastructure(ctx context.Context, tc *butlerv1al
 		// Check if control plane is accessible by trying to get kubeconfig
 		_, err := r.getTenantKubeconfig(ctx, tc, butlerConfig)
 		if err == nil {
-			logger.Info("control plane accessible and workers provisioned, proceeding to addon installation")
+			logger.Info("control plane accessible, proceeding to addon installation")
 			return r.reconcileAddons(ctx, tc, butlerConfig)
 		}
 		logger.V(1).Info("waiting for control plane kubeconfig", "error", err)
+	} else {
+		r.setCondition(tc, butlerv1alpha1.TenantClusterConditionControlPlaneReady,
+			metav1.ConditionFalse, ReasonInfraProvisioning, "Control plane is provisioning")
 	}
 
-	r.setCondition(tc, butlerv1alpha1.TenantClusterConditionWorkersReady,
-		metav1.ConditionFalse, ReasonWorkersProvisioning, "Workers are provisioning")
+	if workersReady {
+		r.setCondition(tc, butlerv1alpha1.TenantClusterConditionWorkersReady,
+			metav1.ConditionTrue, ReasonWorkersReady, "Workers are ready")
+	} else {
+		r.setCondition(tc, butlerv1alpha1.TenantClusterConditionWorkersReady,
+			metav1.ConditionFalse, ReasonWorkersProvisioning, "Workers are provisioning")
+	}
 
 	if !infraReady || !controlPlaneReady || !workersReady {
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
@@ -330,10 +358,48 @@ func (r *Reconciler) reconcileAddons(ctx context.Context, tc *butlerv1alpha1.Ten
 	if tc.Spec.Addons.CNI != nil && tc.Spec.Addons.CNI.Version != "" {
 		ciliumVersion = tc.Spec.Addons.CNI.Version
 	}
-	logger.Info("installing Cilium CNI", "version", ciliumVersion)
-	// Extract API server endpoint from kubeconfig
+
+	// Extract API server endpoint from kubeconfig (used for default/LoadBalancer mode)
 	apiServerHost, apiServerPort := extractAPIServerEndpoint(kubeconfigData)
-	if err := r.Installer.InstallCilium(ctx, kubeconfigData, ciliumVersion, apiServerHost, apiServerPort); err != nil {
+
+	// Determine if we need hostAlias for Ingress/Gateway mode
+	// When using Ingress mode with TLS passthrough, Cilium must connect to the
+	// hostname (not IP) so SNI is sent for routing. But CoreDNS needs CNI to start,
+	// creating a chicken-and-egg problem. We solve this with hostAlias.
+	var ingressIP string
+	if butlerConfig != nil {
+		mode := butlerConfig.GetControlPlaneExposureMode()
+		if mode == butlerv1alpha1.ControlPlaneExposureModeIngress ||
+			mode == butlerv1alpha1.ControlPlaneExposureModeGateway {
+			// Get the Ingress controller IP to add as hostAlias
+			ip, err := r.getIngressControllerIP(ctx, butlerConfig)
+			if err != nil {
+				logger.Error(err, "failed to get ingress controller IP")
+			}
+			ingressIP = ip
+
+			// For Ingress/Gateway mode, we need the EXTERNAL hostname (from admin.conf)
+			// not the internal .svc endpoint (from admin.svc). The external hostname
+			// is needed for proper SNI routing in TLS passthrough.
+			externalKubeconfig, err := r.getExternalKubeconfig(ctx, tc)
+			if err == nil && externalKubeconfig != nil {
+				apiServerHost, apiServerPort = extractAPIServerEndpoint(externalKubeconfig)
+			}
+			logger.Info("Ingress mode detected", "ingressIP", ingressIP, "externalHost", apiServerHost)
+		}
+	}
+
+	ciliumCfg := addons.CiliumConfig{
+		Version:       ciliumVersion,
+		APIServerHost: apiServerHost,
+		APIServerPort: apiServerPort,
+		IngressIP:     ingressIP,
+	}
+
+	logger.Info("installing Cilium CNI", "version", ciliumVersion,
+		"apiServerHost", apiServerHost, "ingressIP", ingressIP)
+
+	if err := r.Installer.InstallCilium(ctx, kubeconfigData, ciliumCfg); err != nil {
 		logger.Error(err, "failed to install Cilium")
 		r.setCondition(tc, butlerv1alpha1.TenantClusterConditionAddonsReady,
 			metav1.ConditionFalse, "CNIInstallFailed", err.Error())
@@ -465,6 +531,28 @@ func (r *Reconciler) getTenantKubeconfig(ctx context.Context, tc *butlerv1alpha1
 	return kubeconfigData, nil
 }
 
+// getExternalKubeconfig returns the kubeconfig with the external hostname (admin.conf).
+// This is used for Cilium configuration in Ingress/Gateway mode to ensure proper SNI is sent.
+func (r *Reconciler) getExternalKubeconfig(ctx context.Context, tc *butlerv1alpha1.TenantCluster) ([]byte, error) {
+	secretName := fmt.Sprintf("%s-admin-kubeconfig", tc.Name)
+
+	secret := &corev1.Secret{}
+	if err := r.Get(ctx, types.NamespacedName{
+		Name:      secretName,
+		Namespace: tc.Status.TenantNamespace,
+	}, secret); err != nil {
+		return nil, fmt.Errorf("failed to get kubeconfig secret: %w", err)
+	}
+
+	// admin.conf contains the external hostname for Ingress/Gateway mode
+	kubeconfigData, ok := secret.Data["admin.conf"]
+	if !ok {
+		return nil, fmt.Errorf("kubeconfig secret missing admin.conf key")
+	}
+
+	return kubeconfigData, nil
+}
+
 func (r *Reconciler) getProviderConfig(ctx context.Context, tc *butlerv1alpha1.TenantCluster) (*butlerv1alpha1.ProviderConfig, error) {
 	const defaultProviderNamespace = "butler-system"
 
@@ -571,7 +659,8 @@ func (r *Reconciler) checkInfrastructureStatus(ctx context.Context, tc *butlerv1
 	tc.Status.WorkerNodesReady = int32(readyReplicas)
 	tc.Status.WorkerNodesDesired = int32(desiredReplicas)
 
-	if replicas > 0 {
+	// Workers are ready when at least one replica is ready
+	if readyReplicas > 0 {
 		workersReady = true
 	}
 
@@ -1256,5 +1345,11 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&corev1.Secret{}).
 		Owns(&rbacv1.RoleBinding{}).
 		Named("tenantcluster").
+		WithOptions(controller.Options{
+			// Allow multiple TenantClusters to be reconciled in parallel.
+			// This is critical for multi-tenant scenarios where creating
+			// multiple clusters simultaneously should not block each other.
+			MaxConcurrentReconciles: 5,
+		}).
 		Complete(r)
 }


### PR DESCRIPTION
## Summary

Enables TenantClusters to use a shared Ingress Controller instead of individual LoadBalancer services per tenant.

- Propagate IngressIP from ButlerConfig to TenantControlPlane
- Inject hostAliases into Cilium values for DNS bootstrap
- Use template-patch-apply pattern for Cilium installation
- Configure Konnectivity agent with Ingress hostname
- Set MaxConcurrentReconciles to 5 for parallel provisioning

## How It Works

The controller detects Ingress mode when `ButlerConfig.spec.controlPlaneExposure.ingressIP` is set. It then:

1. Configures TenantControlPlane with ClusterIP service + Ingress
2. Injects hostAliases into Cilium so CNI pods can reach API server before CoreDNS
3. Configures Konnectivity agent to use Ingress hostname

## Test Plan

- [x] Provisioned 5 TenantClusters concurrently
- [x] Verified all pods reach Ready state
- [x] Tested external kubeconfig access via Ingress
- [x] Tested kubectl exec/logs via Konnectivity