### PR TITLE
feat: GitHub Release creation and docs rebuild on tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,3 +112,35 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+  release:
+    needs: image
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          prerelease: ${{ contains(github.ref, '-rc') || contains(github.ref, '-alpha') }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  notify-docs:
+    needs: release
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger docs site rebuild
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.DOCS_REBUILD_PAT }}
+          repository: butlerdotdev/butlerlabs-docs
+          event-type: release-published
+          client-payload: '{"repo": "${{ github.repository }}", "tag": "${{ github.ref_name }}"}'

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # butler-controller
 
+[![Release](https://img.shields.io/github/v/release/butlerdotdev/butler-controller)](https://github.com/butlerdotdev/butler-controller/releases)
+[![License](https://img.shields.io/github/license/butlerdotdev/butler-controller)](LICENSE)
+[![Go Version](https://img.shields.io/github/go-mod/go-version/butlerdotdev/butler-controller)](go.mod)
+
 Kubernetes controller for managing tenant clusters on the Butler platform.
 
 ## Table of Contents


### PR DESCRIPTION
## Summary

- Add `release` job to create GitHub Release with auto-generated notes on `v*` tags
- Add `notify-docs` job to trigger docs site rebuild via `repository_dispatch`
- Add shields.io badges to README

## Requires

- `DOCS_REBUILD_PAT` secret with repo scope on `butlerdotdev/butlerlabs-docs`
- butlerdotdev/butlerlabs-docs#11 merged first

## Test plan

- [ ] Push a test tag and verify GitHub Release is created
- [ ] Verify `repository_dispatch` fires to butlerlabs-docs