### PR TITLE
fix: pin Go alpine image to reduce Docker Hub rate limit issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.24 AS builder
+FROM golang:1.24-alpine AS builder
 ARG TARGETOS
 ARG TARGETARCH
 WORKDIR /workspace


### PR DESCRIPTION
## Summary
- Use `golang:1.24-alpine` instead of `golang:1.24` in Dockerfile
- Alpine images are smaller and cache better on self-hosted runners
- Helps reduce Docker Hub rate limit (429) errors on butler-runners

## Context
Recent CI failures on main due to Docker Hub unauthenticated pull rate limits being exhausted when multiple builds run on the same self-hosted runner pool.