### PR TITLE
fix: use setup-go and Docker Hub login to avoid rate limits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,15 +32,13 @@ env:
 jobs:
   build:
     runs-on: butler-runners
-    container: golang:1.24-alpine
     steps:
-      - name: Install dependencies
-        run: apk add --no-cache make git bash curl
-
-      - name: Configure git
-        run: git config --global --add safe.directory '*'
-
       - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.24'
 
       - name: Build
         run: make build
@@ -66,6 +64,12 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Log in to GHCR
         uses: docker/login-action@v3


### PR DESCRIPTION
## Summary
- Replace `container: golang:1.24-alpine` with `actions/setup-go@v5` for build job
- Add Docker Hub login before GHCR login in image job

## Why
Self-hosted runners share the same IP and hit Docker Hub unauthenticated rate limits (100 pulls/6 hours). This change:
1. Eliminates Docker Hub pulls for the build job entirely
2. Uses authenticated Docker Hub pulls for image builds (200 pulls/6 hours per user)

## Requires
`DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` secrets must be set at org or repo level.