### PR TITLE
feat: enterprise networking, IPAM, and multi-provider architecture

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -34,12 +34,16 @@ import (
 
 	"github.com/butlerdotdev/butler-controller/internal/addons"
 	"github.com/butlerdotdev/butler-controller/internal/controller/butlerconfig"
+	"github.com/butlerdotdev/butler-controller/internal/controller/ipallocation"
 	"github.com/butlerdotdev/butler-controller/internal/controller/kamajisecret"
 	"github.com/butlerdotdev/butler-controller/internal/controller/kamajistatus"
 	"github.com/butlerdotdev/butler-controller/internal/controller/managementaddon"
+	"github.com/butlerdotdev/butler-controller/internal/controller/networkpool"
+	"github.com/butlerdotdev/butler-controller/internal/controller/providerconfig"
 	"github.com/butlerdotdev/butler-controller/internal/controller/team"
 	"github.com/butlerdotdev/butler-controller/internal/controller/tenantaddon"
 	"github.com/butlerdotdev/butler-controller/internal/controller/tenantcluster"
+	"github.com/butlerdotdev/butler-controller/internal/webhook"
 )
 
 var (
@@ -62,6 +66,7 @@ func main() {
 	var probeAddr string
 	var enableLeaderElection bool
 	var enableKamajiControllers bool
+	var enableWebhooks bool
 
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
@@ -71,6 +76,9 @@ func main() {
 	flag.BoolVar(&enableKamajiControllers, "enable-kamaji-controllers", true,
 		"Enable Kamaji integration controllers (KamajiSecret, KamajiStatus). "+
 			"Disable if not using Kamaji for hosted control planes.")
+	flag.BoolVar(&enableWebhooks, "enable-webhooks", false,
+		"Enable admission webhooks for TenantCluster, NetworkPool, and ProviderConfig. "+
+			"Requires cert-manager for TLS certificate management.")
 
 	opts := zap.Options{
 		Development: true,
@@ -160,6 +168,54 @@ func main() {
 		os.Exit(1)
 	}
 
+	// NetworkPool controller. IPAM allocator — sole writer for IP allocations
+	if err = (&networkpool.Reconciler{
+		Client:   mgr.GetClient(),
+		Scheme:   mgr.GetScheme(),
+		Recorder: mgr.GetEventRecorderFor("networkpool-controller"),
+	}).SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create controller", "controller", "NetworkPool")
+		os.Exit(1)
+	}
+
+	// IPAllocation controller. Thin controller for lifecycle management
+	if err = (&ipallocation.Reconciler{
+		Client: mgr.GetClient(),
+		Scheme: mgr.GetScheme(),
+	}).SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create controller", "controller", "IPAllocation")
+		os.Exit(1)
+	}
+
+	// ProviderConfig controller. Health checks and capacity reporting
+	if err = (&providerconfig.Reconciler{
+		Client:   mgr.GetClient(),
+		Scheme:   mgr.GetScheme(),
+		Recorder: mgr.GetEventRecorderFor("providerconfig-controller"),
+	}).SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create controller", "controller", "ProviderConfig")
+		os.Exit(1)
+	}
+
+	// Admission webhooks
+	if enableWebhooks {
+		if err = (&webhook.TenantClusterValidator{}).SetupWebhookWithManager(mgr); err != nil {
+			setupLog.Error(err, "unable to create webhook", "webhook", "TenantCluster")
+			os.Exit(1)
+		}
+		if err = (&webhook.NetworkPoolValidator{}).SetupWebhookWithManager(mgr); err != nil {
+			setupLog.Error(err, "unable to create webhook", "webhook", "NetworkPool")
+			os.Exit(1)
+		}
+		if err = (&webhook.ProviderConfigValidator{}).SetupWebhookWithManager(mgr); err != nil {
+			setupLog.Error(err, "unable to create webhook", "webhook", "ProviderConfig")
+			os.Exit(1)
+		}
+		setupLog.Info("admission webhooks enabled")
+	} else {
+		setupLog.Info("admission webhooks disabled")
+	}
+
 	// Kamaji integration controllers
 	if enableKamajiControllers {
 		// KamajiSecret controller. Translates kubeconfig format
@@ -194,7 +250,7 @@ func main() {
 	}
 
 	setupLog.Info("starting manager",
-		"controllers", []string{"ButlerConfig", "Team", "TenantCluster", "TenantAddon", "ManagementAddon", "KamajiSecret", "KamajiStatus"})
+		"controllers", []string{"ButlerConfig", "Team", "TenantCluster", "TenantAddon", "ManagementAddon", "NetworkPool", "IPAllocation", "ProviderConfig", "KamajiSecret", "KamajiStatus"})
 
 	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
 		setupLog.Error(err, "problem running manager")

--- a/docs/architecture/ADR-008-enterprise-networking-ipam.md
+++ b/docs/architecture/ADR-008-enterprise-networking-ipam.md
@@ -1,0 +1,96 @@
+# ADR-008: Enterprise Networking and IPAM
+
+## Status
+
+Accepted
+
+## Context
+
+Butler's networking model was entirely manual: platform admins specified LoadBalancer IP ranges per TenantCluster in `spec.networking.loadBalancerPool`. This works for small deployments but breaks down at scale:
+
+- **No IP tracking**: With 50+ tenants, admins resort to spreadsheets to avoid IP conflicts
+- **No provider scoping**: All ProviderConfigs are platform-wide, no access control per team
+- **No quota enforcement**: Teams can consume unlimited resources
+- **No cloud provider support**: Only on-prem providers (Harvester, Nutanix, Proxmox)
+
+We needed automated IPAM for on-prem providers, provider scoping and limits, and a foundation for cloud provider support.
+
+## Decision
+
+### IPAM Architecture
+
+We follow the **PVC/PV provisioner pattern** from Kubernetes core:
+
+1. **NetworkPool** (cluster-scoped pool definition) is the "StorageClass"
+2. **IPAllocation** (individual allocation record) is the "PVC/PV"
+3. **NetworkPool controller** is the sole allocator (single writer per pool)
+
+This prevents double-allocation by design. Controller-runtime's work queue serialization ensures only one reconcile runs per NetworkPool at a time. No distributed locks needed.
+
+### Allocation Algorithm
+
+Best-fit allocation using a bitmap:
+
+1. Build bitmap of the entire allocatable range
+2. Mark reserved CIDRs and existing allocations as used
+3. Find all contiguous free blocks
+4. Select the smallest block that fits the request (best-fit)
+
+Best-fit minimizes fragmentation compared to first-fit by preventing large blocks from being consumed by small requests.
+
+### Pinned Allocations
+
+For migration scenarios, IPAllocations can specify a `pinnedRange` with exact start/end addresses. The allocator validates the range is within the pool, not reserved, and not already allocated.
+
+### Provider Scoping
+
+ProviderConfigs support `scope: {type: platform|team, teamRef: ...}`. Platform-scoped providers are available to all teams. Team-scoped providers restrict access to the referenced team. Enforcement happens in both the admission webhook (fail-fast) and the controller reconcile loop (defense-in-depth).
+
+### Provider Limits
+
+ProviderConfigs support `limits: {maxClustersPerTeam, maxNodesPerTeam}`. Enforced at admission time and during reconciliation.
+
+## Alternatives Considered
+
+### IPAM as a separate service (rejected)
+
+Running IPAM as a gRPC service adds operational complexity without benefit. The Kubernetes API already provides persistence, watches, and RBAC. A controller-based approach is simpler and follows established patterns (cert-manager, MetalLB).
+
+### Annotation-based IP tracking (rejected)
+
+Storing allocations as annotations on NetworkPool would create a single large object that's rewritten on every change. At 500+ tenants, this becomes a performance bottleneck. Separate IPAllocation resources scale better and enable standard `kubectl get ipa` queries.
+
+### First-fit allocation (rejected)
+
+First-fit is simpler but leads to fragmentation. After several allocate/free cycles, large free blocks get split by small allocations. Best-fit keeps large blocks available for large requests.
+
+## Consequences
+
+### Positive
+- Zero manual IP management for new deployments
+- Existing deployments migrate incrementally (all new fields are optional)
+- Prometheus metrics expose pool utilization for alerting
+- Events provide audit trail for IP allocation/deallocation
+- Pinned allocations enable migration from legacy manual setup
+
+### Negative
+- NetworkPool controller is a single point of allocation (by design for safety, but if it crashes, new allocations stall until leader election recovers)
+- Pool capacity warnings emit every reconcile cycle (60s) when above threshold — should add rate limiting if noisy
+
+### Metrics Emitted
+- `butler_network_pool_total_ips` — total IPs per pool
+- `butler_network_pool_allocated_ips` — allocated IPs per pool
+- `butler_network_pool_available_ips` — available IPs per pool
+- `butler_network_pool_fragmentation_percent` — free space fragmentation
+- `butler_ip_allocation_processed_total` — allocation counter by result
+- `butler_provider_config_ready` — provider readiness gauge
+- `butler_provider_config_available_ips` — available IPs per provider
+
+### Events Emitted
+- `PoolCapacityWarning` — pool > 80% utilized
+- `PoolCapacityDanger` — pool > 90% utilized
+- `PoolExhausted` — pool 100% utilized
+- `IPsAllocated` — successful IP allocation
+- `AllocationFailed` — failed allocation attempt
+- `CredentialsInvalid` — provider credential validation failed
+- `PoolsExhausted` — all pools for a provider exhausted

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/butlerdotdev/butler-controller
 go 1.24.6
 
 require (
-	github.com/butlerdotdev/butler-api v0.2.0
+	github.com/butlerdotdev/butler-api v0.2.1-0.20260212223541-2e8d01d141c1
 	github.com/onsi/ginkgo/v2 v2.22.0
 	github.com/onsi/gomega v1.36.1
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,9 @@
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
-github.com/butlerdotdev/butler-api v0.2.0 h1:VAXomGsykXPxF87EoSQdWMg11l+U27KRveLGr3B49n8=
-github.com/butlerdotdev/butler-api v0.2.0/go.mod h1:q/RjPFM/r2ELq4DqR78OiAxerKBvH5D4nTGsVLKbjqY=
+github.com/butlerdotdev/butler-api v0.2.1-0.20260212222955-6807d364fa7f h1:Q1/Od7U+m32lLiG/0NlUjePPVvaBxZAxmFqRq73Bxo0=
+github.com/butlerdotdev/butler-api v0.2.1-0.20260212222955-6807d364fa7f/go.mod h1:q/RjPFM/r2ELq4DqR78OiAxerKBvH5D4nTGsVLKbjqY=
+github.com/butlerdotdev/butler-api v0.2.1-0.20260212223541-2e8d01d141c1 h1:1xXRk8optO9gGIe8OBinn1MphdsnACp3EK+yVOH/YHk=
+github.com/butlerdotdev/butler-api v0.2.1-0.20260212223541-2e8d01d141c1/go.mod h1:q/RjPFM/r2ELq4DqR78OiAxerKBvH5D4nTGsVLKbjqY=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/internal/controller/ipallocation/ipallocation_controller.go
+++ b/internal/controller/ipallocation/ipallocation_controller.go
@@ -1,0 +1,128 @@
+/*
+Copyright 2026 The Butler Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ipallocation
+
+import (
+	"context"
+	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	butlerv1alpha1 "github.com/butlerdotdev/butler-api/api/v1alpha1"
+)
+
+// Reconciler reconciles an IPAllocation object.
+// This is a thin controller — validation, finalizers, and deletion cleanup.
+// Allocation itself is handled by the NetworkPool controller.
+type Reconciler struct {
+	client.Client
+	Scheme *runtime.Scheme
+}
+
+// +kubebuilder:rbac:groups=butler.butlerlabs.dev,resources=ipallocations,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=butler.butlerlabs.dev,resources=ipallocations/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=butler.butlerlabs.dev,resources=ipallocations/finalizers,verbs=update
+
+func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := log.FromContext(ctx)
+
+	alloc := &butlerv1alpha1.IPAllocation{}
+	if err := r.Get(ctx, req.NamespacedName, alloc); err != nil {
+		if apierrors.IsNotFound(err) {
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, err
+	}
+
+	logger.V(1).Info("reconciling IPAllocation", "name", alloc.Name, "phase", alloc.Status.Phase)
+
+	// Handle deletion
+	if !alloc.DeletionTimestamp.IsZero() {
+		return r.handleDeletion(ctx, alloc)
+	}
+
+	// Add finalizer
+	if !controllerutil.ContainsFinalizer(alloc, butlerv1alpha1.FinalizerIPAllocation) {
+		controllerutil.AddFinalizer(alloc, butlerv1alpha1.FinalizerIPAllocation)
+		if err := r.Update(ctx, alloc); err != nil {
+			return ctrl.Result{}, err
+		}
+	}
+
+	// Set initial phase if not set
+	if alloc.Status.Phase == "" {
+		alloc.Status.Phase = butlerv1alpha1.IPAllocationPhasePending
+		alloc.Status.ObservedGeneration = alloc.Generation
+		if err := r.Status().Update(ctx, alloc); err != nil {
+			return ctrl.Result{}, err
+		}
+		// Return immediately — the NetworkPool controller will pick this up
+		return ctrl.Result{}, nil
+	}
+
+	switch alloc.Status.Phase {
+	case butlerv1alpha1.IPAllocationPhasePending:
+		// Waiting for NetworkPool controller to fulfill
+		return ctrl.Result{RequeueAfter: 15 * time.Second}, nil
+	case butlerv1alpha1.IPAllocationPhaseFailed:
+		// Backstop retry — primary retry is event-driven via NetworkPool controller
+		return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
+	case butlerv1alpha1.IPAllocationPhaseAllocated:
+		// Healthy — periodic check
+		return ctrl.Result{RequeueAfter: 5 * time.Minute}, nil
+	}
+
+	return ctrl.Result{}, nil
+}
+
+func (r *Reconciler) handleDeletion(ctx context.Context, alloc *butlerv1alpha1.IPAllocation) (ctrl.Result, error) {
+	logger := log.FromContext(ctx)
+
+	if !controllerutil.ContainsFinalizer(alloc, butlerv1alpha1.FinalizerIPAllocation) {
+		return ctrl.Result{}, nil
+	}
+
+	// Set released timestamp for audit trail
+	if alloc.Status.ReleasedAt == nil {
+		now := metav1.Now()
+		alloc.Status.ReleasedAt = &now
+		alloc.Status.Phase = butlerv1alpha1.IPAllocationPhaseReleased
+		if err := r.Status().Update(ctx, alloc); err != nil {
+			return ctrl.Result{}, err
+		}
+	}
+
+	logger.Info("releasing IPAllocation", "name", alloc.Name,
+		"start", alloc.Status.StartAddress, "end", alloc.Status.EndAddress)
+
+	controllerutil.RemoveFinalizer(alloc, butlerv1alpha1.FinalizerIPAllocation)
+	return ctrl.Result{}, r.Update(ctx, alloc)
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&butlerv1alpha1.IPAllocation{}).
+		Named("ipallocation").
+		Complete(r)
+}

--- a/internal/controller/networkpool/metrics.go
+++ b/internal/controller/networkpool/metrics.go
@@ -1,0 +1,92 @@
+/*
+Copyright 2026 The Butler Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package networkpool
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+var (
+	poolTotalIPs = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "butler_network_pool_total_ips",
+			Help: "Total number of IPs in a NetworkPool (excludes reserved).",
+		},
+		[]string{"pool", "namespace"},
+	)
+
+	poolAllocatedIPs = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "butler_network_pool_allocated_ips",
+			Help: "Number of allocated IPs in a NetworkPool.",
+		},
+		[]string{"pool", "namespace"},
+	)
+
+	poolAvailableIPs = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "butler_network_pool_available_ips",
+			Help: "Number of available IPs in a NetworkPool.",
+		},
+		[]string{"pool", "namespace"},
+	)
+
+	poolAllocationCount = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "butler_network_pool_allocation_count",
+			Help: "Number of active IPAllocations from a NetworkPool.",
+		},
+		[]string{"pool", "namespace"},
+	)
+
+	poolFragmentationPercent = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "butler_network_pool_fragmentation_percent",
+			Help: "Fragmentation percentage of free space in a NetworkPool (0-100).",
+		},
+		[]string{"pool", "namespace"},
+	)
+
+	poolLargestFreeBlock = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "butler_network_pool_largest_free_block",
+			Help: "Size of the largest contiguous free block in a NetworkPool.",
+		},
+		[]string{"pool", "namespace"},
+	)
+
+	allocationProcessed = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "butler_ip_allocation_processed_total",
+			Help: "Total number of IP allocations processed, by result.",
+		},
+		[]string{"pool", "namespace", "result"},
+	)
+)
+
+func init() {
+	metrics.Registry.MustRegister(
+		poolTotalIPs,
+		poolAllocatedIPs,
+		poolAvailableIPs,
+		poolAllocationCount,
+		poolFragmentationPercent,
+		poolLargestFreeBlock,
+		allocationProcessed,
+	)
+}

--- a/internal/controller/networkpool/networkpool_controller.go
+++ b/internal/controller/networkpool/networkpool_controller.go
@@ -1,0 +1,450 @@
+/*
+Copyright 2026 The Butler Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package networkpool
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	butlerv1alpha1 "github.com/butlerdotdev/butler-api/api/v1alpha1"
+	"github.com/butlerdotdev/butler-controller/internal/ipam"
+)
+
+// Reconciler reconciles a NetworkPool object.
+// It is the sole allocator — it processes Pending IPAllocations.
+type Reconciler struct {
+	client.Client
+	Scheme   *runtime.Scheme
+	Recorder record.EventRecorder
+}
+
+// +kubebuilder:rbac:groups=butler.butlerlabs.dev,resources=networkpools,verbs=get;list;watch;update;patch
+// +kubebuilder:rbac:groups=butler.butlerlabs.dev,resources=networkpools/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=butler.butlerlabs.dev,resources=networkpools/finalizers,verbs=update
+// +kubebuilder:rbac:groups=butler.butlerlabs.dev,resources=ipallocations,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=butler.butlerlabs.dev,resources=ipallocations/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups="",resources=events,verbs=create;patch
+
+func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := log.FromContext(ctx)
+
+	pool := &butlerv1alpha1.NetworkPool{}
+	if err := r.Get(ctx, req.NamespacedName, pool); err != nil {
+		if apierrors.IsNotFound(err) {
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, err
+	}
+
+	logger.Info("reconciling NetworkPool", "name", pool.Name, "namespace", pool.Namespace)
+
+	// Handle deletion
+	if !pool.DeletionTimestamp.IsZero() {
+		return r.handleDeletion(ctx, pool)
+	}
+
+	// Add finalizer
+	if !controllerutil.ContainsFinalizer(pool, butlerv1alpha1.FinalizerNetworkPool) {
+		controllerutil.AddFinalizer(pool, butlerv1alpha1.FinalizerNetworkPool)
+		if err := r.Update(ctx, pool); err != nil {
+			return ctrl.Result{}, err
+		}
+	}
+
+	// Validate CIDR math
+	errs := r.validatePool(pool)
+	if len(errs) > 0 {
+		meta.SetStatusCondition(&pool.Status.Conditions, metav1.Condition{
+			Type:               butlerv1alpha1.ConditionTypeReady,
+			Status:             metav1.ConditionFalse,
+			Reason:             butlerv1alpha1.ReasonValidationFailed,
+			Message:            fmt.Sprintf("validation errors: %v", errs),
+			ObservedGeneration: pool.Generation,
+		})
+		pool.Status.ObservedGeneration = pool.Generation
+		if err := r.Status().Update(ctx, pool); err != nil {
+			return ctrl.Result{}, err
+		}
+		return ctrl.Result{}, nil
+	}
+
+	// List all IPAllocations for this pool
+	allocList := &butlerv1alpha1.IPAllocationList{}
+	if err := r.List(ctx, allocList,
+		client.InNamespace(pool.Namespace),
+		client.MatchingFields{"spec.poolRef.name": pool.Name},
+	); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	// Process pending allocations (FIFO by creation timestamp)
+	pendingProcessed := r.processPendingAllocations(ctx, pool, allocList)
+
+	// Compute status from all allocations
+	if err := r.updatePoolStatus(ctx, pool, allocList); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	// Requeue faster if we processed pending allocations (re-check for new ones)
+	if pendingProcessed > 0 {
+		return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
+	}
+
+	return ctrl.Result{RequeueAfter: 60 * time.Second}, nil
+}
+
+func (r *Reconciler) handleDeletion(ctx context.Context, pool *butlerv1alpha1.NetworkPool) (ctrl.Result, error) {
+	logger := log.FromContext(ctx)
+
+	if !controllerutil.ContainsFinalizer(pool, butlerv1alpha1.FinalizerNetworkPool) {
+		return ctrl.Result{}, nil
+	}
+
+	// Block deletion if allocated IPAllocations exist
+	allocList := &butlerv1alpha1.IPAllocationList{}
+	if err := r.List(ctx, allocList,
+		client.InNamespace(pool.Namespace),
+		client.MatchingFields{"spec.poolRef.name": pool.Name},
+	); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	activeCount := 0
+	for _, alloc := range allocList.Items {
+		if alloc.Status.Phase == butlerv1alpha1.IPAllocationPhaseAllocated {
+			activeCount++
+		}
+	}
+
+	if activeCount > 0 {
+		logger.Info("blocking NetworkPool deletion, active allocations exist", "count", activeCount)
+		meta.SetStatusCondition(&pool.Status.Conditions, metav1.Condition{
+			Type:               butlerv1alpha1.ConditionTypeReady,
+			Status:             metav1.ConditionFalse,
+			Reason:             butlerv1alpha1.ReasonDeleting,
+			Message:            fmt.Sprintf("waiting for %d active allocations to be released", activeCount),
+			ObservedGeneration: pool.Generation,
+		})
+		if err := r.Status().Update(ctx, pool); err != nil {
+			return ctrl.Result{}, err
+		}
+		return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
+	}
+
+	controllerutil.RemoveFinalizer(pool, butlerv1alpha1.FinalizerNetworkPool)
+	return ctrl.Result{}, r.Update(ctx, pool)
+}
+
+func (r *Reconciler) validatePool(pool *butlerv1alpha1.NetworkPool) []string {
+	var reservedCIDRs []string
+	for _, reserved := range pool.Spec.Reserved {
+		reservedCIDRs = append(reservedCIDRs, reserved.CIDR)
+	}
+
+	var allocStart, allocEnd string
+	if pool.Spec.TenantAllocation != nil {
+		allocStart = pool.Spec.TenantAllocation.Start
+		allocEnd = pool.Spec.TenantAllocation.End
+	}
+
+	return ipam.ValidatePoolSpec(pool.Spec.CIDR, reservedCIDRs, allocStart, allocEnd)
+}
+
+func (r *Reconciler) processPendingAllocations(ctx context.Context, pool *butlerv1alpha1.NetworkPool, allocList *butlerv1alpha1.IPAllocationList) int {
+	logger := log.FromContext(ctx)
+
+	// Separate pending, allocated, and failed
+	var pending []butlerv1alpha1.IPAllocation
+	var allocated []butlerv1alpha1.IPAllocation
+	for _, alloc := range allocList.Items {
+		switch alloc.Status.Phase {
+		case butlerv1alpha1.IPAllocationPhaseAllocated:
+			allocated = append(allocated, alloc)
+		case butlerv1alpha1.IPAllocationPhasePending, "":
+			pending = append(pending, alloc)
+		case butlerv1alpha1.IPAllocationPhaseFailed:
+			// Re-process failed allocations (event-driven retry)
+			pending = append(pending, alloc)
+		}
+	}
+
+	if len(pending) == 0 {
+		return 0
+	}
+
+	// Sort pending by creation timestamp (FIFO)
+	sort.Slice(pending, func(i, j int) bool {
+		return pending[i].CreationTimestamp.Before(&pending[j].CreationTimestamp)
+	})
+
+	// Build pool state from current allocations
+	poolState := r.buildPoolState(pool, allocated)
+	processed := 0
+
+	for i := range pending {
+		alloc := &pending[i]
+		count := r.getAllocationCount(pool, alloc)
+
+		var result *ipam.AllocationResult
+		var err error
+		if alloc.Spec.PinnedRange != nil {
+			// Pinned allocation: validate and assign the requested range
+			result, err = ipam.AllocatePinnedRange(poolState, alloc.Spec.PinnedRange.StartAddress, alloc.Spec.PinnedRange.EndAddress)
+		} else {
+			result, err = ipam.AllocateRange(poolState, count)
+		}
+		if err != nil {
+			logger.Info("allocation failed", "allocation", alloc.Name, "error", err)
+			now := metav1.Now()
+			alloc.Status.Phase = butlerv1alpha1.IPAllocationPhaseFailed
+			meta.SetStatusCondition(&alloc.Status.Conditions, metav1.Condition{
+				Type:               butlerv1alpha1.ConditionTypeReady,
+				Status:             metav1.ConditionFalse,
+				Reason:             butlerv1alpha1.ReasonPoolExhausted,
+				Message:            err.Error(),
+				ObservedGeneration: alloc.Generation,
+				LastTransitionTime: now,
+			})
+			if updateErr := r.Status().Update(ctx, alloc); updateErr != nil {
+				logger.Error(updateErr, "failed to update IPAllocation status", "allocation", alloc.Name)
+			}
+			r.Recorder.Eventf(pool, "Warning", "AllocationFailed",
+				"Failed to allocate IPs for %s: %v", alloc.Name, err)
+			allocationProcessed.WithLabelValues(pool.Name, pool.Namespace, "failed").Inc()
+			continue
+		}
+
+		// Allocation succeeded
+		now := metav1.Now()
+		alloc.Status.Phase = butlerv1alpha1.IPAllocationPhaseAllocated
+		alloc.Status.StartAddress = result.Start
+		alloc.Status.EndAddress = result.End
+		alloc.Status.CIDR = result.CIDR
+		alloc.Status.Addresses = result.Addresses
+		alloc.Status.AllocatedCount = result.Count
+		alloc.Status.AllocatedAt = &now
+		alloc.Status.AllocatedBy = "networkpool-controller"
+		alloc.Status.ObservedGeneration = alloc.Generation
+
+		meta.SetStatusCondition(&alloc.Status.Conditions, metav1.Condition{
+			Type:               butlerv1alpha1.ConditionTypeReady,
+			Status:             metav1.ConditionTrue,
+			Reason:             butlerv1alpha1.ReasonReady,
+			Message:            fmt.Sprintf("allocated %d IPs: %s", result.Count, result.CIDR),
+			ObservedGeneration: alloc.Generation,
+			LastTransitionTime: now,
+		})
+
+		if updateErr := r.Status().Update(ctx, alloc); updateErr != nil {
+			logger.Error(updateErr, "failed to update IPAllocation status", "allocation", alloc.Name)
+			continue
+		}
+
+		logger.Info("allocated IPs", "allocation", alloc.Name, "start", result.Start, "end", result.End, "count", result.Count)
+		r.Recorder.Eventf(pool, "Normal", "IPsAllocated",
+			"Allocated %d IPs (%s - %s) for %s", result.Count, result.Start, result.End, alloc.Name)
+		allocationProcessed.WithLabelValues(pool.Name, pool.Namespace, "success").Inc()
+
+		// Update pool state with new allocation for next iteration
+		poolState.ExistingAllocs = append(poolState.ExistingAllocs, ipam.AllocatedRange{
+			Start: result.Start,
+			End:   result.End,
+		})
+		processed++
+	}
+
+	return processed
+}
+
+func (r *Reconciler) buildPoolState(pool *butlerv1alpha1.NetworkPool, allocated []butlerv1alpha1.IPAllocation) ipam.PoolState {
+	state := ipam.PoolState{}
+
+	// Set allocatable range
+	if pool.Spec.TenantAllocation != nil {
+		state.AllocatableStart = pool.Spec.TenantAllocation.Start
+		state.AllocatableEnd = pool.Spec.TenantAllocation.End
+	} else {
+		// Use full CIDR range
+		start, end, _, err := ipam.ParseCIDR(pool.Spec.CIDR)
+		if err != nil {
+			return state
+		}
+		state.AllocatableStart = start.String()
+		state.AllocatableEnd = end.String()
+	}
+
+	// Add reserved CIDRs
+	for _, reserved := range pool.Spec.Reserved {
+		state.ReservedCIDRs = append(state.ReservedCIDRs, reserved.CIDR)
+	}
+
+	// Add existing allocations
+	for _, alloc := range allocated {
+		if alloc.Status.StartAddress != "" && alloc.Status.EndAddress != "" {
+			state.ExistingAllocs = append(state.ExistingAllocs, ipam.AllocatedRange{
+				Start: alloc.Status.StartAddress,
+				End:   alloc.Status.EndAddress,
+			})
+		}
+	}
+
+	return state
+}
+
+func (r *Reconciler) getAllocationCount(pool *butlerv1alpha1.NetworkPool, alloc *butlerv1alpha1.IPAllocation) int32 {
+	if alloc.Spec.Count != nil {
+		return *alloc.Spec.Count
+	}
+
+	// Use pool defaults
+	if pool.Spec.TenantAllocation != nil {
+		switch alloc.Spec.Type {
+		case butlerv1alpha1.IPAllocationTypeNodes:
+			if pool.Spec.TenantAllocation.Defaults.NodesPerTenant > 0 {
+				return pool.Spec.TenantAllocation.Defaults.NodesPerTenant
+			}
+		case butlerv1alpha1.IPAllocationTypeLoadBalancer:
+			if pool.Spec.TenantAllocation.Defaults.LBPoolPerTenant > 0 {
+				return pool.Spec.TenantAllocation.Defaults.LBPoolPerTenant
+			}
+		}
+	}
+
+	// Fallback defaults
+	switch alloc.Spec.Type {
+	case butlerv1alpha1.IPAllocationTypeNodes:
+		return 5
+	case butlerv1alpha1.IPAllocationTypeLoadBalancer:
+		return 8
+	}
+	return 1
+}
+
+func (r *Reconciler) updatePoolStatus(ctx context.Context, pool *butlerv1alpha1.NetworkPool, allocList *butlerv1alpha1.IPAllocationList) error {
+	// Build pool state for capacity calculation
+	var allocated []butlerv1alpha1.IPAllocation
+	allocationCount := int32(0)
+	for _, alloc := range allocList.Items {
+		if alloc.Status.Phase == butlerv1alpha1.IPAllocationPhaseAllocated {
+			allocated = append(allocated, alloc)
+			allocationCount++
+		}
+	}
+
+	poolState := r.buildPoolState(pool, allocated)
+
+	totalIPs, allocatedIPs, availableIPs, err := ipam.PoolCapacityInfo(poolState)
+	if err != nil {
+		return fmt.Errorf("failed to compute pool capacity: %w", err)
+	}
+
+	fragInfo, err := ipam.ComputeFragmentation(poolState)
+	if err != nil {
+		return fmt.Errorf("failed to compute fragmentation: %w", err)
+	}
+
+	pool.Status.TotalIPs = totalIPs
+	pool.Status.AllocatedIPs = allocatedIPs
+	pool.Status.AvailableIPs = availableIPs
+	pool.Status.AllocationCount = allocationCount
+	pool.Status.FragmentationPercent = &fragInfo.FragmentationPercent
+	pool.Status.LargestFreeBlock = fragInfo.LargestFreeBlock
+	pool.Status.ObservedGeneration = pool.Generation
+
+	meta.SetStatusCondition(&pool.Status.Conditions, metav1.Condition{
+		Type:               butlerv1alpha1.ConditionTypeReady,
+		Status:             metav1.ConditionTrue,
+		Reason:             butlerv1alpha1.ReasonReady,
+		Message:            fmt.Sprintf("%d/%d IPs available (%d allocations)", availableIPs, totalIPs, allocationCount),
+		ObservedGeneration: pool.Generation,
+	})
+
+	// Update Prometheus metrics
+	labels := []string{pool.Name, pool.Namespace}
+	poolTotalIPs.WithLabelValues(labels...).Set(float64(totalIPs))
+	poolAllocatedIPs.WithLabelValues(labels...).Set(float64(allocatedIPs))
+	poolAvailableIPs.WithLabelValues(labels...).Set(float64(availableIPs))
+	poolAllocationCount.WithLabelValues(labels...).Set(float64(allocationCount))
+	poolFragmentationPercent.WithLabelValues(labels...).Set(float64(fragInfo.FragmentationPercent))
+	poolLargestFreeBlock.WithLabelValues(labels...).Set(float64(fragInfo.LargestFreeBlock))
+
+	// Emit capacity warning events at thresholds
+	if totalIPs > 0 {
+		usagePercent := float64(allocatedIPs) / float64(totalIPs) * 100
+		switch {
+		case availableIPs == 0:
+			r.Recorder.Eventf(pool, "Warning", "PoolExhausted",
+				"NetworkPool is fully exhausted (%d/%d IPs allocated)", allocatedIPs, totalIPs)
+		case usagePercent >= 90:
+			r.Recorder.Eventf(pool, "Warning", "PoolCapacityDanger",
+				"NetworkPool is over 90%% utilized (%d/%d IPs allocated)", allocatedIPs, totalIPs)
+		case usagePercent >= 80:
+			r.Recorder.Eventf(pool, "Warning", "PoolCapacityWarning",
+				"NetworkPool is over 80%% utilized (%d/%d IPs allocated)", allocatedIPs, totalIPs)
+		}
+	}
+
+	return r.Status().Update(ctx, pool)
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
+	// Register field indexer for efficient IPAllocation lookups by pool name
+	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &butlerv1alpha1.IPAllocation{},
+		"spec.poolRef.name", func(obj client.Object) []string {
+			alloc, ok := obj.(*butlerv1alpha1.IPAllocation)
+			if !ok {
+				return nil
+			}
+			return []string{alloc.Spec.PoolRef.Name}
+		}); err != nil {
+		return err
+	}
+
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&butlerv1alpha1.NetworkPool{}).
+		Watches(&butlerv1alpha1.IPAllocation{},
+			handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, obj client.Object) []reconcile.Request {
+				alloc, ok := obj.(*butlerv1alpha1.IPAllocation)
+				if !ok {
+					return nil
+				}
+				return []reconcile.Request{
+					{NamespacedName: client.ObjectKey{
+						Name:      alloc.Spec.PoolRef.Name,
+						Namespace: alloc.Namespace,
+					}},
+				}
+			}),
+		).
+		Named("networkpool").
+		Complete(r)
+}

--- a/internal/controller/networkpool/networkpool_controller_test.go
+++ b/internal/controller/networkpool/networkpool_controller_test.go
@@ -1,0 +1,399 @@
+/*
+Copyright 2026 The Butler Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package networkpool
+
+import (
+	"fmt"
+	"net"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"k8s.io/apimachinery/pkg/types"
+
+	butlerv1alpha1 "github.com/butlerdotdev/butler-api/api/v1alpha1"
+)
+
+var _ = Describe("NetworkPool Controller", func() {
+	const (
+		timeout  = 10 * time.Second
+		interval = 100 * time.Millisecond
+
+		testNamespace = "default"
+		testCIDR      = "10.40.0.0/24"
+		allocStart    = "10.40.0.128"
+		allocEnd      = "10.40.0.255"
+	)
+
+	// newStandardTenantAllocation returns the tenantAllocation config used across most tests.
+	newStandardTenantAllocation := func() *butlerv1alpha1.TenantAllocationConfig {
+		return &butlerv1alpha1.TenantAllocationConfig{
+			Start: allocStart,
+			End:   allocEnd,
+		}
+	}
+
+	// cleanupPool deletes the pool and waits for it to disappear. It first deletes
+	// all IPAllocations referencing the pool to unblock the finalizer.
+	cleanupPool := func(poolName string) {
+		allocList := &butlerv1alpha1.IPAllocationList{}
+		_ = k8sClient.List(ctx, allocList)
+		for i := range allocList.Items {
+			alloc := &allocList.Items[i]
+			if alloc.Spec.PoolRef.Name == poolName && alloc.Namespace == testNamespace {
+				_ = k8sClient.Delete(ctx, alloc)
+			}
+		}
+
+		// Wait for all allocations to be fully deleted
+		Eventually(func() int {
+			list := &butlerv1alpha1.IPAllocationList{}
+			_ = k8sClient.List(ctx, list)
+			count := 0
+			for _, a := range list.Items {
+				if a.Spec.PoolRef.Name == poolName && a.Namespace == testNamespace {
+					count++
+				}
+			}
+			return count
+		}, timeout, interval).Should(Equal(0))
+
+		pool := &butlerv1alpha1.NetworkPool{}
+		if err := k8sClient.Get(ctx, types.NamespacedName{Name: poolName, Namespace: testNamespace}, pool); err == nil {
+			_ = k8sClient.Delete(ctx, pool)
+			Eventually(func() error {
+				return k8sClient.Get(ctx, types.NamespacedName{Name: poolName, Namespace: testNamespace}, pool)
+			}, timeout, interval).ShouldNot(Succeed())
+		}
+	}
+
+	Describe("Pool Status Math", func() {
+		const poolName = "pool-status-math"
+
+		AfterEach(func() {
+			cleanupPool(poolName)
+		})
+
+		It("should compute correct IP counts from CIDR and tenantAllocation range", func() {
+			pool := newNetworkPool(poolName, testNamespace, testCIDR, newStandardTenantAllocation())
+			Expect(k8sClient.Create(ctx, pool)).To(Succeed())
+
+			// 10.40.0.128 to 10.40.0.255 = 128 IPs
+			Eventually(func(g Gomega) {
+				fetched := &butlerv1alpha1.NetworkPool{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: poolName, Namespace: testNamespace}, fetched)).To(Succeed())
+				g.Expect(fetched.Status.TotalIPs).To(Equal(int32(128)))
+				g.Expect(fetched.Status.AvailableIPs).To(Equal(int32(128)))
+				g.Expect(fetched.Status.AllocatedIPs).To(Equal(int32(0)))
+			}, timeout, interval).Should(Succeed())
+		})
+	})
+
+	Describe("Single Allocation", func() {
+		const poolName = "pool-single-alloc"
+		const allocName = "alloc-single"
+
+		AfterEach(func() {
+			cleanupPool(poolName)
+		})
+
+		It("should allocate IPs from a pending IPAllocation", func() {
+			pool := newNetworkPool(poolName, testNamespace, testCIDR, newStandardTenantAllocation())
+			Expect(k8sClient.Create(ctx, pool)).To(Succeed())
+
+			// Wait for pool to be ready
+			Eventually(func(g Gomega) {
+				fetched := &butlerv1alpha1.NetworkPool{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: poolName, Namespace: testNamespace}, fetched)).To(Succeed())
+				g.Expect(fetched.Status.TotalIPs).To(Equal(int32(128)))
+			}, timeout, interval).Should(Succeed())
+
+			alloc := newIPAllocation(allocName, testNamespace, poolName, butlerv1alpha1.IPAllocationTypeLoadBalancer, int32Ptr(8))
+			Expect(k8sClient.Create(ctx, alloc)).To(Succeed())
+
+			// Wait for allocation to reach Allocated phase
+			Eventually(func(g Gomega) {
+				fetched := &butlerv1alpha1.IPAllocation{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: allocName, Namespace: testNamespace}, fetched)).To(Succeed())
+				g.Expect(fetched.Status.Phase).To(Equal(butlerv1alpha1.IPAllocationPhaseAllocated))
+			}, timeout, interval).Should(Succeed())
+
+			// Verify allocation details
+			fetchedAlloc := &butlerv1alpha1.IPAllocation{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: allocName, Namespace: testNamespace}, fetchedAlloc)).To(Succeed())
+
+			Expect(fetchedAlloc.Status.StartAddress).NotTo(BeEmpty())
+			Expect(fetchedAlloc.Status.EndAddress).NotTo(BeEmpty())
+			Expect(fetchedAlloc.Status.AllocatedCount).To(Equal(int32(8)))
+			Expect(fetchedAlloc.Status.Addresses).To(HaveLen(8))
+			Expect(fetchedAlloc.Status.AllocatedAt).NotTo(BeNil())
+			Expect(fetchedAlloc.Status.AllocatedBy).To(Equal("networkpool-controller"))
+
+			// Verify pool status updated
+			Eventually(func(g Gomega) {
+				fetchedPool := &butlerv1alpha1.NetworkPool{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: poolName, Namespace: testNamespace}, fetchedPool)).To(Succeed())
+				g.Expect(fetchedPool.Status.AllocatedIPs).To(Equal(int32(8)))
+				g.Expect(fetchedPool.Status.AvailableIPs).To(Equal(int32(120)))
+			}, timeout, interval).Should(Succeed())
+		})
+	})
+
+	Describe("Multiple Non-Overlapping Allocations", func() {
+		const poolName = "pool-multi-alloc"
+
+		AfterEach(func() {
+			cleanupPool(poolName)
+		})
+
+		It("should allocate non-overlapping ranges for multiple IPAllocations", func() {
+			pool := newNetworkPool(poolName, testNamespace, testCIDR, newStandardTenantAllocation())
+			Expect(k8sClient.Create(ctx, pool)).To(Succeed())
+
+			// Wait for pool to be ready
+			Eventually(func(g Gomega) {
+				fetched := &butlerv1alpha1.NetworkPool{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: poolName, Namespace: testNamespace}, fetched)).To(Succeed())
+				g.Expect(fetched.Status.TotalIPs).To(Equal(int32(128)))
+			}, timeout, interval).Should(Succeed())
+
+			// Create 3 allocations sequentially
+			allocNames := []string{"alloc-multi-1", "alloc-multi-2", "alloc-multi-3"}
+			for _, name := range allocNames {
+				alloc := newIPAllocation(name, testNamespace, poolName, butlerv1alpha1.IPAllocationTypeLoadBalancer, int32Ptr(8))
+				Expect(k8sClient.Create(ctx, alloc)).To(Succeed())
+			}
+
+			// Wait for all 3 to reach Allocated phase
+			for _, name := range allocNames {
+				Eventually(func(g Gomega) {
+					fetched := &butlerv1alpha1.IPAllocation{}
+					g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: name, Namespace: testNamespace}, fetched)).To(Succeed())
+					g.Expect(fetched.Status.Phase).To(Equal(butlerv1alpha1.IPAllocationPhaseAllocated))
+				}, timeout, interval).Should(Succeed())
+			}
+
+			// Collect allocated ranges and verify no overlap
+			type ipRange struct {
+				start uint32
+				end   uint32
+			}
+			var ranges []ipRange
+			for _, name := range allocNames {
+				fetched := &butlerv1alpha1.IPAllocation{}
+				Expect(k8sClient.Get(ctx, types.NamespacedName{Name: name, Namespace: testNamespace}, fetched)).To(Succeed())
+				Expect(fetched.Status.StartAddress).NotTo(BeEmpty())
+				Expect(fetched.Status.EndAddress).NotTo(BeEmpty())
+				Expect(fetched.Status.AllocatedCount).To(Equal(int32(8)))
+
+				startIP := net.ParseIP(fetched.Status.StartAddress).To4()
+				endIP := net.ParseIP(fetched.Status.EndAddress).To4()
+				Expect(startIP).NotTo(BeNil())
+				Expect(endIP).NotTo(BeNil())
+
+				s := uint32(startIP[0])<<24 | uint32(startIP[1])<<16 | uint32(startIP[2])<<8 | uint32(startIP[3])
+				e := uint32(endIP[0])<<24 | uint32(endIP[1])<<16 | uint32(endIP[2])<<8 | uint32(endIP[3])
+				ranges = append(ranges, ipRange{start: s, end: e})
+			}
+
+			// Verify no ranges overlap
+			for i := 0; i < len(ranges); i++ {
+				for j := i + 1; j < len(ranges); j++ {
+					overlaps := ranges[i].start <= ranges[j].end && ranges[j].start <= ranges[i].end
+					Expect(overlaps).To(BeFalse(), fmt.Sprintf(
+						"ranges %d and %d overlap: [%d-%d] vs [%d-%d]",
+						i, j, ranges[i].start, ranges[i].end, ranges[j].start, ranges[j].end,
+					))
+				}
+			}
+
+			// Verify pool status: 24 IPs allocated, 104 available
+			Eventually(func(g Gomega) {
+				fetchedPool := &butlerv1alpha1.NetworkPool{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: poolName, Namespace: testNamespace}, fetchedPool)).To(Succeed())
+				g.Expect(fetchedPool.Status.AllocatedIPs).To(Equal(int32(24)))
+				g.Expect(fetchedPool.Status.AvailableIPs).To(Equal(int32(104)))
+			}, timeout, interval).Should(Succeed())
+		})
+	})
+
+	Describe("Pool Exhaustion", func() {
+		const poolName = "pool-exhaustion"
+
+		AfterEach(func() {
+			cleanupPool(poolName)
+		})
+
+		It("should fail allocation when the pool is exhausted", func() {
+			// Small pool: 10.40.0.128 to 10.40.0.135 = 8 IPs
+			smallAlloc := &butlerv1alpha1.TenantAllocationConfig{
+				Start: "10.40.0.128",
+				End:   "10.40.0.135",
+			}
+			pool := newNetworkPool(poolName, testNamespace, testCIDR, smallAlloc)
+			Expect(k8sClient.Create(ctx, pool)).To(Succeed())
+
+			// Wait for pool to be ready
+			Eventually(func(g Gomega) {
+				fetched := &butlerv1alpha1.NetworkPool{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: poolName, Namespace: testNamespace}, fetched)).To(Succeed())
+				g.Expect(fetched.Status.TotalIPs).To(Equal(int32(8)))
+			}, timeout, interval).Should(Succeed())
+
+			// First allocation: request 8 IPs, should succeed
+			alloc1 := newIPAllocation("alloc-exhaust-1", testNamespace, poolName, butlerv1alpha1.IPAllocationTypeLoadBalancer, int32Ptr(8))
+			Expect(k8sClient.Create(ctx, alloc1)).To(Succeed())
+
+			Eventually(func(g Gomega) {
+				fetched := &butlerv1alpha1.IPAllocation{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "alloc-exhaust-1", Namespace: testNamespace}, fetched)).To(Succeed())
+				g.Expect(fetched.Status.Phase).To(Equal(butlerv1alpha1.IPAllocationPhaseAllocated))
+			}, timeout, interval).Should(Succeed())
+
+			// Second allocation: request 4 more IPs, should fail (pool exhausted)
+			alloc2 := newIPAllocation("alloc-exhaust-2", testNamespace, poolName, butlerv1alpha1.IPAllocationTypeLoadBalancer, int32Ptr(4))
+			Expect(k8sClient.Create(ctx, alloc2)).To(Succeed())
+
+			Eventually(func(g Gomega) {
+				fetched := &butlerv1alpha1.IPAllocation{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: "alloc-exhaust-2", Namespace: testNamespace}, fetched)).To(Succeed())
+				g.Expect(fetched.Status.Phase).To(Equal(butlerv1alpha1.IPAllocationPhaseFailed))
+			}, timeout, interval).Should(Succeed())
+		})
+	})
+
+	Describe("Allocation Cleanup", func() {
+		const poolName = "pool-cleanup"
+		const allocName = "alloc-cleanup"
+
+		AfterEach(func() {
+			cleanupPool(poolName)
+		})
+
+		It("should release IPs and update pool status when an IPAllocation is deleted", func() {
+			pool := newNetworkPool(poolName, testNamespace, testCIDR, newStandardTenantAllocation())
+			Expect(k8sClient.Create(ctx, pool)).To(Succeed())
+
+			// Wait for pool to be ready
+			Eventually(func(g Gomega) {
+				fetched := &butlerv1alpha1.NetworkPool{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: poolName, Namespace: testNamespace}, fetched)).To(Succeed())
+				g.Expect(fetched.Status.TotalIPs).To(Equal(int32(128)))
+			}, timeout, interval).Should(Succeed())
+
+			alloc := newIPAllocation(allocName, testNamespace, poolName, butlerv1alpha1.IPAllocationTypeLoadBalancer, int32Ptr(8))
+			Expect(k8sClient.Create(ctx, alloc)).To(Succeed())
+
+			// Wait for allocation to succeed
+			Eventually(func(g Gomega) {
+				fetched := &butlerv1alpha1.IPAllocation{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: allocName, Namespace: testNamespace}, fetched)).To(Succeed())
+				g.Expect(fetched.Status.Phase).To(Equal(butlerv1alpha1.IPAllocationPhaseAllocated))
+			}, timeout, interval).Should(Succeed())
+
+			// Verify pool has 8 allocated
+			Eventually(func(g Gomega) {
+				fetchedPool := &butlerv1alpha1.NetworkPool{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: poolName, Namespace: testNamespace}, fetchedPool)).To(Succeed())
+				g.Expect(fetchedPool.Status.AllocatedIPs).To(Equal(int32(8)))
+			}, timeout, interval).Should(Succeed())
+
+			// Delete the IPAllocation
+			fetchedAlloc := &butlerv1alpha1.IPAllocation{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: allocName, Namespace: testNamespace}, fetchedAlloc)).To(Succeed())
+			Expect(k8sClient.Delete(ctx, fetchedAlloc)).To(Succeed())
+
+			// The IPAllocation controller sets releasedAt and removes the finalizer,
+			// then the object is garbage collected. Verify pool returns to full capacity.
+			Eventually(func(g Gomega) {
+				fetchedPool := &butlerv1alpha1.NetworkPool{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: poolName, Namespace: testNamespace}, fetchedPool)).To(Succeed())
+				g.Expect(fetchedPool.Status.AllocatedIPs).To(Equal(int32(0)))
+				g.Expect(fetchedPool.Status.AvailableIPs).To(Equal(int32(128)))
+			}, timeout, interval).Should(Succeed())
+		})
+	})
+
+	Describe("Deletion Protection", func() {
+		const poolName = "pool-deletion-protection"
+		const allocName = "alloc-deletion-protection"
+
+		AfterEach(func() {
+			cleanupPool(poolName)
+		})
+
+		It("should add a finalizer to the NetworkPool", func() {
+			pool := newNetworkPool(poolName, testNamespace, testCIDR, newStandardTenantAllocation())
+			Expect(k8sClient.Create(ctx, pool)).To(Succeed())
+
+			// Wait for the finalizer to be added by the controller
+			Eventually(func(g Gomega) {
+				fetched := &butlerv1alpha1.NetworkPool{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: poolName, Namespace: testNamespace}, fetched)).To(Succeed())
+				g.Expect(fetched.Finalizers).To(ContainElement(butlerv1alpha1.FinalizerNetworkPool))
+			}, timeout, interval).Should(Succeed())
+		})
+
+		It("should block pool deletion while allocated IPAllocations exist", func() {
+			pool := newNetworkPool(poolName, testNamespace, testCIDR, newStandardTenantAllocation())
+			Expect(k8sClient.Create(ctx, pool)).To(Succeed())
+
+			// Wait for pool to be ready
+			Eventually(func(g Gomega) {
+				fetched := &butlerv1alpha1.NetworkPool{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: poolName, Namespace: testNamespace}, fetched)).To(Succeed())
+				g.Expect(fetched.Status.TotalIPs).To(Equal(int32(128)))
+			}, timeout, interval).Should(Succeed())
+
+			// Create an allocation
+			alloc := newIPAllocation(allocName, testNamespace, poolName, butlerv1alpha1.IPAllocationTypeLoadBalancer, int32Ptr(8))
+			Expect(k8sClient.Create(ctx, alloc)).To(Succeed())
+
+			Eventually(func(g Gomega) {
+				fetched := &butlerv1alpha1.IPAllocation{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: allocName, Namespace: testNamespace}, fetched)).To(Succeed())
+				g.Expect(fetched.Status.Phase).To(Equal(butlerv1alpha1.IPAllocationPhaseAllocated))
+			}, timeout, interval).Should(Succeed())
+
+			// Attempt to delete the pool (should be blocked by finalizer)
+			fetchedPool := &butlerv1alpha1.NetworkPool{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: poolName, Namespace: testNamespace}, fetchedPool)).To(Succeed())
+			Expect(k8sClient.Delete(ctx, fetchedPool)).To(Succeed())
+
+			// Pool should still exist (deletion blocked by finalizer)
+			Consistently(func() error {
+				return k8sClient.Get(ctx, types.NamespacedName{Name: poolName, Namespace: testNamespace}, fetchedPool)
+			}, 2*time.Second, interval).Should(Succeed())
+
+			// Verify the pool has a DeletionTimestamp set but is not yet deleted
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: poolName, Namespace: testNamespace}, fetchedPool)).To(Succeed())
+			Expect(fetchedPool.DeletionTimestamp).NotTo(BeNil())
+			Expect(fetchedPool.Finalizers).To(ContainElement(butlerv1alpha1.FinalizerNetworkPool))
+
+			// Delete the allocation to unblock pool deletion
+			fetchedAlloc := &butlerv1alpha1.IPAllocation{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: allocName, Namespace: testNamespace}, fetchedAlloc)).To(Succeed())
+			Expect(k8sClient.Delete(ctx, fetchedAlloc)).To(Succeed())
+
+			// Pool should now be fully deleted
+			Eventually(func() error {
+				return k8sClient.Get(ctx, types.NamespacedName{Name: poolName, Namespace: testNamespace}, fetchedPool)
+			}, timeout, interval).ShouldNot(Succeed())
+		})
+	})
+})

--- a/internal/controller/networkpool/suite_test.go
+++ b/internal/controller/networkpool/suite_test.go
@@ -1,0 +1,159 @@
+/*
+Copyright 2026 The Butler Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package networkpool
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+
+	butlerv1alpha1 "github.com/butlerdotdev/butler-api/api/v1alpha1"
+	ipallocationctrl "github.com/butlerdotdev/butler-controller/internal/controller/ipallocation"
+)
+
+var (
+	cfg       *rest.Config
+	k8sClient client.Client
+	testEnv   *envtest.Environment
+	ctx       context.Context
+	cancel    context.CancelFunc
+)
+
+func TestNetworkPool(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "NetworkPool Controller Suite")
+}
+
+var _ = BeforeSuite(func() {
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+
+	ctx, cancel = context.WithCancel(context.TODO())
+
+	By("bootstrapping test environment")
+	testEnv = &envtest.Environment{
+		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "..", "butler-api", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing: true,
+	}
+
+	var err error
+	cfg, err = testEnv.Start()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(cfg).NotTo(BeNil())
+
+	err = butlerv1alpha1.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(k8sClient).NotTo(BeNil())
+
+	// Start the controller manager with metrics disabled to avoid port conflicts
+	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
+		Scheme: scheme.Scheme,
+		Metrics: metricsserver.Options{
+			BindAddress: "0", // Disable metrics server in tests
+		},
+	})
+	Expect(err).NotTo(HaveOccurred())
+
+	// Register the NetworkPool controller (sole allocator for IPAllocations)
+	err = (&Reconciler{
+		Client: mgr.GetClient(),
+		Scheme: mgr.GetScheme(),
+	}).SetupWithManager(mgr)
+	Expect(err).NotTo(HaveOccurred())
+
+	// Register the IPAllocation controller (finalizers, initial phase, deletion cleanup)
+	err = (&ipallocationctrl.Reconciler{
+		Client: mgr.GetClient(),
+		Scheme: mgr.GetScheme(),
+	}).SetupWithManager(mgr)
+	Expect(err).NotTo(HaveOccurred())
+
+	go func() {
+		defer GinkgoRecover()
+		err = mgr.Start(ctx)
+		Expect(err).NotTo(HaveOccurred())
+	}()
+
+	// Wait for cache to sync
+	time.Sleep(100 * time.Millisecond)
+})
+
+var _ = AfterSuite(func() {
+	By("tearing down the test environment")
+	cancel()
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
+})
+
+// Helper to create a NetworkPool for testing.
+func newNetworkPool(name, namespace, cidr string, tenantAllocation *butlerv1alpha1.TenantAllocationConfig) *butlerv1alpha1.NetworkPool {
+	return &butlerv1alpha1.NetworkPool{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: butlerv1alpha1.NetworkPoolSpec{
+			CIDR:             cidr,
+			TenantAllocation: tenantAllocation,
+		},
+	}
+}
+
+// Helper to create an IPAllocation for testing.
+func newIPAllocation(name, namespace, poolName string, allocType butlerv1alpha1.IPAllocationType, count *int32) *butlerv1alpha1.IPAllocation {
+	return &butlerv1alpha1.IPAllocation{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels: map[string]string{
+				butlerv1alpha1.LabelNetworkPool: poolName,
+			},
+		},
+		Spec: butlerv1alpha1.IPAllocationSpec{
+			PoolRef: butlerv1alpha1.LocalObjectReference{
+				Name: poolName,
+			},
+			TenantClusterRef: butlerv1alpha1.NamespacedObjectReference{
+				Name:      "test-cluster",
+				Namespace: namespace,
+			},
+			Type:  allocType,
+			Count: count,
+		},
+	}
+}
+
+// int32Ptr returns a pointer to the given int32 value.
+func int32Ptr(v int32) *int32 {
+	return &v
+}

--- a/internal/controller/providerconfig/metrics.go
+++ b/internal/controller/providerconfig/metrics.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2026 The Butler Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package providerconfig
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+var (
+	providerReady = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "butler_provider_config_ready",
+			Help: "Whether a ProviderConfig is ready (1=ready, 0=not ready).",
+		},
+		[]string{"provider", "namespace", "type", "scope"},
+	)
+
+	providerAvailableIPs = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "butler_provider_config_available_ips",
+			Help: "Available IPs across all pools for an IPAM-mode ProviderConfig.",
+		},
+		[]string{"provider", "namespace"},
+	)
+
+	providerEstimatedTenants = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "butler_provider_config_estimated_tenants",
+			Help: "Estimated number of tenants that can be provisioned by a ProviderConfig.",
+		},
+		[]string{"provider", "namespace"},
+	)
+)
+
+func init() {
+	metrics.Registry.MustRegister(
+		providerReady,
+		providerAvailableIPs,
+		providerEstimatedTenants,
+	)
+}

--- a/internal/controller/providerconfig/providerconfig_controller.go
+++ b/internal/controller/providerconfig/providerconfig_controller.go
@@ -1,0 +1,347 @@
+/*
+Copyright 2026 The Butler Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package providerconfig
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	butlerv1alpha1 "github.com/butlerdotdev/butler-api/api/v1alpha1"
+)
+
+const (
+	ConditionCredentialsValid = "CredentialsValid"
+	ConditionPoolAvailable    = "PoolAvailable"
+)
+
+// expectedSecretKeys defines the required Secret keys per provider type.
+var expectedSecretKeys = map[butlerv1alpha1.ProviderType][]string{
+	butlerv1alpha1.ProviderTypeHarvester: {"kubeconfig"},
+	butlerv1alpha1.ProviderTypeNutanix:   {"username", "password"},
+	butlerv1alpha1.ProviderTypeProxmox:   {"username", "password"},
+	butlerv1alpha1.ProviderTypeAzure:     {"clientID", "clientSecret", "tenantID"},
+	butlerv1alpha1.ProviderTypeAWS:       {"accessKeyID", "secretAccessKey"},
+	butlerv1alpha1.ProviderTypeGCP:       {"serviceAccountKey"},
+}
+
+// Reconciler reconciles a ProviderConfig object.
+type Reconciler struct {
+	client.Client
+	Scheme   *runtime.Scheme
+	Recorder record.EventRecorder
+}
+
+// +kubebuilder:rbac:groups=butler.butlerlabs.dev,resources=providerconfigs,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=butler.butlerlabs.dev,resources=providerconfigs/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=butler.butlerlabs.dev,resources=providerconfigs/finalizers,verbs=update
+// +kubebuilder:rbac:groups=butler.butlerlabs.dev,resources=networkpools,verbs=get;list;watch
+// +kubebuilder:rbac:groups=butler.butlerlabs.dev,resources=teams,verbs=get;list;watch
+// +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch
+
+func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := log.FromContext(ctx)
+
+	pc := &butlerv1alpha1.ProviderConfig{}
+	if err := r.Get(ctx, req.NamespacedName, pc); err != nil {
+		if apierrors.IsNotFound(err) {
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, err
+	}
+
+	logger.Info("reconciling ProviderConfig", "name", pc.Name, "provider", pc.Spec.Provider)
+
+	// Handle deletion
+	if !pc.DeletionTimestamp.IsZero() {
+		return r.handleDeletion(ctx, pc)
+	}
+
+	// Add finalizer
+	if !controllerutil.ContainsFinalizer(pc, butlerv1alpha1.FinalizerProviderConfig) {
+		controllerutil.AddFinalizer(pc, butlerv1alpha1.FinalizerProviderConfig)
+		if err := r.Update(ctx, pc); err != nil {
+			return ctrl.Result{}, err
+		}
+	}
+
+	// Validate credentials
+	credentialsValid := r.validateCredentials(ctx, pc)
+
+	// Validate scope if team-scoped
+	if pc.Spec.Scope != nil && pc.Spec.Scope.Type == butlerv1alpha1.ProviderConfigScopeTeam {
+		r.validateTeamScope(ctx, pc)
+	}
+
+	// Check pool availability if IPAM mode
+	if pc.Spec.Network != nil && pc.Spec.Network.Mode == "ipam" {
+		r.checkPoolAvailability(ctx, pc)
+	}
+
+	// Set overall ready status
+	now := metav1.Now()
+	pc.Status.Ready = credentialsValid
+	pc.Status.LastProbeTime = &now
+
+	if err := r.Status().Update(ctx, pc); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	// Update Prometheus metrics
+	scope := "platform"
+	if pc.Spec.Scope != nil && pc.Spec.Scope.Type != "" {
+		scope = string(pc.Spec.Scope.Type)
+	}
+	readyVal := float64(0)
+	if credentialsValid {
+		readyVal = 1
+	}
+	providerReady.WithLabelValues(pc.Name, pc.Namespace, string(pc.Spec.Provider), scope).Set(readyVal)
+
+	if pc.Status.Capacity != nil {
+		providerAvailableIPs.WithLabelValues(pc.Name, pc.Namespace).Set(float64(pc.Status.Capacity.AvailableIPs))
+		providerEstimatedTenants.WithLabelValues(pc.Name, pc.Namespace).Set(float64(pc.Status.Capacity.EstimatedTenants))
+	}
+
+	return ctrl.Result{RequeueAfter: 5 * time.Minute}, nil
+}
+
+func (r *Reconciler) handleDeletion(ctx context.Context, pc *butlerv1alpha1.ProviderConfig) (ctrl.Result, error) {
+	logger := log.FromContext(ctx)
+
+	if !controllerutil.ContainsFinalizer(pc, butlerv1alpha1.FinalizerProviderConfig) {
+		return ctrl.Result{}, nil
+	}
+
+	// Check for TenantClusters referencing this provider
+	tcList := &butlerv1alpha1.TenantClusterList{}
+	if err := r.List(ctx, tcList); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	refCount := 0
+	for _, tc := range tcList.Items {
+		if tc.Spec.ProviderConfigRef != nil && tc.Spec.ProviderConfigRef.Name == pc.Name {
+			refCount++
+		}
+	}
+
+	if refCount > 0 {
+		logger.Info("blocking ProviderConfig deletion, TenantClusters reference it", "count", refCount)
+		return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
+	}
+
+	controllerutil.RemoveFinalizer(pc, butlerv1alpha1.FinalizerProviderConfig)
+	return ctrl.Result{}, r.Update(ctx, pc)
+}
+
+func (r *Reconciler) validateCredentials(ctx context.Context, pc *butlerv1alpha1.ProviderConfig) bool {
+	secretNS := pc.Spec.CredentialsRef.Namespace
+	if secretNS == "" {
+		secretNS = pc.Namespace
+	}
+
+	secret := &corev1.Secret{}
+	err := r.Get(ctx, types.NamespacedName{
+		Name:      pc.Spec.CredentialsRef.Name,
+		Namespace: secretNS,
+	}, secret)
+
+	if err != nil {
+		msg := fmt.Sprintf("credentials secret not found: %v", err)
+		if apierrors.IsNotFound(err) {
+			msg = fmt.Sprintf("credentials secret %s/%s not found", secretNS, pc.Spec.CredentialsRef.Name)
+		}
+		meta.SetStatusCondition(&pc.Status.Conditions, metav1.Condition{
+			Type:               ConditionCredentialsValid,
+			Status:             metav1.ConditionFalse,
+			Reason:             butlerv1alpha1.ReasonCredentialsInvalid,
+			Message:            msg,
+			ObservedGeneration: pc.Generation,
+		})
+		pc.Status.Validated = false
+		r.Recorder.Eventf(pc, "Warning", "CredentialsInvalid", "%s", msg)
+		return false
+	}
+
+	// Check expected keys
+	keys := expectedSecretKeys[pc.Spec.Provider]
+	var missing []string
+	for _, key := range keys {
+		if _, ok := secret.Data[key]; !ok {
+			missing = append(missing, key)
+		}
+	}
+
+	if len(missing) > 0 {
+		msg := fmt.Sprintf("secret missing required keys: %v", missing)
+		meta.SetStatusCondition(&pc.Status.Conditions, metav1.Condition{
+			Type:               ConditionCredentialsValid,
+			Status:             metav1.ConditionFalse,
+			Reason:             butlerv1alpha1.ReasonCredentialsInvalid,
+			Message:            msg,
+			ObservedGeneration: pc.Generation,
+		})
+		pc.Status.Validated = false
+		r.Recorder.Eventf(pc, "Warning", "CredentialsInvalid", "%s", msg)
+		return false
+	}
+
+	now := metav1.Now()
+	meta.SetStatusCondition(&pc.Status.Conditions, metav1.Condition{
+		Type:               ConditionCredentialsValid,
+		Status:             metav1.ConditionTrue,
+		Reason:             butlerv1alpha1.ReasonReady,
+		Message:            "credentials validated",
+		ObservedGeneration: pc.Generation,
+	})
+	pc.Status.Validated = true
+	pc.Status.LastValidationTime = &now
+	return true
+}
+
+func (r *Reconciler) validateTeamScope(ctx context.Context, pc *butlerv1alpha1.ProviderConfig) {
+	if pc.Spec.Scope.TeamRef == nil {
+		meta.SetStatusCondition(&pc.Status.Conditions, metav1.Condition{
+			Type:               butlerv1alpha1.ConditionTypeReady,
+			Status:             metav1.ConditionFalse,
+			Reason:             butlerv1alpha1.ReasonValidationFailed,
+			Message:            "scope.type is 'team' but teamRef is not set",
+			ObservedGeneration: pc.Generation,
+		})
+		return
+	}
+
+	team := &butlerv1alpha1.Team{}
+	if err := r.Get(ctx, types.NamespacedName{Name: pc.Spec.Scope.TeamRef.Name}, team); err != nil {
+		meta.SetStatusCondition(&pc.Status.Conditions, metav1.Condition{
+			Type:               butlerv1alpha1.ConditionTypeReady,
+			Status:             metav1.ConditionFalse,
+			Reason:             butlerv1alpha1.ReasonValidationFailed,
+			Message:            fmt.Sprintf("referenced team %q not found", pc.Spec.Scope.TeamRef.Name),
+			ObservedGeneration: pc.Generation,
+		})
+	}
+}
+
+func (r *Reconciler) checkPoolAvailability(ctx context.Context, pc *butlerv1alpha1.ProviderConfig) {
+	if len(pc.Spec.Network.PoolRefs) == 0 {
+		meta.SetStatusCondition(&pc.Status.Conditions, metav1.Condition{
+			Type:               ConditionPoolAvailable,
+			Status:             metav1.ConditionFalse,
+			Reason:             butlerv1alpha1.ReasonValidationFailed,
+			Message:            "network.mode is 'ipam' but no poolRefs configured",
+			ObservedGeneration: pc.Generation,
+		})
+		return
+	}
+
+	totalAvailable := int32(0)
+	for _, poolRef := range pc.Spec.Network.PoolRefs {
+		pool := &butlerv1alpha1.NetworkPool{}
+		if err := r.Get(ctx, types.NamespacedName{
+			Name:      poolRef.Name,
+			Namespace: pc.Namespace,
+		}, pool); err != nil {
+			continue
+		}
+		totalAvailable += pool.Status.AvailableIPs
+	}
+
+	// Estimate capacity
+	nodesPerTenant := int32(5)
+	lbPerTenant := int32(8)
+	if pc.Spec.Network.LoadBalancer != nil && pc.Spec.Network.LoadBalancer.DefaultPoolSize != nil {
+		lbPerTenant = *pc.Spec.Network.LoadBalancer.DefaultPoolSize
+	}
+	perTenant := nodesPerTenant + lbPerTenant
+	estimatedTenants := int32(0)
+	if perTenant > 0 {
+		estimatedTenants = totalAvailable / perTenant
+	}
+
+	pc.Status.Capacity = &butlerv1alpha1.ProviderCapacity{
+		AvailableIPs:     totalAvailable,
+		EstimatedTenants: estimatedTenants,
+	}
+
+	if totalAvailable > 0 {
+		meta.SetStatusCondition(&pc.Status.Conditions, metav1.Condition{
+			Type:               ConditionPoolAvailable,
+			Status:             metav1.ConditionTrue,
+			Reason:             butlerv1alpha1.ReasonPoolAvailable,
+			Message:            fmt.Sprintf("%d IPs available (~%d tenants)", totalAvailable, estimatedTenants),
+			ObservedGeneration: pc.Generation,
+		})
+	} else {
+		meta.SetStatusCondition(&pc.Status.Conditions, metav1.Condition{
+			Type:               ConditionPoolAvailable,
+			Status:             metav1.ConditionFalse,
+			Reason:             butlerv1alpha1.ReasonPoolExhausted,
+			Message:            "all configured pools are exhausted",
+			ObservedGeneration: pc.Generation,
+		})
+		r.Recorder.Event(pc, "Warning", "PoolsExhausted", "all configured network pools are exhausted")
+	}
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&butlerv1alpha1.ProviderConfig{}).
+		Watches(&corev1.Secret{},
+			handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, obj client.Object) []reconcile.Request {
+				// Find ProviderConfigs referencing this secret
+				pcList := &butlerv1alpha1.ProviderConfigList{}
+				if err := mgr.GetClient().List(ctx, pcList); err != nil {
+					return nil
+				}
+				var requests []reconcile.Request
+				for _, pc := range pcList.Items {
+					secretNS := pc.Spec.CredentialsRef.Namespace
+					if secretNS == "" {
+						secretNS = pc.Namespace
+					}
+					if obj.GetName() == pc.Spec.CredentialsRef.Name && obj.GetNamespace() == secretNS {
+						requests = append(requests, reconcile.Request{
+							NamespacedName: types.NamespacedName{
+								Name:      pc.Name,
+								Namespace: pc.Namespace,
+							},
+						})
+					}
+				}
+				return requests
+			}),
+		).
+		Named("providerconfig").
+		Complete(r)
+}

--- a/internal/controller/providerconfig/providerconfig_controller_test.go
+++ b/internal/controller/providerconfig/providerconfig_controller_test.go
@@ -1,0 +1,405 @@
+/*
+Copyright 2026 The Butler Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package providerconfig
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	butlerv1alpha1 "github.com/butlerdotdev/butler-api/api/v1alpha1"
+)
+
+var _ = Describe("ProviderConfig Controller", func() {
+	const (
+		timeout  = 10 * time.Second
+		interval = 100 * time.Millisecond
+	)
+
+	Describe("Valid Credentials (Harvester)", func() {
+		const (
+			namespaceName = "test-provider-harvester"
+			secretName    = "harvester-creds"
+			pcName        = "harvester-valid"
+		)
+
+		BeforeEach(func() {
+			ns := newNamespace(namespaceName)
+			Expect(k8sClient.Create(ctx, ns)).To(Succeed())
+		})
+
+		AfterEach(func() {
+			// Clean up ProviderConfig (remove finalizer first to avoid blocking)
+			pc := &butlerv1alpha1.ProviderConfig{}
+			if err := k8sClient.Get(ctx, types.NamespacedName{Name: pcName, Namespace: namespaceName}, pc); err == nil {
+				controllerutil.RemoveFinalizer(pc, butlerv1alpha1.FinalizerProviderConfig)
+				_ = k8sClient.Update(ctx, pc)
+				_ = k8sClient.Delete(ctx, pc)
+			}
+
+			ns := newNamespace(namespaceName)
+			_ = k8sClient.Delete(ctx, ns)
+			time.Sleep(200 * time.Millisecond)
+		})
+
+		It("should set CredentialsValid=True and status.validated=true when secret has correct keys", func() {
+			// Create Secret with the required "kubeconfig" key for Harvester
+			secret := newSecret(secretName, namespaceName, map[string][]byte{
+				"kubeconfig": []byte("apiVersion: v1\nkind: Config"),
+			})
+			Expect(k8sClient.Create(ctx, secret)).To(Succeed())
+
+			// Create ProviderConfig referencing the secret
+			pc := newProviderConfig(pcName, namespaceName, butlerv1alpha1.ProviderTypeHarvester, secretName)
+			Expect(k8sClient.Create(ctx, pc)).To(Succeed())
+
+			// Eventually: condition CredentialsValid=True
+			Eventually(func(g Gomega) {
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: pcName, Namespace: namespaceName}, pc)
+				g.Expect(err).NotTo(HaveOccurred())
+
+				cond := meta.FindStatusCondition(pc.Status.Conditions, ConditionCredentialsValid)
+				g.Expect(cond).NotTo(BeNil())
+				g.Expect(cond.Status).To(Equal(metav1.ConditionTrue))
+				g.Expect(cond.Reason).To(Equal(butlerv1alpha1.ReasonReady))
+
+				g.Expect(pc.Status.Validated).To(BeTrue())
+				g.Expect(pc.Status.Ready).To(BeTrue())
+			}, timeout, interval).Should(Succeed())
+		})
+	})
+
+	Describe("Missing Secret", func() {
+		const (
+			namespaceName = "test-provider-missing-secret"
+			pcName        = "pc-missing-secret"
+		)
+
+		BeforeEach(func() {
+			ns := newNamespace(namespaceName)
+			Expect(k8sClient.Create(ctx, ns)).To(Succeed())
+		})
+
+		AfterEach(func() {
+			pc := &butlerv1alpha1.ProviderConfig{}
+			if err := k8sClient.Get(ctx, types.NamespacedName{Name: pcName, Namespace: namespaceName}, pc); err == nil {
+				controllerutil.RemoveFinalizer(pc, butlerv1alpha1.FinalizerProviderConfig)
+				_ = k8sClient.Update(ctx, pc)
+				_ = k8sClient.Delete(ctx, pc)
+			}
+
+			ns := newNamespace(namespaceName)
+			_ = k8sClient.Delete(ctx, ns)
+			time.Sleep(200 * time.Millisecond)
+		})
+
+		It("should set CredentialsValid=False when the referenced secret does not exist", func() {
+			// Create ProviderConfig referencing a non-existent secret
+			pc := newProviderConfig(pcName, namespaceName, butlerv1alpha1.ProviderTypeHarvester, "nonexistent-secret")
+			Expect(k8sClient.Create(ctx, pc)).To(Succeed())
+
+			// Eventually: condition CredentialsValid=False
+			Eventually(func(g Gomega) {
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: pcName, Namespace: namespaceName}, pc)
+				g.Expect(err).NotTo(HaveOccurred())
+
+				cond := meta.FindStatusCondition(pc.Status.Conditions, ConditionCredentialsValid)
+				g.Expect(cond).NotTo(BeNil())
+				g.Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+				g.Expect(cond.Reason).To(Equal(butlerv1alpha1.ReasonCredentialsInvalid))
+				g.Expect(cond.Message).To(ContainSubstring("not found"))
+
+				g.Expect(pc.Status.Validated).To(BeFalse())
+				g.Expect(pc.Status.Ready).To(BeFalse())
+			}, timeout, interval).Should(Succeed())
+		})
+	})
+
+	Describe("Missing Secret Keys (Nutanix)", func() {
+		const (
+			namespaceName = "test-provider-nutanix-keys"
+			secretName    = "nutanix-creds-partial"
+			pcName        = "pc-nutanix-missing-keys"
+		)
+
+		BeforeEach(func() {
+			ns := newNamespace(namespaceName)
+			Expect(k8sClient.Create(ctx, ns)).To(Succeed())
+		})
+
+		AfterEach(func() {
+			pc := &butlerv1alpha1.ProviderConfig{}
+			if err := k8sClient.Get(ctx, types.NamespacedName{Name: pcName, Namespace: namespaceName}, pc); err == nil {
+				controllerutil.RemoveFinalizer(pc, butlerv1alpha1.FinalizerProviderConfig)
+				_ = k8sClient.Update(ctx, pc)
+				_ = k8sClient.Delete(ctx, pc)
+			}
+
+			ns := newNamespace(namespaceName)
+			_ = k8sClient.Delete(ctx, ns)
+			time.Sleep(200 * time.Millisecond)
+		})
+
+		It("should set CredentialsValid=False with a message about missing keys", func() {
+			// Create Secret with only "username" (missing "password")
+			secret := newSecret(secretName, namespaceName, map[string][]byte{
+				"username": []byte("admin"),
+			})
+			Expect(k8sClient.Create(ctx, secret)).To(Succeed())
+
+			// Create ProviderConfig with provider=nutanix
+			pc := newProviderConfig(pcName, namespaceName, butlerv1alpha1.ProviderTypeNutanix, secretName)
+			Expect(k8sClient.Create(ctx, pc)).To(Succeed())
+
+			// Eventually: condition CredentialsValid=False with message about missing keys
+			Eventually(func(g Gomega) {
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: pcName, Namespace: namespaceName}, pc)
+				g.Expect(err).NotTo(HaveOccurred())
+
+				cond := meta.FindStatusCondition(pc.Status.Conditions, ConditionCredentialsValid)
+				g.Expect(cond).NotTo(BeNil())
+				g.Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+				g.Expect(cond.Reason).To(Equal(butlerv1alpha1.ReasonCredentialsInvalid))
+				g.Expect(cond.Message).To(ContainSubstring("missing required keys"))
+				g.Expect(cond.Message).To(ContainSubstring("password"))
+
+				g.Expect(pc.Status.Validated).To(BeFalse())
+			}, timeout, interval).Should(Succeed())
+		})
+	})
+
+	Describe("Team Scope Validation", func() {
+		const (
+			namespaceName = "test-provider-team-scope"
+			secretName    = "team-scope-creds"
+			pcName        = "pc-team-scope"
+			teamName      = "test-team"
+		)
+
+		BeforeEach(func() {
+			ns := newNamespace(namespaceName)
+			Expect(k8sClient.Create(ctx, ns)).To(Succeed())
+
+			// Create the referenced Team
+			team := newTeam(teamName)
+			Expect(k8sClient.Create(ctx, team)).To(Succeed())
+		})
+
+		AfterEach(func() {
+			pc := &butlerv1alpha1.ProviderConfig{}
+			if err := k8sClient.Get(ctx, types.NamespacedName{Name: pcName, Namespace: namespaceName}, pc); err == nil {
+				controllerutil.RemoveFinalizer(pc, butlerv1alpha1.FinalizerProviderConfig)
+				_ = k8sClient.Update(ctx, pc)
+				_ = k8sClient.Delete(ctx, pc)
+			}
+
+			team := &butlerv1alpha1.Team{}
+			if err := k8sClient.Get(ctx, types.NamespacedName{Name: teamName}, team); err == nil {
+				_ = k8sClient.Delete(ctx, team)
+			}
+
+			ns := newNamespace(namespaceName)
+			_ = k8sClient.Delete(ctx, ns)
+			time.Sleep(200 * time.Millisecond)
+		})
+
+		It("should validate successfully when scope.type=team and teamRef points to an existing team", func() {
+			// Create Secret with valid credentials
+			secret := newSecret(secretName, namespaceName, map[string][]byte{
+				"kubeconfig": []byte("apiVersion: v1\nkind: Config"),
+			})
+			Expect(k8sClient.Create(ctx, secret)).To(Succeed())
+
+			// Create ProviderConfig with team scope
+			pc := newProviderConfig(pcName, namespaceName, butlerv1alpha1.ProviderTypeHarvester, secretName)
+			pc.Spec.Scope = &butlerv1alpha1.ProviderConfigScope{
+				Type: butlerv1alpha1.ProviderConfigScopeTeam,
+				TeamRef: &butlerv1alpha1.LocalObjectReference{
+					Name: teamName,
+				},
+			}
+			Expect(k8sClient.Create(ctx, pc)).To(Succeed())
+
+			// Eventually: credentials are valid and no scope error condition is set
+			Eventually(func(g Gomega) {
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: pcName, Namespace: namespaceName}, pc)
+				g.Expect(err).NotTo(HaveOccurred())
+
+				credsCond := meta.FindStatusCondition(pc.Status.Conditions, ConditionCredentialsValid)
+				g.Expect(credsCond).NotTo(BeNil())
+				g.Expect(credsCond.Status).To(Equal(metav1.ConditionTrue))
+
+				// The Ready condition should not be set to False with ValidationFailed
+				readyCond := meta.FindStatusCondition(pc.Status.Conditions, butlerv1alpha1.ConditionTypeReady)
+				if readyCond != nil {
+					g.Expect(readyCond.Reason).NotTo(Equal(butlerv1alpha1.ReasonValidationFailed))
+				}
+
+				g.Expect(pc.Status.Validated).To(BeTrue())
+				g.Expect(pc.Status.Ready).To(BeTrue())
+			}, timeout, interval).Should(Succeed())
+		})
+	})
+
+	Describe("Team Scope Missing TeamRef", func() {
+		const (
+			namespaceName = "test-provider-no-teamref"
+			secretName    = "no-teamref-creds"
+			pcName        = "pc-no-teamref"
+		)
+
+		BeforeEach(func() {
+			ns := newNamespace(namespaceName)
+			Expect(k8sClient.Create(ctx, ns)).To(Succeed())
+		})
+
+		AfterEach(func() {
+			pc := &butlerv1alpha1.ProviderConfig{}
+			if err := k8sClient.Get(ctx, types.NamespacedName{Name: pcName, Namespace: namespaceName}, pc); err == nil {
+				controllerutil.RemoveFinalizer(pc, butlerv1alpha1.FinalizerProviderConfig)
+				_ = k8sClient.Update(ctx, pc)
+				_ = k8sClient.Delete(ctx, pc)
+			}
+
+			ns := newNamespace(namespaceName)
+			_ = k8sClient.Delete(ctx, ns)
+			time.Sleep(200 * time.Millisecond)
+		})
+
+		It("should set Ready=False when scope.type=team but teamRef is not set", func() {
+			// Create Secret with valid credentials so credential validation passes
+			secret := newSecret(secretName, namespaceName, map[string][]byte{
+				"kubeconfig": []byte("apiVersion: v1\nkind: Config"),
+			})
+			Expect(k8sClient.Create(ctx, secret)).To(Succeed())
+
+			// Create ProviderConfig with scope.type=team but no teamRef
+			pc := newProviderConfig(pcName, namespaceName, butlerv1alpha1.ProviderTypeHarvester, secretName)
+			pc.Spec.Scope = &butlerv1alpha1.ProviderConfigScope{
+				Type: butlerv1alpha1.ProviderConfigScopeTeam,
+				// TeamRef intentionally nil
+			}
+			Expect(k8sClient.Create(ctx, pc)).To(Succeed())
+
+			// Eventually: condition Ready=False with message about teamRef
+			Eventually(func(g Gomega) {
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: pcName, Namespace: namespaceName}, pc)
+				g.Expect(err).NotTo(HaveOccurred())
+
+				readyCond := meta.FindStatusCondition(pc.Status.Conditions, butlerv1alpha1.ConditionTypeReady)
+				g.Expect(readyCond).NotTo(BeNil())
+				g.Expect(readyCond.Status).To(Equal(metav1.ConditionFalse))
+				g.Expect(readyCond.Reason).To(Equal(butlerv1alpha1.ReasonValidationFailed))
+				g.Expect(readyCond.Message).To(ContainSubstring("teamRef"))
+			}, timeout, interval).Should(Succeed())
+		})
+	})
+
+	Describe("Deletion Protection", func() {
+		const (
+			namespaceName = "test-provider-deletion"
+			secretName    = "deletion-creds"
+			pcName        = "pc-deletion-test"
+			tcName        = "tc-referencing-pc"
+		)
+
+		BeforeEach(func() {
+			ns := newNamespace(namespaceName)
+			Expect(k8sClient.Create(ctx, ns)).To(Succeed())
+		})
+
+		AfterEach(func() {
+			// Clean up TenantCluster first
+			tc := &butlerv1alpha1.TenantCluster{}
+			if err := k8sClient.Get(ctx, types.NamespacedName{Name: tcName, Namespace: namespaceName}, tc); err == nil {
+				_ = k8sClient.Delete(ctx, tc)
+			}
+
+			// Clean up ProviderConfig (remove finalizer to allow deletion)
+			pc := &butlerv1alpha1.ProviderConfig{}
+			if err := k8sClient.Get(ctx, types.NamespacedName{Name: pcName, Namespace: namespaceName}, pc); err == nil {
+				controllerutil.RemoveFinalizer(pc, butlerv1alpha1.FinalizerProviderConfig)
+				_ = k8sClient.Update(ctx, pc)
+				_ = k8sClient.Delete(ctx, pc)
+			}
+
+			ns := newNamespace(namespaceName)
+			_ = k8sClient.Delete(ctx, ns)
+			time.Sleep(200 * time.Millisecond)
+		})
+
+		It("should add the finalizer to a new ProviderConfig", func() {
+			// Create Secret
+			secret := newSecret(secretName, namespaceName, map[string][]byte{
+				"kubeconfig": []byte("apiVersion: v1\nkind: Config"),
+			})
+			Expect(k8sClient.Create(ctx, secret)).To(Succeed())
+
+			// Create ProviderConfig
+			pc := newProviderConfig(pcName, namespaceName, butlerv1alpha1.ProviderTypeHarvester, secretName)
+			Expect(k8sClient.Create(ctx, pc)).To(Succeed())
+
+			// Eventually: finalizer is added
+			Eventually(func(g Gomega) {
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: pcName, Namespace: namespaceName}, pc)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(controllerutil.ContainsFinalizer(pc, butlerv1alpha1.FinalizerProviderConfig)).To(BeTrue())
+			}, timeout, interval).Should(Succeed())
+		})
+
+		It("should block deletion while TenantClusters reference the ProviderConfig", func() {
+			// Create Secret
+			secret := newSecret(secretName, namespaceName, map[string][]byte{
+				"kubeconfig": []byte("apiVersion: v1\nkind: Config"),
+			})
+			Expect(k8sClient.Create(ctx, secret)).To(Succeed())
+
+			// Create ProviderConfig
+			pc := newProviderConfig(pcName, namespaceName, butlerv1alpha1.ProviderTypeHarvester, secretName)
+			Expect(k8sClient.Create(ctx, pc)).To(Succeed())
+
+			// Wait for finalizer to be added
+			Eventually(func(g Gomega) {
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: pcName, Namespace: namespaceName}, pc)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(controllerutil.ContainsFinalizer(pc, butlerv1alpha1.FinalizerProviderConfig)).To(BeTrue())
+			}, timeout, interval).Should(Succeed())
+
+			// Create a TenantCluster referencing this ProviderConfig
+			tc := newTenantCluster(tcName, namespaceName, pcName)
+			Expect(k8sClient.Create(ctx, tc)).To(Succeed())
+
+			// Delete the ProviderConfig (should be blocked by finalizer)
+			Expect(k8sClient.Delete(ctx, pc)).To(Succeed())
+
+			// Consistently: the ProviderConfig should still exist because the finalizer
+			// blocks deletion while TenantClusters reference it
+			Consistently(func(g Gomega) {
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: pcName, Namespace: namespaceName}, pc)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(pc.DeletionTimestamp).NotTo(BeNil())
+				g.Expect(controllerutil.ContainsFinalizer(pc, butlerv1alpha1.FinalizerProviderConfig)).To(BeTrue())
+			}, 3*time.Second, interval).Should(Succeed())
+		})
+	})
+})

--- a/internal/controller/providerconfig/suite_test.go
+++ b/internal/controller/providerconfig/suite_test.go
@@ -1,0 +1,175 @@
+/*
+Copyright 2026 The Butler Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package providerconfig
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+
+	butlerv1alpha1 "github.com/butlerdotdev/butler-api/api/v1alpha1"
+)
+
+var (
+	cfg       *rest.Config
+	k8sClient client.Client
+	testEnv   *envtest.Environment
+	ctx       context.Context
+	cancel    context.CancelFunc
+)
+
+func TestProviderConfig(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "ProviderConfig Controller Suite")
+}
+
+var _ = BeforeSuite(func() {
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+
+	ctx, cancel = context.WithCancel(context.TODO())
+
+	By("bootstrapping test environment")
+	testEnv = &envtest.Environment{
+		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "..", "butler-api", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing: true,
+	}
+
+	var err error
+	cfg, err = testEnv.Start()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(cfg).NotTo(BeNil())
+
+	err = butlerv1alpha1.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(k8sClient).NotTo(BeNil())
+
+	// Start the controller manager with metrics disabled to avoid port conflicts
+	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
+		Scheme: scheme.Scheme,
+		Metrics: metricsserver.Options{
+			BindAddress: "0", // Disable metrics server in tests
+		},
+	})
+	Expect(err).NotTo(HaveOccurred())
+
+	err = (&Reconciler{
+		Client: mgr.GetClient(),
+		Scheme: mgr.GetScheme(),
+	}).SetupWithManager(mgr)
+	Expect(err).NotTo(HaveOccurred())
+
+	go func() {
+		defer GinkgoRecover()
+		err = mgr.Start(ctx)
+		Expect(err).NotTo(HaveOccurred())
+	}()
+
+	// Wait for cache to sync
+	time.Sleep(100 * time.Millisecond)
+})
+
+var _ = AfterSuite(func() {
+	By("tearing down the test environment")
+	cancel()
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
+})
+
+// Helper to create a namespace
+func newNamespace(name string) *corev1.Namespace {
+	return &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+	}
+}
+
+// Helper to create a Secret with the given data keys
+func newSecret(name, namespace string, data map[string][]byte) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Data: data,
+	}
+}
+
+// Helper to create a ProviderConfig for testing
+func newProviderConfig(name, namespace string, provider butlerv1alpha1.ProviderType, secretName string) *butlerv1alpha1.ProviderConfig {
+	return &butlerv1alpha1.ProviderConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: butlerv1alpha1.ProviderConfigSpec{
+			Provider: provider,
+			CredentialsRef: butlerv1alpha1.SecretReference{
+				Name: secretName,
+			},
+		},
+	}
+}
+
+// Helper to create a Team for testing
+func newTeam(name string) *butlerv1alpha1.Team {
+	return &butlerv1alpha1.Team{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Spec: butlerv1alpha1.TeamSpec{
+			DisplayName: name,
+		},
+	}
+}
+
+// Helper to create a TenantCluster that references a ProviderConfig
+func newTenantCluster(name, namespace, providerConfigName string) *butlerv1alpha1.TenantCluster {
+	return &butlerv1alpha1.TenantCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: butlerv1alpha1.TenantClusterSpec{
+			KubernetesVersion: "v1.30.0",
+			ProviderConfigRef: &butlerv1alpha1.ProviderReference{
+				Name: providerConfigName,
+			},
+			Workers: butlerv1alpha1.WorkersSpec{
+				Replicas: 1,
+			},
+		},
+	}
+}

--- a/internal/controller/tenantcluster/tenantcluster_controller.go
+++ b/internal/controller/tenantcluster/tenantcluster_controller.go
@@ -193,6 +193,21 @@ func (r *Reconciler) reconcileInfrastructure(ctx context.Context, tc *butlerv1al
 		return ctrl.Result{}, err
 	}
 
+	// Validate provider scope access
+	if err := r.validateProviderAccess(ctx, tc, providerConfig); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	// Reconcile IPAM allocation (if provider has network.mode=ipam)
+	ipamReady, err := r.reconcileIPAllocation(ctx, tc, providerConfig)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	if !ipamReady {
+		logger.Info("waiting for IPAM allocation")
+		return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
+	}
+
 	// Build CAPI resources with ButlerConfig for platform-level settings
 	// ButlerConfig provides ControlPlaneExposure settings (LoadBalancer/Ingress/Gateway mode)
 	// which enables auto-enabling tcp-proxy for non-LoadBalancer modes
@@ -456,7 +471,18 @@ func (r *Reconciler) reconcileAddons(ctx context.Context, tc *butlerv1alpha1.Ten
 		metallbVersion = tc.Spec.Addons.LoadBalancer.Version
 	}
 	var poolStart, poolEnd string
-	if tc.Spec.Networking.LoadBalancerPool != nil {
+	// Check IPAM allocation first, fall back to manual loadBalancerPool
+	if tc.Status.LBAllocationRef != nil {
+		lbAlloc := &butlerv1alpha1.IPAllocation{}
+		if err := r.Get(ctx, types.NamespacedName{
+			Name:      tc.Status.LBAllocationRef.Name,
+			Namespace: "butler-system",
+		}, lbAlloc); err == nil && lbAlloc.Status.Phase == butlerv1alpha1.IPAllocationPhaseAllocated {
+			poolStart = lbAlloc.Status.StartAddress
+			poolEnd = lbAlloc.Status.EndAddress
+		}
+	}
+	if poolStart == "" && tc.Spec.Networking.LoadBalancerPool != nil {
 		poolStart = tc.Spec.Networking.LoadBalancerPool.Start
 		poolEnd = tc.Spec.Networking.LoadBalancerPool.End
 	}
@@ -570,9 +596,13 @@ func (r *Reconciler) getProviderConfig(ctx context.Context, tc *butlerv1alpha1.T
 	const defaultProviderNamespace = "butler-system"
 
 	if tc.Spec.ProviderConfigRef != nil && tc.Spec.ProviderConfigRef.Name != "" {
+		ns := tc.Spec.ProviderConfigRef.Namespace
+		if ns == "" {
+			ns = defaultProviderNamespace
+		}
 		pc := &butlerv1alpha1.ProviderConfig{}
-		if err := r.Get(ctx, types.NamespacedName{Name: tc.Spec.ProviderConfigRef.Name, Namespace: defaultProviderNamespace}, pc); err != nil {
-			return nil, fmt.Errorf("failed to get ProviderConfig %s/%s: %w", defaultProviderNamespace, tc.Spec.ProviderConfigRef.Name, err)
+		if err := r.Get(ctx, types.NamespacedName{Name: tc.Spec.ProviderConfigRef.Name, Namespace: ns}, pc); err != nil {
+			return nil, fmt.Errorf("failed to get ProviderConfig %s/%s: %w", ns, tc.Spec.ProviderConfigRef.Name, err)
 		}
 		return pc, nil
 	}
@@ -1184,6 +1214,9 @@ func (r *Reconciler) handleDeletion(ctx context.Context, tc *butlerv1alpha1.Tena
 		}
 	}
 
+	// Clean up IPAllocations before deleting namespace
+	r.cleanupIPAllocations(ctx, tc)
+
 	if tc.Status.TenantNamespace != "" {
 		ns := &corev1.Namespace{}
 		err := r.Get(ctx, types.NamespacedName{Name: tc.Status.TenantNamespace}, ns)
@@ -1669,6 +1702,258 @@ func (r *Reconciler) reconcileTalosBootstrap(ctx context.Context, tc *butlerv1al
 		"endpoint", controlPlaneEndpoint)
 
 	return nil
+}
+
+// validateProviderAccess checks if the TenantCluster's team has access to the ProviderConfig.
+func (r *Reconciler) validateProviderAccess(ctx context.Context, tc *butlerv1alpha1.TenantCluster, pc *butlerv1alpha1.ProviderConfig) error {
+	// Platform-scoped providers are accessible to all teams
+	if pc.Spec.Scope == nil || pc.Spec.Scope.Type == "" || pc.Spec.Scope.Type == butlerv1alpha1.ProviderConfigScopePlatform {
+		r.setCondition(tc, butlerv1alpha1.TenantClusterConditionProviderAccessGranted,
+			metav1.ConditionTrue, butlerv1alpha1.ReasonReady, "platform-scoped provider")
+		return r.validateProviderLimits(ctx, tc, pc)
+	}
+
+	// Team-scoped: verify the TC's team matches the PC's team
+	if pc.Spec.Scope.TeamRef == nil {
+		r.setCondition(tc, butlerv1alpha1.TenantClusterConditionProviderAccessGranted,
+			metav1.ConditionFalse, butlerv1alpha1.ReasonProviderAccessDenied,
+			"provider is team-scoped but has no teamRef")
+		return fmt.Errorf("provider %s is team-scoped but has no teamRef", pc.Name)
+	}
+
+	if tc.Spec.TeamRef == nil {
+		r.setCondition(tc, butlerv1alpha1.TenantClusterConditionProviderAccessGranted,
+			metav1.ConditionFalse, butlerv1alpha1.ReasonProviderAccessDenied,
+			"cluster has no teamRef but provider is team-scoped")
+		return fmt.Errorf("cluster has no teamRef but provider %s is team-scoped to %s",
+			pc.Name, pc.Spec.Scope.TeamRef.Name)
+	}
+
+	if tc.Spec.TeamRef.Name != pc.Spec.Scope.TeamRef.Name {
+		r.setCondition(tc, butlerv1alpha1.TenantClusterConditionProviderAccessGranted,
+			metav1.ConditionFalse, butlerv1alpha1.ReasonProviderAccessDenied,
+			fmt.Sprintf("team %s does not have access to provider %s (scoped to %s)",
+				tc.Spec.TeamRef.Name, pc.Name, pc.Spec.Scope.TeamRef.Name))
+		return fmt.Errorf("team %s does not have access to provider %s (scoped to %s)",
+			tc.Spec.TeamRef.Name, pc.Name, pc.Spec.Scope.TeamRef.Name)
+	}
+
+	r.setCondition(tc, butlerv1alpha1.TenantClusterConditionProviderAccessGranted,
+		metav1.ConditionTrue, butlerv1alpha1.ReasonReady,
+		fmt.Sprintf("team %s has access to provider %s", tc.Spec.TeamRef.Name, pc.Name))
+
+	// Enforce provider limits (defense-in-depth when webhooks are disabled)
+	return r.validateProviderLimits(ctx, tc, pc)
+}
+
+// validateProviderLimits checks maxClustersPerTeam and maxNodesPerTeam limits from ProviderConfig.
+func (r *Reconciler) validateProviderLimits(ctx context.Context, tc *butlerv1alpha1.TenantCluster, pc *butlerv1alpha1.ProviderConfig) error {
+	if pc.Spec.Limits == nil {
+		return nil
+	}
+
+	if pc.Spec.Limits.MaxClustersPerTeam != nil {
+		maxClusters := *pc.Spec.Limits.MaxClustersPerTeam
+		var tcList butlerv1alpha1.TenantClusterList
+		if err := r.List(ctx, &tcList, client.InNamespace(tc.Namespace)); err != nil {
+			return fmt.Errorf("failed to list TenantClusters: %w", err)
+		}
+
+		var existingCount int32
+		for i := range tcList.Items {
+			if tcList.Items[i].Name != tc.Name {
+				existingCount++
+			}
+		}
+
+		if existingCount >= maxClusters {
+			msg := fmt.Sprintf("team namespace %q has %d cluster(s), provider %q limits to %d",
+				tc.Namespace, existingCount, pc.Name, maxClusters)
+			r.setCondition(tc, butlerv1alpha1.TenantClusterConditionProviderAccessGranted,
+				metav1.ConditionFalse, butlerv1alpha1.ReasonQuotaExceeded, msg)
+			return fmt.Errorf("quota exceeded: %s", msg)
+		}
+	}
+
+	if pc.Spec.Limits.MaxNodesPerTeam != nil {
+		maxNodes := *pc.Spec.Limits.MaxNodesPerTeam
+		var tcList butlerv1alpha1.TenantClusterList
+		if err := r.List(ctx, &tcList, client.InNamespace(tc.Namespace)); err != nil {
+			return fmt.Errorf("failed to list TenantClusters: %w", err)
+		}
+
+		totalNodes := tc.Spec.Workers.Replicas
+		for i := range tcList.Items {
+			if tcList.Items[i].Name != tc.Name {
+				totalNodes += tcList.Items[i].Spec.Workers.Replicas
+			}
+		}
+
+		if totalNodes > maxNodes {
+			msg := fmt.Sprintf("total worker replicas (%d) exceeds provider %q per-team limit (%d)",
+				totalNodes, pc.Name, maxNodes)
+			r.setCondition(tc, butlerv1alpha1.TenantClusterConditionProviderAccessGranted,
+				metav1.ConditionFalse, butlerv1alpha1.ReasonQuotaExceeded, msg)
+			return fmt.Errorf("quota exceeded: %s", msg)
+		}
+	}
+
+	return nil
+}
+
+// reconcileIPAllocation creates or checks LB IPAllocation for IPAM mode providers.
+// Returns true if IPAM is ready (allocated or not needed), false if waiting.
+func (r *Reconciler) reconcileIPAllocation(ctx context.Context, tc *butlerv1alpha1.TenantCluster, pc *butlerv1alpha1.ProviderConfig) (bool, error) {
+	logger := log.FromContext(ctx)
+
+	// Skip IPAM if not configured
+	if pc.Spec.Network == nil || pc.Spec.Network.Mode != "ipam" {
+		r.setCondition(tc, butlerv1alpha1.TenantClusterConditionNetworkReady,
+			metav1.ConditionTrue, butlerv1alpha1.ReasonReady, "cloud networking mode")
+		return true, nil
+	}
+
+	if len(pc.Spec.Network.PoolRefs) == 0 {
+		r.setCondition(tc, butlerv1alpha1.TenantClusterConditionNetworkReady,
+			metav1.ConditionFalse, butlerv1alpha1.ReasonNetworkNotReady,
+			"IPAM mode but no poolRefs configured on provider")
+		return false, fmt.Errorf("IPAM mode but no poolRefs configured on provider %s", pc.Name)
+	}
+
+	// Check if LB allocation already exists
+	if tc.Status.LBAllocationRef != nil {
+		alloc := &butlerv1alpha1.IPAllocation{}
+		if err := r.Get(ctx, types.NamespacedName{
+			Name:      tc.Status.LBAllocationRef.Name,
+			Namespace: "butler-system",
+		}, alloc); err != nil {
+			if apierrors.IsNotFound(err) {
+				// Allocation was deleted, clear ref and retry
+				tc.Status.LBAllocationRef = nil
+			} else {
+				return false, err
+			}
+		} else {
+			switch alloc.Status.Phase {
+			case butlerv1alpha1.IPAllocationPhaseAllocated:
+				r.setCondition(tc, butlerv1alpha1.TenantClusterConditionNetworkReady,
+					metav1.ConditionTrue, butlerv1alpha1.ReasonReady,
+					fmt.Sprintf("LB IPs allocated: %s", alloc.Status.CIDR))
+				return true, nil
+			case butlerv1alpha1.IPAllocationPhasePending:
+				r.setCondition(tc, butlerv1alpha1.TenantClusterConditionNetworkReady,
+					metav1.ConditionFalse, butlerv1alpha1.ReasonReconciling,
+					"waiting for LB IP allocation")
+				return false, nil
+			case butlerv1alpha1.IPAllocationPhaseFailed:
+				// Delete failed allocation and try next pool
+				logger.Info("LB allocation failed, cleaning up", "allocation", alloc.Name)
+				if err := r.Delete(ctx, alloc); err != nil && !apierrors.IsNotFound(err) {
+					return false, err
+				}
+				tc.Status.LBAllocationRef = nil
+			}
+		}
+	}
+
+	// Create new allocation — try pools in priority order
+	lbCount := r.getLBPoolSize(tc, pc)
+	allocName := fmt.Sprintf("%s-%s-lb", tc.Namespace, tc.Name)
+
+	for _, poolRef := range pc.Spec.Network.PoolRefs {
+		// Check pool capacity
+		pool := &butlerv1alpha1.NetworkPool{}
+		if err := r.Get(ctx, types.NamespacedName{
+			Name:      poolRef.Name,
+			Namespace: "butler-system",
+		}, pool); err != nil {
+			logger.V(1).Info("pool not found, trying next", "pool", poolRef.Name)
+			continue
+		}
+
+		if pool.Status.AvailableIPs < lbCount {
+			logger.V(1).Info("pool has insufficient capacity, trying next",
+				"pool", poolRef.Name, "available", pool.Status.AvailableIPs, "needed", lbCount)
+			continue
+		}
+
+		// Create IPAllocation
+		alloc := &butlerv1alpha1.IPAllocation{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      allocName,
+				Namespace: "butler-system",
+				Labels: map[string]string{
+					butlerv1alpha1.LabelNetworkPool: poolRef.Name,
+					butlerv1alpha1.LabelTeam:        tc.Namespace,
+					butlerv1alpha1.LabelTenant:      tc.Name,
+				},
+			},
+			Spec: butlerv1alpha1.IPAllocationSpec{
+				PoolRef:          butlerv1alpha1.LocalObjectReference{Name: poolRef.Name},
+				TenantClusterRef: butlerv1alpha1.NamespacedObjectReference{Name: tc.Name, Namespace: tc.Namespace},
+				Type:             butlerv1alpha1.IPAllocationTypeLoadBalancer,
+				Count:            &lbCount,
+			},
+		}
+
+		if err := r.Create(ctx, alloc); err != nil {
+			if apierrors.IsAlreadyExists(err) {
+				// Re-fetch and check status
+				existing := &butlerv1alpha1.IPAllocation{}
+				if getErr := r.Get(ctx, types.NamespacedName{Name: allocName, Namespace: "butler-system"}, existing); getErr == nil {
+					tc.Status.LBAllocationRef = &butlerv1alpha1.LocalObjectReference{Name: allocName}
+					return false, nil
+				}
+			}
+			return false, fmt.Errorf("failed to create IPAllocation: %w", err)
+		}
+
+		logger.Info("created LB IPAllocation", "allocation", allocName, "pool", poolRef.Name, "count", lbCount)
+		tc.Status.LBAllocationRef = &butlerv1alpha1.LocalObjectReference{Name: allocName}
+		return false, nil // Wait for allocation to be fulfilled
+	}
+
+	// All pools exhausted
+	r.setCondition(tc, butlerv1alpha1.TenantClusterConditionNetworkReady,
+		metav1.ConditionFalse, butlerv1alpha1.ReasonPoolExhausted,
+		"all configured pools are exhausted")
+	return false, nil
+}
+
+func (r *Reconciler) getLBPoolSize(tc *butlerv1alpha1.TenantCluster, pc *butlerv1alpha1.ProviderConfig) int32 {
+	// TC override takes priority
+	if tc.Spec.Networking.LBPoolSize != nil {
+		return *tc.Spec.Networking.LBPoolSize
+	}
+	// Then provider default
+	if pc.Spec.Network != nil && pc.Spec.Network.LoadBalancer != nil && pc.Spec.Network.LoadBalancer.DefaultPoolSize != nil {
+		return *pc.Spec.Network.LoadBalancer.DefaultPoolSize
+	}
+	return 8
+}
+
+// cleanupIPAllocations deletes IPAllocations referenced by the TenantCluster.
+func (r *Reconciler) cleanupIPAllocations(ctx context.Context, tc *butlerv1alpha1.TenantCluster) {
+	logger := log.FromContext(ctx)
+
+	refs := []*butlerv1alpha1.LocalObjectReference{tc.Status.IPAllocationRef, tc.Status.LBAllocationRef}
+	for _, ref := range refs {
+		if ref == nil {
+			continue
+		}
+		alloc := &butlerv1alpha1.IPAllocation{}
+		if err := r.Get(ctx, types.NamespacedName{Name: ref.Name, Namespace: "butler-system"}, alloc); err != nil {
+			if !apierrors.IsNotFound(err) {
+				logger.Error(err, "failed to get IPAllocation for cleanup", "name", ref.Name)
+			}
+			continue
+		}
+		if err := r.Delete(ctx, alloc); err != nil && !apierrors.IsNotFound(err) {
+			logger.Error(err, "failed to delete IPAllocation", "name", ref.Name)
+		} else {
+			logger.Info("deleted IPAllocation during cleanup", "name", ref.Name)
+		}
+	}
 }
 
 func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {

--- a/internal/ipam/allocator.go
+++ b/internal/ipam/allocator.go
@@ -1,0 +1,632 @@
+/*
+Copyright 2026 The Butler Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ipam
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"math"
+	"math/bits"
+	"net"
+	"sort"
+	"strings"
+)
+
+var (
+	// ErrPoolExhausted indicates no contiguous block of the requested size is available.
+	ErrPoolExhausted = errors.New("pool exhausted: no contiguous block available")
+
+	// ErrInvalidCIDR indicates an unparseable CIDR string.
+	ErrInvalidCIDR = errors.New("invalid CIDR notation")
+
+	// ErrInvalidRange indicates start IP is after end IP.
+	ErrInvalidRange = errors.New("invalid IP range: start is after end")
+
+	// ErrOutOfRange indicates the requested range falls outside the pool.
+	ErrOutOfRange = errors.New("range falls outside pool boundaries")
+)
+
+// PoolState represents the current state of a network pool for allocation purposes.
+// It decouples the allocator from Kubernetes types.
+type PoolState struct {
+	// AllocatableStart is the first IP available for tenant allocation.
+	AllocatableStart string
+	// AllocatableEnd is the last IP available for tenant allocation.
+	AllocatableEnd string
+	// ReservedCIDRs are CIDR ranges excluded from allocation (e.g., management cluster IPs).
+	ReservedCIDRs []string
+	// ExistingAllocs are currently allocated ranges.
+	ExistingAllocs []AllocatedRange
+}
+
+// AllocatedRange represents a contiguous block of allocated IPs.
+type AllocatedRange struct {
+	Start string
+	End   string
+}
+
+// AllocationResult contains the result of a successful allocation.
+type AllocationResult struct {
+	Start     string
+	End       string
+	CIDR      string // CIDR notation if power-of-2 aligned, otherwise "start-end"
+	Addresses []string
+	Count     int32
+}
+
+// FreeBlock represents a contiguous block of free IPs in the pool.
+type FreeBlock struct {
+	StartOffset uint32
+	EndOffset   uint32
+	Size        uint32
+}
+
+// FragmentationInfo contains pool health metrics.
+type FragmentationInfo struct {
+	FragmentationPercent int32
+	LargestFreeBlock    int32
+	FreeBlockCount      int32
+	TotalFreeIPs        int32
+}
+
+// IPToUint32 converts a 4-byte IPv4 address to a uint32.
+func IPToUint32(ip net.IP) uint32 {
+	ip = ip.To4()
+	if ip == nil {
+		return 0
+	}
+	return binary.BigEndian.Uint32(ip)
+}
+
+// Uint32ToIP converts a uint32 to a 4-byte IPv4 address.
+func Uint32ToIP(n uint32) net.IP {
+	ip := make(net.IP, 4)
+	binary.BigEndian.PutUint32(ip, n)
+	return ip
+}
+
+// ParseCIDR parses a CIDR string and returns the first IP, last IP, and total host count.
+func ParseCIDR(cidr string) (start net.IP, end net.IP, count int32, err error) {
+	_, network, err := net.ParseCIDR(cidr)
+	if err != nil {
+		return nil, nil, 0, fmt.Errorf("%w: %s", ErrInvalidCIDR, err)
+	}
+
+	ones, totalBits := network.Mask.Size()
+	if totalBits != 32 {
+		return nil, nil, 0, fmt.Errorf("%w: only IPv4 supported", ErrInvalidCIDR)
+	}
+
+	startUint := IPToUint32(network.IP.To4())
+	hostBits := uint(totalBits - ones)
+	total := uint32(1) << hostBits
+	endUint := startUint + total - 1
+
+	if total > math.MaxInt32 {
+		count = math.MaxInt32
+	} else {
+		count = int32(total)
+	}
+
+	return Uint32ToIP(startUint), Uint32ToIP(endUint), count, nil
+}
+
+// CountIPsInRange returns the number of IPs between start and end (inclusive).
+func CountIPsInRange(start, end string) (int32, error) {
+	startIP := net.ParseIP(start).To4()
+	endIP := net.ParseIP(end).To4()
+	if startIP == nil || endIP == nil {
+		return 0, fmt.Errorf("invalid IP address")
+	}
+
+	s := IPToUint32(startIP)
+	e := IPToUint32(endIP)
+	if s > e {
+		return 0, ErrInvalidRange
+	}
+
+	diff := e - s + 1
+	if diff > math.MaxInt32 {
+		return math.MaxInt32, nil
+	}
+	return int32(diff), nil
+}
+
+// EnumerateIPs returns all IPs between start and end (inclusive).
+func EnumerateIPs(start, end string) ([]string, error) {
+	startIP := net.ParseIP(start).To4()
+	endIP := net.ParseIP(end).To4()
+	if startIP == nil || endIP == nil {
+		return nil, fmt.Errorf("invalid IP address")
+	}
+
+	s := IPToUint32(startIP)
+	e := IPToUint32(endIP)
+	if s > e {
+		return nil, ErrInvalidRange
+	}
+
+	count := e - s + 1
+	if count > 65536 {
+		return nil, fmt.Errorf("range too large to enumerate: %d IPs", count)
+	}
+
+	ips := make([]string, 0, count)
+	for i := s; i <= e; i++ {
+		ips = append(ips, Uint32ToIP(i).String())
+	}
+	return ips, nil
+}
+
+// FormatCIDR returns CIDR notation if the range is power-of-2 aligned,
+// otherwise returns "start-end" format.
+func FormatCIDR(start, end string) string {
+	startIP := net.ParseIP(start).To4()
+	endIP := net.ParseIP(end).To4()
+	if startIP == nil || endIP == nil {
+		return fmt.Sprintf("%s-%s", start, end)
+	}
+
+	s := IPToUint32(startIP)
+	e := IPToUint32(endIP)
+	if s > e {
+		return fmt.Sprintf("%s-%s", start, end)
+	}
+
+	count := e - s + 1
+
+	// Check if count is a power of 2
+	if count == 0 || (count&(count-1)) != 0 {
+		return fmt.Sprintf("%s-%s", start, end)
+	}
+
+	// Check if start is aligned to the block size
+	if s%count != 0 {
+		return fmt.Sprintf("%s-%s", start, end)
+	}
+
+	// Calculate prefix length
+	prefixLen := 32 - bits.TrailingZeros32(count)
+	return fmt.Sprintf("%s/%d", start, prefixLen)
+}
+
+// ValidateCIDRContains checks if the inner CIDR is completely contained within the outer CIDR.
+func ValidateCIDRContains(outer, inner string) (bool, error) {
+	_, outerNet, err := net.ParseCIDR(outer)
+	if err != nil {
+		return false, fmt.Errorf("invalid outer CIDR %q: %w", outer, err)
+	}
+
+	innerStart, innerEnd, _, err := ParseCIDR(inner)
+	if err != nil {
+		return false, fmt.Errorf("invalid inner CIDR %q: %w", inner, err)
+	}
+
+	return outerNet.Contains(innerStart) && outerNet.Contains(innerEnd), nil
+}
+
+// ValidateRangeWithinCIDR checks if a start-end range is within a CIDR.
+func ValidateRangeWithinCIDR(cidr, start, end string) (bool, error) {
+	_, network, err := net.ParseCIDR(cidr)
+	if err != nil {
+		return false, fmt.Errorf("invalid CIDR %q: %w", cidr, err)
+	}
+
+	startIP := net.ParseIP(start).To4()
+	endIP := net.ParseIP(end).To4()
+	if startIP == nil || endIP == nil {
+		return false, fmt.Errorf("invalid IP address")
+	}
+
+	return network.Contains(startIP) && network.Contains(endIP), nil
+}
+
+// BuildBitmap creates a bitmap representing the allocatable range.
+// true = used/reserved, false = free.
+func BuildBitmap(pool PoolState) ([]bool, uint32, error) {
+	startIP := net.ParseIP(pool.AllocatableStart).To4()
+	endIP := net.ParseIP(pool.AllocatableEnd).To4()
+	if startIP == nil || endIP == nil {
+		return nil, 0, fmt.Errorf("invalid pool range")
+	}
+
+	poolStart := IPToUint32(startIP)
+	poolEnd := IPToUint32(endIP)
+	if poolStart > poolEnd {
+		return nil, 0, ErrInvalidRange
+	}
+
+	size := poolEnd - poolStart + 1
+	if size > 1<<20 { // Cap at ~1M IPs to prevent OOM
+		return nil, 0, fmt.Errorf("pool too large: %d IPs (max 1048576)", size)
+	}
+
+	bitmap := make([]bool, size)
+
+	// Mark reserved CIDRs
+	for _, reserved := range pool.ReservedCIDRs {
+		rStart, rEnd, _, err := ParseCIDR(reserved)
+		if err != nil {
+			return nil, 0, fmt.Errorf("invalid reserved CIDR %q: %w", reserved, err)
+		}
+		rs := IPToUint32(rStart.To4())
+		re := IPToUint32(rEnd.To4())
+
+		for i := rs; i <= re; i++ {
+			if i >= poolStart && i <= poolEnd {
+				bitmap[i-poolStart] = true
+			}
+		}
+	}
+
+	// Mark existing allocations
+	for _, alloc := range pool.ExistingAllocs {
+		aStartIP := net.ParseIP(alloc.Start).To4()
+		aEndIP := net.ParseIP(alloc.End).To4()
+		if aStartIP == nil || aEndIP == nil {
+			continue
+		}
+		as := IPToUint32(aStartIP)
+		ae := IPToUint32(aEndIP)
+
+		for i := as; i <= ae; i++ {
+			if i >= poolStart && i <= poolEnd {
+				bitmap[i-poolStart] = true
+			}
+		}
+	}
+
+	return bitmap, poolStart, nil
+}
+
+// findFreeBlocks scans the bitmap and returns all contiguous free blocks.
+func findFreeBlocks(bitmap []bool) []FreeBlock {
+	var blocks []FreeBlock
+	inFree := false
+	var blockStart uint32
+
+	for i, used := range bitmap {
+		if !used && !inFree {
+			// Start of a free block
+			inFree = true
+			blockStart = uint32(i)
+		} else if used && inFree {
+			// End of a free block
+			blocks = append(blocks, FreeBlock{
+				StartOffset: blockStart,
+				EndOffset:   uint32(i) - 1,
+				Size:        uint32(i) - blockStart,
+			})
+			inFree = false
+		}
+	}
+
+	// Handle trailing free block
+	if inFree {
+		blocks = append(blocks, FreeBlock{
+			StartOffset: blockStart,
+			EndOffset:   uint32(len(bitmap)) - 1,
+			Size:        uint32(len(bitmap)) - blockStart,
+		})
+	}
+
+	return blocks
+}
+
+// AllocateRange finds the best-fit contiguous block of the requested size.
+// Best-fit selects the smallest free block that satisfies the request,
+// minimizing fragmentation.
+func AllocateRange(pool PoolState, requestedCount int32) (*AllocationResult, error) {
+	if requestedCount <= 0 {
+		return nil, fmt.Errorf("requested count must be positive")
+	}
+
+	bitmap, poolStartUint, err := BuildBitmap(pool)
+	if err != nil {
+		return nil, err
+	}
+
+	freeBlocks := findFreeBlocks(bitmap)
+	if len(freeBlocks) == 0 {
+		return nil, ErrPoolExhausted
+	}
+
+	// Best-fit: find the smallest block that fits
+	var bestBlock *FreeBlock
+	for i := range freeBlocks {
+		block := &freeBlocks[i]
+		if block.Size >= uint32(requestedCount) {
+			if bestBlock == nil || block.Size < bestBlock.Size {
+				bestBlock = block
+			}
+		}
+	}
+
+	if bestBlock == nil {
+		return nil, ErrPoolExhausted
+	}
+
+	// Allocate from the start of the best-fit block
+	allocStart := poolStartUint + bestBlock.StartOffset
+	allocEnd := allocStart + uint32(requestedCount) - 1
+
+	startStr := Uint32ToIP(allocStart).String()
+	endStr := Uint32ToIP(allocEnd).String()
+
+	addresses, err := EnumerateIPs(startStr, endStr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to enumerate allocated IPs: %w", err)
+	}
+
+	return &AllocationResult{
+		Start:     startStr,
+		End:       endStr,
+		CIDR:      FormatCIDR(startStr, endStr),
+		Addresses: addresses,
+		Count:     requestedCount,
+	}, nil
+}
+
+// AllocatePinnedRange validates and allocates a specific IP range.
+// Returns an error if the range is outside the pool, overlaps reserved ranges,
+// or conflicts with existing allocations.
+func AllocatePinnedRange(pool PoolState, start, end string) (*AllocationResult, error) {
+	startIP := net.ParseIP(start).To4()
+	endIP := net.ParseIP(end).To4()
+	if startIP == nil || endIP == nil {
+		return nil, fmt.Errorf("invalid pinned range IPs: %s-%s", start, end)
+	}
+
+	pinnedStart := IPToUint32(startIP)
+	pinnedEnd := IPToUint32(endIP)
+	if pinnedStart > pinnedEnd {
+		return nil, fmt.Errorf("%w: pinned start %s is after end %s", ErrInvalidRange, start, end)
+	}
+
+	// Verify the range is within the allocatable pool
+	poolStartIP := net.ParseIP(pool.AllocatableStart).To4()
+	poolEndIP := net.ParseIP(pool.AllocatableEnd).To4()
+	if poolStartIP == nil || poolEndIP == nil {
+		return nil, fmt.Errorf("invalid pool range")
+	}
+
+	poolStart := IPToUint32(poolStartIP)
+	poolEnd := IPToUint32(poolEndIP)
+	if pinnedStart < poolStart || pinnedEnd > poolEnd {
+		return nil, fmt.Errorf("%w: pinned range %s-%s is outside pool %s-%s",
+			ErrOutOfRange, start, end, pool.AllocatableStart, pool.AllocatableEnd)
+	}
+
+	// Build bitmap and check for conflicts
+	bitmap, bitmapStart, err := BuildBitmap(pool)
+	if err != nil {
+		return nil, err
+	}
+
+	for i := pinnedStart; i <= pinnedEnd; i++ {
+		offset := i - bitmapStart
+		if int(offset) >= len(bitmap) {
+			return nil, fmt.Errorf("%w: pinned IP %s outside bitmap", ErrOutOfRange, Uint32ToIP(i))
+		}
+		if bitmap[offset] {
+			return nil, fmt.Errorf("pinned range conflicts at IP %s (reserved or already allocated)", Uint32ToIP(i))
+		}
+	}
+
+	addresses, err := EnumerateIPs(start, end)
+	if err != nil {
+		return nil, fmt.Errorf("failed to enumerate pinned IPs: %w", err)
+	}
+
+	count := pinnedEnd - pinnedStart + 1
+	return &AllocationResult{
+		Start:     start,
+		End:       end,
+		CIDR:      FormatCIDR(start, end),
+		Addresses: addresses,
+		Count:     int32(count),
+	}, nil
+}
+
+// ComputeFragmentation calculates pool health metrics from a bitmap.
+func ComputeFragmentation(pool PoolState) (*FragmentationInfo, error) {
+	bitmap, _, err := BuildBitmap(pool)
+	if err != nil {
+		return nil, err
+	}
+
+	freeBlocks := findFreeBlocks(bitmap)
+
+	totalFree := uint32(0)
+	largestFree := uint32(0)
+	for _, block := range freeBlocks {
+		totalFree += block.Size
+		if block.Size > largestFree {
+			largestFree = block.Size
+		}
+	}
+
+	var fragmentPercent int32
+	if totalFree == 0 {
+		fragmentPercent = 0
+	} else if len(freeBlocks) <= 1 {
+		fragmentPercent = 0 // Single contiguous free block = no fragmentation
+	} else {
+		// Fragmentation = 1 - (largest_free_block / total_free)
+		// 0% = all free space is contiguous
+		// 100% = free space is maximally fragmented
+		fragmentPercent = int32(100 - (largestFree * 100 / totalFree))
+	}
+
+	info := &FragmentationInfo{
+		FragmentationPercent: fragmentPercent,
+		FreeBlockCount:       int32(len(freeBlocks)),
+		TotalFreeIPs:         capInt32(totalFree),
+	}
+	if largestFree > math.MaxInt32 {
+		info.LargestFreeBlock = math.MaxInt32
+	} else {
+		info.LargestFreeBlock = int32(largestFree)
+	}
+
+	return info, nil
+}
+
+// ValidatePoolSpec validates the internal consistency of a network pool specification.
+func ValidatePoolSpec(cidr string, reservedCIDRs []string, allocStart, allocEnd string) []string {
+	var errs []string
+
+	_, _, _, err := ParseCIDR(cidr)
+	if err != nil {
+		errs = append(errs, fmt.Sprintf("invalid pool CIDR: %v", err))
+		return errs // Can't validate further
+	}
+
+	// Validate reserved ranges are within pool CIDR
+	for _, reserved := range reservedCIDRs {
+		contained, err := ValidateCIDRContains(cidr, reserved)
+		if err != nil {
+			errs = append(errs, fmt.Sprintf("invalid reserved CIDR %q: %v", reserved, err))
+		} else if !contained {
+			errs = append(errs, fmt.Sprintf("reserved CIDR %q is not within pool CIDR %q", reserved, cidr))
+		}
+	}
+
+	// Validate allocation range is within pool CIDR
+	if allocStart != "" && allocEnd != "" {
+		within, err := ValidateRangeWithinCIDR(cidr, allocStart, allocEnd)
+		if err != nil {
+			errs = append(errs, fmt.Sprintf("invalid allocation range: %v", err))
+		} else if !within {
+			errs = append(errs, fmt.Sprintf("allocation range %s-%s is not within pool CIDR %q", allocStart, allocEnd, cidr))
+		}
+
+		startIP := net.ParseIP(allocStart).To4()
+		endIP := net.ParseIP(allocEnd).To4()
+		if startIP != nil && endIP != nil {
+			if IPToUint32(startIP) > IPToUint32(endIP) {
+				errs = append(errs, fmt.Sprintf("allocation start %s is after end %s", allocStart, allocEnd))
+			}
+		}
+	}
+
+	return errs
+}
+
+// PoolCapacityInfo computes capacity information for a pool.
+func PoolCapacityInfo(pool PoolState) (totalIPs int32, allocatedIPs int32, availableIPs int32, err error) {
+	bitmap, _, err := BuildBitmap(pool)
+	if err != nil {
+		return 0, 0, 0, err
+	}
+
+	total := int32(len(bitmap))
+	reserved := int32(0)
+	allocated := int32(0)
+
+	// Count reserved IPs (from reserved CIDRs — always marked, even if no allocations exist)
+	// We need to distinguish reserved from allocated. Build a separate bitmap for just reserved.
+	startIP := net.ParseIP(pool.AllocatableStart).To4()
+	poolStartUint := IPToUint32(startIP)
+
+	reservedBitmap := make([]bool, len(bitmap))
+	for _, cidr := range pool.ReservedCIDRs {
+		rStart, rEnd, _, parseErr := ParseCIDR(cidr)
+		if parseErr != nil {
+			continue
+		}
+		rs := IPToUint32(rStart.To4())
+		re := IPToUint32(rEnd.To4())
+		for i := rs; i <= re; i++ {
+			if i >= poolStartUint && i <= poolStartUint+uint32(len(bitmap))-1 {
+				reservedBitmap[i-poolStartUint] = true
+			}
+		}
+	}
+
+	for i, used := range bitmap {
+		if reservedBitmap[i] {
+			reserved++
+		} else if used {
+			allocated++
+		}
+	}
+
+	usable := total - reserved
+	available := usable - allocated
+
+	return usable, allocated, available, nil
+}
+
+// SortPoolRefsByPriority sorts pool references by priority (lower = higher priority).
+// Stable sort preserves order for equal priorities.
+func SortPoolRefsByPriority(refs []PoolRef) {
+	sort.SliceStable(refs, func(i, j int) bool {
+		pi := int32(0)
+		pj := int32(0)
+		if refs[i].Priority != nil {
+			pi = *refs[i].Priority
+		}
+		if refs[j].Priority != nil {
+			pj = *refs[j].Priority
+		}
+		return pi < pj
+	})
+}
+
+// PoolRef is a simplified pool reference for sorting.
+type PoolRef struct {
+	Name     string
+	Priority *int32
+}
+
+func capInt32(v uint32) int32 {
+	if v > math.MaxInt32 {
+		return math.MaxInt32
+	}
+	return int32(v)
+}
+
+// ParseIPRange parses a range string that could be either CIDR notation or "start-end" format.
+func ParseIPRange(rangeStr string) (start, end string, err error) {
+	if strings.Contains(rangeStr, "/") {
+		// CIDR notation
+		startIP, endIP, _, err := ParseCIDR(rangeStr)
+		if err != nil {
+			return "", "", err
+		}
+		return startIP.String(), endIP.String(), nil
+	}
+
+	if strings.Contains(rangeStr, "-") {
+		parts := strings.SplitN(rangeStr, "-", 2)
+		startIP := net.ParseIP(strings.TrimSpace(parts[0])).To4()
+		endIP := net.ParseIP(strings.TrimSpace(parts[1])).To4()
+		if startIP == nil || endIP == nil {
+			return "", "", fmt.Errorf("invalid IP range: %s", rangeStr)
+		}
+		return startIP.String(), endIP.String(), nil
+	}
+
+	// Single IP
+	ip := net.ParseIP(rangeStr).To4()
+	if ip == nil {
+		return "", "", fmt.Errorf("invalid IP: %s", rangeStr)
+	}
+	return ip.String(), ip.String(), nil
+}

--- a/internal/ipam/allocator_test.go
+++ b/internal/ipam/allocator_test.go
@@ -1,0 +1,1411 @@
+/*
+Copyright 2026 The Butler Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ipam
+
+import (
+	"errors"
+	"net"
+	"strings"
+	"testing"
+	"time"
+)
+
+// --- IPToUint32 / Uint32ToIP ---
+
+func TestIPToUint32(t *testing.T) {
+	tests := []struct {
+		name string
+		ip   string
+		want uint32
+	}{
+		{"zero", "0.0.0.0", 0},
+		{"one", "0.0.0.1", 1},
+		{"class A", "10.0.0.1", 0x0a000001},
+		{"class C", "192.168.1.1", 0xc0a80101},
+		{"broadcast", "255.255.255.255", 0xffffffff},
+		{"10.40.0.128", "10.40.0.128", 0x0a280080},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ip := net.ParseIP(tt.ip)
+			got := IPToUint32(ip)
+			if got != tt.want {
+				t.Errorf("IPToUint32(%s) = %d, want %d", tt.ip, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIPToUint32_Nil(t *testing.T) {
+	got := IPToUint32(nil)
+	if got != 0 {
+		t.Errorf("IPToUint32(nil) = %d, want 0", got)
+	}
+}
+
+func TestUint32ToIP(t *testing.T) {
+	tests := []struct {
+		name string
+		n    uint32
+		want string
+	}{
+		{"zero", 0, "0.0.0.0"},
+		{"one", 1, "0.0.0.1"},
+		{"max", 0xffffffff, "255.255.255.255"},
+		{"10.40.0.128", 0x0a280080, "10.40.0.128"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := Uint32ToIP(tt.n).String()
+			if got != tt.want {
+				t.Errorf("Uint32ToIP(%d) = %s, want %s", tt.n, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIPRoundTrip(t *testing.T) {
+	ips := []string{"10.40.0.1", "192.168.0.0", "172.16.255.254", "0.0.0.0", "255.255.255.255"}
+	for _, ipStr := range ips {
+		ip := net.ParseIP(ipStr).To4()
+		result := Uint32ToIP(IPToUint32(ip))
+		if !ip.Equal(result) {
+			t.Errorf("round-trip failed for %s: got %s", ipStr, result)
+		}
+	}
+}
+
+// --- ParseCIDR ---
+
+func TestParseCIDR(t *testing.T) {
+	tests := []struct {
+		name      string
+		cidr      string
+		wantStart string
+		wantEnd   string
+		wantCount int32
+		wantErr   bool
+	}{
+		{"/32 single host", "10.0.0.1/32", "10.0.0.1", "10.0.0.1", 1, false},
+		{"/31 two hosts", "10.0.0.0/31", "10.0.0.0", "10.0.0.1", 2, false},
+		{"/30 four hosts", "10.0.0.0/30", "10.0.0.0", "10.0.0.3", 4, false},
+		{"/29 eight hosts", "10.40.0.0/29", "10.40.0.0", "10.40.0.7", 8, false},
+		{"/24 class C", "10.40.0.0/24", "10.40.0.0", "10.40.0.255", 256, false},
+		{"/16 class B", "10.40.0.0/16", "10.40.0.0", "10.40.255.255", 65536, false},
+		{"invalid CIDR", "not-a-cidr", "", "", 0, true},
+		{"missing prefix", "10.0.0.0", "", "", 0, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			start, end, count, err := ParseCIDR(tt.cidr)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("ParseCIDR(%s) error = %v, wantErr = %v", tt.cidr, err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+			if start.String() != tt.wantStart {
+				t.Errorf("start = %s, want %s", start, tt.wantStart)
+			}
+			if end.String() != tt.wantEnd {
+				t.Errorf("end = %s, want %s", end, tt.wantEnd)
+			}
+			if count != tt.wantCount {
+				t.Errorf("count = %d, want %d", count, tt.wantCount)
+			}
+		})
+	}
+}
+
+// --- CountIPsInRange ---
+
+func TestCountIPsInRange(t *testing.T) {
+	tests := []struct {
+		name    string
+		start   string
+		end     string
+		want    int32
+		wantErr bool
+	}{
+		{"single IP", "10.0.0.1", "10.0.0.1", 1, false},
+		{"two IPs", "10.0.0.1", "10.0.0.2", 2, false},
+		{"256 IPs", "10.0.0.0", "10.0.0.255", 256, false},
+		{"reversed", "10.0.0.2", "10.0.0.1", 0, true},
+		{"invalid start", "bad", "10.0.0.1", 0, true},
+		{"invalid end", "10.0.0.1", "bad", 0, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := CountIPsInRange(tt.start, tt.end)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("CountIPsInRange(%s, %s) error = %v, wantErr = %v", tt.start, tt.end, err, tt.wantErr)
+			}
+			if !tt.wantErr && got != tt.want {
+				t.Errorf("got %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+// --- EnumerateIPs ---
+
+func TestEnumerateIPs(t *testing.T) {
+	tests := []struct {
+		name    string
+		start   string
+		end     string
+		want    int
+		wantErr bool
+	}{
+		{"single IP", "10.0.0.1", "10.0.0.1", 1, false},
+		{"three IPs", "10.0.0.1", "10.0.0.3", 3, false},
+		{"full /24", "10.0.0.0", "10.0.0.255", 256, false},
+		{"reversed", "10.0.0.2", "10.0.0.1", 0, true},
+		{"too large", "10.0.0.0", "10.1.0.0", 0, true}, // 65537 IPs > 65536 cap
+		{"invalid IP", "bad", "10.0.0.1", 0, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := EnumerateIPs(tt.start, tt.end)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("EnumerateIPs(%s, %s) error = %v, wantErr = %v", tt.start, tt.end, err, tt.wantErr)
+			}
+			if !tt.wantErr {
+				if len(got) != tt.want {
+					t.Errorf("got %d IPs, want %d", len(got), tt.want)
+				}
+				// Verify first and last
+				if len(got) > 0 {
+					if got[0] != tt.start {
+						t.Errorf("first IP = %s, want %s", got[0], tt.start)
+					}
+					if got[len(got)-1] != tt.end {
+						t.Errorf("last IP = %s, want %s", got[len(got)-1], tt.end)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestEnumerateIPs_ExactCap(t *testing.T) {
+	// 65536 IPs should succeed (exactly at cap)
+	ips, err := EnumerateIPs("10.0.0.0", "10.0.255.255")
+	if err != nil {
+		t.Fatalf("unexpected error for 65536 IPs: %v", err)
+	}
+	if len(ips) != 65536 {
+		t.Errorf("got %d IPs, want 65536", len(ips))
+	}
+}
+
+// --- FormatCIDR ---
+
+func TestFormatCIDR(t *testing.T) {
+	tests := []struct {
+		name  string
+		start string
+		end   string
+		want  string
+	}{
+		{"/32 aligned", "10.0.0.1", "10.0.0.1", "10.0.0.1/32"},
+		{"/31 aligned", "10.0.0.0", "10.0.0.1", "10.0.0.0/31"},
+		{"/30 aligned", "10.0.0.0", "10.0.0.3", "10.0.0.0/30"},
+		{"/29 aligned", "10.0.0.0", "10.0.0.7", "10.0.0.0/29"},
+		{"/28 aligned", "10.0.0.0", "10.0.0.15", "10.0.0.0/28"},
+		{"/24 aligned", "10.0.0.0", "10.0.0.255", "10.0.0.0/24"},
+		{"not power of 2 (3 IPs)", "10.0.0.1", "10.0.0.3", "10.0.0.1-10.0.0.3"},
+		{"power of 2 but unaligned", "10.0.0.1", "10.0.0.2", "10.0.0.1-10.0.0.2"},
+		{"5 IPs", "10.0.0.0", "10.0.0.4", "10.0.0.0-10.0.0.4"},
+		{"reversed range", "10.0.0.5", "10.0.0.1", "10.0.0.5-10.0.0.1"},
+		{"invalid start", "bad", "10.0.0.1", "bad-10.0.0.1"},
+		{"aligned /29 at offset", "10.0.0.8", "10.0.0.15", "10.0.0.8/29"},
+		{"aligned /28 at offset", "10.0.0.16", "10.0.0.31", "10.0.0.16/28"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := FormatCIDR(tt.start, tt.end)
+			if got != tt.want {
+				t.Errorf("FormatCIDR(%s, %s) = %q, want %q", tt.start, tt.end, got, tt.want)
+			}
+		})
+	}
+}
+
+// --- ValidateCIDRContains ---
+
+func TestValidateCIDRContains(t *testing.T) {
+	tests := []struct {
+		name    string
+		outer   string
+		inner   string
+		want    bool
+		wantErr bool
+	}{
+		{"same CIDR", "10.40.0.0/24", "10.40.0.0/24", true, false},
+		{"inner within outer", "10.40.0.0/24", "10.40.0.0/26", true, false},
+		{"inner at end of outer", "10.40.0.0/24", "10.40.0.192/26", true, false},
+		{"inner outside outer", "10.40.0.0/24", "10.40.1.0/26", false, false},
+		{"inner partially overlaps", "10.40.0.0/25", "10.40.0.64/26", true, false},
+		{"inner extends beyond", "10.40.0.0/25", "10.40.0.0/24", false, false},
+		{"invalid outer", "bad", "10.0.0.0/24", false, true},
+		{"invalid inner", "10.0.0.0/24", "bad", false, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ValidateCIDRContains(tt.outer, tt.inner)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("error = %v, wantErr = %v", err, tt.wantErr)
+			}
+			if !tt.wantErr && got != tt.want {
+				t.Errorf("got %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// --- ValidateRangeWithinCIDR ---
+
+func TestValidateRangeWithinCIDR(t *testing.T) {
+	tests := []struct {
+		name    string
+		cidr    string
+		start   string
+		end     string
+		want    bool
+		wantErr bool
+	}{
+		{"range within /24", "10.40.0.0/24", "10.40.0.10", "10.40.0.200", true, false},
+		{"full /24", "10.40.0.0/24", "10.40.0.0", "10.40.0.255", true, false},
+		{"start outside", "10.40.0.0/24", "10.39.255.255", "10.40.0.10", false, false},
+		{"end outside", "10.40.0.0/24", "10.40.0.200", "10.40.1.5", false, false},
+		{"invalid CIDR", "bad", "10.0.0.1", "10.0.0.2", false, true},
+		{"invalid IP", "10.0.0.0/24", "bad", "10.0.0.1", false, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ValidateRangeWithinCIDR(tt.cidr, tt.start, tt.end)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("error = %v, wantErr = %v", err, tt.wantErr)
+			}
+			if !tt.wantErr && got != tt.want {
+				t.Errorf("got %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// --- BuildBitmap ---
+
+func TestBuildBitmap(t *testing.T) {
+	t.Run("empty pool", func(t *testing.T) {
+		pool := PoolState{
+			AllocatableStart: "10.0.0.0",
+			AllocatableEnd:   "10.0.0.7",
+		}
+		bitmap, startUint, err := BuildBitmap(pool)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(bitmap) != 8 {
+			t.Fatalf("bitmap length = %d, want 8", len(bitmap))
+		}
+		if startUint != IPToUint32(net.ParseIP("10.0.0.0")) {
+			t.Errorf("startUint mismatch")
+		}
+		for i, used := range bitmap {
+			if used {
+				t.Errorf("bitmap[%d] = true, want false (empty pool)", i)
+			}
+		}
+	})
+
+	t.Run("with reserved CIDR", func(t *testing.T) {
+		pool := PoolState{
+			AllocatableStart: "10.0.0.0",
+			AllocatableEnd:   "10.0.0.15",
+			ReservedCIDRs:    []string{"10.0.0.0/30"}, // reserves .0-.3
+		}
+		bitmap, _, err := BuildBitmap(pool)
+		if err != nil {
+			t.Fatal(err)
+		}
+		// First 4 IPs should be reserved
+		for i := 0; i < 4; i++ {
+			if !bitmap[i] {
+				t.Errorf("bitmap[%d] should be reserved (true)", i)
+			}
+		}
+		for i := 4; i < 16; i++ {
+			if bitmap[i] {
+				t.Errorf("bitmap[%d] should be free (false)", i)
+			}
+		}
+	})
+
+	t.Run("with existing allocation", func(t *testing.T) {
+		pool := PoolState{
+			AllocatableStart: "10.0.0.0",
+			AllocatableEnd:   "10.0.0.15",
+			ExistingAllocs: []AllocatedRange{
+				{Start: "10.0.0.4", End: "10.0.0.7"},
+			},
+		}
+		bitmap, _, err := BuildBitmap(pool)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for i := 0; i < 4; i++ {
+			if bitmap[i] {
+				t.Errorf("bitmap[%d] should be free", i)
+			}
+		}
+		for i := 4; i < 8; i++ {
+			if !bitmap[i] {
+				t.Errorf("bitmap[%d] should be allocated (true)", i)
+			}
+		}
+		for i := 8; i < 16; i++ {
+			if bitmap[i] {
+				t.Errorf("bitmap[%d] should be free", i)
+			}
+		}
+	})
+
+	t.Run("reserved outside allocatable range ignored", func(t *testing.T) {
+		pool := PoolState{
+			AllocatableStart: "10.0.0.128",
+			AllocatableEnd:   "10.0.0.135",
+			ReservedCIDRs:    []string{"10.0.0.0/25"}, // entirely before allocatable range
+		}
+		bitmap, _, err := BuildBitmap(pool)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for i, used := range bitmap {
+			if used {
+				t.Errorf("bitmap[%d] should be free (reserved range outside pool)", i)
+			}
+		}
+	})
+
+	t.Run("invalid range", func(t *testing.T) {
+		pool := PoolState{
+			AllocatableStart: "10.0.0.10",
+			AllocatableEnd:   "10.0.0.5",
+		}
+		_, _, err := BuildBitmap(pool)
+		if err == nil {
+			t.Fatal("expected error for reversed range")
+		}
+	})
+
+	t.Run("pool too large", func(t *testing.T) {
+		pool := PoolState{
+			AllocatableStart: "10.0.0.0",
+			AllocatableEnd:   "10.255.255.255", // ~16M IPs
+		}
+		_, _, err := BuildBitmap(pool)
+		if err == nil {
+			t.Fatal("expected error for pool > 1M IPs")
+		}
+	})
+}
+
+// --- AllocateRange ---
+
+func TestAllocateRange(t *testing.T) {
+	tests := []struct {
+		name           string
+		pool           PoolState
+		requestedCount int32
+		wantStart      string
+		wantEnd        string
+		wantErr        error
+	}{
+		{
+			name: "empty pool first allocation",
+			pool: PoolState{
+				AllocatableStart: "10.0.0.0",
+				AllocatableEnd:   "10.0.0.255",
+			},
+			requestedCount: 8,
+			wantStart:      "10.0.0.0",
+			wantEnd:        "10.0.0.7",
+		},
+		{
+			name: "single IP allocation",
+			pool: PoolState{
+				AllocatableStart: "10.0.0.0",
+				AllocatableEnd:   "10.0.0.255",
+			},
+			requestedCount: 1,
+			wantStart:      "10.0.0.0",
+			wantEnd:        "10.0.0.0",
+		},
+		{
+			name: "skips existing allocation",
+			pool: PoolState{
+				AllocatableStart: "10.0.0.0",
+				AllocatableEnd:   "10.0.0.31",
+				ExistingAllocs: []AllocatedRange{
+					{Start: "10.0.0.0", End: "10.0.0.7"},
+				},
+			},
+			requestedCount: 8,
+			wantStart:      "10.0.0.8",
+			wantEnd:        "10.0.0.15",
+		},
+		{
+			name: "skips reserved range",
+			pool: PoolState{
+				AllocatableStart: "10.0.0.0",
+				AllocatableEnd:   "10.0.0.31",
+				ReservedCIDRs:    []string{"10.0.0.0/29"}, // .0-.7
+			},
+			requestedCount: 4,
+			wantStart:      "10.0.0.8",
+			wantEnd:        "10.0.0.11",
+		},
+		{
+			name: "fills gap between allocations",
+			pool: PoolState{
+				AllocatableStart: "10.0.0.0",
+				AllocatableEnd:   "10.0.0.31",
+				ExistingAllocs: []AllocatedRange{
+					{Start: "10.0.0.0", End: "10.0.0.3"},
+					{Start: "10.0.0.12", End: "10.0.0.15"},
+				},
+			},
+			// Gap of 8 IPs (.4-.11), gap of 16 IPs (.16-.31)
+			// Best-fit should pick the 8-IP gap for a request of 8
+			requestedCount: 8,
+			wantStart:      "10.0.0.4",
+			wantEnd:        "10.0.0.11",
+		},
+		{
+			name: "best-fit picks smallest fitting gap",
+			pool: PoolState{
+				AllocatableStart: "10.0.0.0",
+				AllocatableEnd:   "10.0.0.63",
+				ExistingAllocs: []AllocatedRange{
+					{Start: "10.0.0.0", End: "10.0.0.2"},   // uses .0-.2
+					{Start: "10.0.0.13", End: "10.0.0.14"},  // uses .13-.14 → gap .3-.12 = 10 IPs
+					{Start: "10.0.0.15", End: "10.0.0.17"},  // gap = 0 after .14
+					{Start: "10.0.0.68", End: "10.0.0.68"},  // outside pool, ignored
+				},
+			},
+			// Free blocks: .3-.12 (10 IPs), .18-.63 (46 IPs)
+			// Request 5: best-fit picks .3-.12 (size 10) over .18-.63 (size 46)
+			requestedCount: 5,
+			wantStart:      "10.0.0.3",
+			wantEnd:        "10.0.0.7",
+		},
+		{
+			name: "best-fit with gaps of 10, 50, 3 - request 5 picks 10",
+			pool: PoolState{
+				AllocatableStart: "10.0.0.0",
+				AllocatableEnd:   "10.0.0.99",
+				ExistingAllocs: []AllocatedRange{
+					// Layout: [10 free][5 alloc][3 free][2 alloc][50 free][30 alloc]
+					// .0-.9 free (10)
+					{Start: "10.0.0.10", End: "10.0.0.14"}, // 5 allocated
+					// .15-.17 free (3)
+					{Start: "10.0.0.18", End: "10.0.0.19"}, // 2 allocated
+					// .20-.69 free (50)
+					{Start: "10.0.0.70", End: "10.0.0.99"}, // 30 allocated
+				},
+			},
+			// Free blocks: [10, 3, 50]
+			// Request 5: best-fit picks 10 (smallest >= 5), not 50 or 3
+			requestedCount: 5,
+			wantStart:      "10.0.0.0",
+			wantEnd:        "10.0.0.4",
+		},
+		{
+			name: "exhausted pool",
+			pool: PoolState{
+				AllocatableStart: "10.0.0.0",
+				AllocatableEnd:   "10.0.0.7",
+				ExistingAllocs: []AllocatedRange{
+					{Start: "10.0.0.0", End: "10.0.0.7"},
+				},
+			},
+			requestedCount: 1,
+			wantErr:        ErrPoolExhausted,
+		},
+		{
+			name: "no block large enough",
+			pool: PoolState{
+				AllocatableStart: "10.0.0.0",
+				AllocatableEnd:   "10.0.0.31",
+				ExistingAllocs: []AllocatedRange{
+					{Start: "10.0.0.4", End: "10.0.0.7"},
+					{Start: "10.0.0.12", End: "10.0.0.15"},
+					{Start: "10.0.0.20", End: "10.0.0.23"},
+					{Start: "10.0.0.28", End: "10.0.0.31"},
+				},
+			},
+			// Free blocks: .0-.3 (4), .8-.11 (4), .16-.19 (4), .24-.27 (4)
+			// Request 5: no block >= 5
+			requestedCount: 5,
+			wantErr:        ErrPoolExhausted,
+		},
+		{
+			name: "full pool minus one",
+			pool: PoolState{
+				AllocatableStart: "10.0.0.0",
+				AllocatableEnd:   "10.0.0.7",
+				ExistingAllocs: []AllocatedRange{
+					{Start: "10.0.0.0", End: "10.0.0.6"},
+				},
+			},
+			requestedCount: 1,
+			wantStart:      "10.0.0.7",
+			wantEnd:        "10.0.0.7",
+		},
+		{
+			name: "entire pool as one allocation",
+			pool: PoolState{
+				AllocatableStart: "10.0.0.0",
+				AllocatableEnd:   "10.0.0.255",
+			},
+			requestedCount: 256,
+			wantStart:      "10.0.0.0",
+			wantEnd:        "10.0.0.255",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := AllocateRange(tt.pool, tt.requestedCount)
+			if tt.wantErr != nil {
+				if !errors.Is(err, tt.wantErr) {
+					t.Fatalf("got error %v, want %v", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if result.Start != tt.wantStart {
+				t.Errorf("start = %s, want %s", result.Start, tt.wantStart)
+			}
+			if result.End != tt.wantEnd {
+				t.Errorf("end = %s, want %s", result.End, tt.wantEnd)
+			}
+			if result.Count != tt.requestedCount {
+				t.Errorf("count = %d, want %d", result.Count, tt.requestedCount)
+			}
+			if len(result.Addresses) != int(tt.requestedCount) {
+				t.Errorf("addresses length = %d, want %d", len(result.Addresses), tt.requestedCount)
+			}
+		})
+	}
+}
+
+func TestAllocateRange_InvalidCount(t *testing.T) {
+	pool := PoolState{
+		AllocatableStart: "10.0.0.0",
+		AllocatableEnd:   "10.0.0.255",
+	}
+
+	_, err := AllocateRange(pool, 0)
+	if err == nil {
+		t.Fatal("expected error for count=0")
+	}
+
+	_, err = AllocateRange(pool, -1)
+	if err == nil {
+		t.Fatal("expected error for count=-1")
+	}
+}
+
+func TestAllocateRange_NoOverlap(t *testing.T) {
+	// Simulate sequential allocations and verify no overlap
+	pool := PoolState{
+		AllocatableStart: "10.0.0.0",
+		AllocatableEnd:   "10.0.0.255",
+	}
+
+	allocations := make([]AllocationResult, 0)
+	for i := 0; i < 32; i++ { // 32 * 8 = 256 IPs
+		result, err := AllocateRange(pool, 8)
+		if err != nil {
+			t.Fatalf("allocation %d failed: %v", i, err)
+		}
+		allocations = append(allocations, *result)
+		pool.ExistingAllocs = append(pool.ExistingAllocs, AllocatedRange{
+			Start: result.Start,
+			End:   result.End,
+		})
+	}
+
+	// Verify no overlap between any pair of allocations
+	for i := 0; i < len(allocations); i++ {
+		iStart := IPToUint32(net.ParseIP(allocations[i].Start))
+		iEnd := IPToUint32(net.ParseIP(allocations[i].End))
+		for j := i + 1; j < len(allocations); j++ {
+			jStart := IPToUint32(net.ParseIP(allocations[j].Start))
+			jEnd := IPToUint32(net.ParseIP(allocations[j].End))
+			if iStart <= jEnd && jStart <= iEnd {
+				t.Errorf("overlap between allocation %d (%s-%s) and %d (%s-%s)",
+					i, allocations[i].Start, allocations[i].End,
+					j, allocations[j].Start, allocations[j].End)
+			}
+		}
+	}
+
+	// Pool should be exhausted now
+	_, err := AllocateRange(pool, 1)
+	if !errors.Is(err, ErrPoolExhausted) {
+		t.Errorf("expected ErrPoolExhausted after filling pool, got %v", err)
+	}
+}
+
+func TestAllocateRange_WithReservedAndAllocated(t *testing.T) {
+	// Complex scenario: reserved range in the middle, existing allocations around it
+	pool := PoolState{
+		AllocatableStart: "10.0.0.0",
+		AllocatableEnd:   "10.0.0.63",
+		ReservedCIDRs:    []string{"10.0.0.16/28"}, // .16-.31 reserved
+		ExistingAllocs: []AllocatedRange{
+			{Start: "10.0.0.0", End: "10.0.0.7"}, // .0-.7 allocated
+		},
+	}
+
+	// Free: .8-.15 (8 IPs), .32-.63 (32 IPs)
+	// Request 8: best-fit picks .8-.15 (exact fit)
+	result, err := AllocateRange(pool, 8)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Start != "10.0.0.8" || result.End != "10.0.0.15" {
+		t.Errorf("got %s-%s, want 10.0.0.8-10.0.0.15", result.Start, result.End)
+	}
+}
+
+func TestAllocateRange_LargePool(t *testing.T) {
+	// /16 = 65536 IPs — verify it doesn't OOM and completes quickly
+	pool := PoolState{
+		AllocatableStart: "10.40.0.0",
+		AllocatableEnd:   "10.40.255.255",
+	}
+
+	start := time.Now()
+	result, err := AllocateRange(pool, 8)
+	elapsed := time.Since(start)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Start != "10.40.0.0" {
+		t.Errorf("start = %s, want 10.40.0.0", result.Start)
+	}
+	if elapsed > 100*time.Millisecond {
+		t.Errorf("allocation took %v, want < 100ms", elapsed)
+	}
+}
+
+func TestAllocateRange_LargePoolFragmented(t *testing.T) {
+	// /16 pool with every other 8-block allocated (severe fragmentation)
+	pool := PoolState{
+		AllocatableStart: "10.40.0.0",
+		AllocatableEnd:   "10.40.255.255",
+	}
+
+	// Allocate every other 8-IP block for first 1024 IPs
+	baseIP := IPToUint32(net.ParseIP("10.40.0.0"))
+	for i := uint32(0); i < 64; i++ {
+		s := baseIP + i*16
+		e := s + 7
+		pool.ExistingAllocs = append(pool.ExistingAllocs, AllocatedRange{
+			Start: Uint32ToIP(s).String(),
+			End:   Uint32ToIP(e).String(),
+		})
+	}
+
+	start := time.Now()
+	result, err := AllocateRange(pool, 8)
+	elapsed := time.Since(start)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Best-fit should pick one of the 8-IP gaps between allocated blocks
+	if result.Count != 8 {
+		t.Errorf("count = %d, want 8", result.Count)
+	}
+	if elapsed > 100*time.Millisecond {
+		t.Errorf("allocation took %v, want < 100ms", elapsed)
+	}
+}
+
+// --- ComputeFragmentation ---
+
+func TestComputeFragmentation(t *testing.T) {
+	tests := []struct {
+		name               string
+		pool               PoolState
+		wantFragPercent    int32
+		wantLargestFree    int32
+		wantFreeBlockCount int32
+		wantTotalFreeIPs   int32
+	}{
+		{
+			name: "empty pool - no fragmentation",
+			pool: PoolState{
+				AllocatableStart: "10.0.0.0",
+				AllocatableEnd:   "10.0.0.31",
+			},
+			wantFragPercent:    0,
+			wantLargestFree:    32,
+			wantFreeBlockCount: 1,
+			wantTotalFreeIPs:   32,
+		},
+		{
+			name: "full pool - no fragmentation",
+			pool: PoolState{
+				AllocatableStart: "10.0.0.0",
+				AllocatableEnd:   "10.0.0.31",
+				ExistingAllocs: []AllocatedRange{
+					{Start: "10.0.0.0", End: "10.0.0.31"},
+				},
+			},
+			wantFragPercent:    0,
+			wantLargestFree:    0,
+			wantFreeBlockCount: 0,
+			wantTotalFreeIPs:   0,
+		},
+		{
+			name: "one allocation in middle - two free blocks",
+			pool: PoolState{
+				AllocatableStart: "10.0.0.0",
+				AllocatableEnd:   "10.0.0.31",
+				ExistingAllocs: []AllocatedRange{
+					{Start: "10.0.0.8", End: "10.0.0.15"},
+				},
+			},
+			// Free: .0-.7 (8 IPs), .16-.31 (16 IPs) = 24 total free, 2 blocks
+			// Fragmentation = 100 - (16*100/24) = 100 - 66 = 34% (integer division)
+			wantFragPercent:    34,
+			wantLargestFree:    16,
+			wantFreeBlockCount: 2,
+			wantTotalFreeIPs:   24,
+		},
+		{
+			name: "alternating allocated/free - high fragmentation",
+			pool: PoolState{
+				AllocatableStart: "10.0.0.0",
+				AllocatableEnd:   "10.0.0.31",
+				ExistingAllocs: []AllocatedRange{
+					{Start: "10.0.0.2", End: "10.0.0.3"},
+					{Start: "10.0.0.6", End: "10.0.0.7"},
+					{Start: "10.0.0.10", End: "10.0.0.11"},
+					{Start: "10.0.0.14", End: "10.0.0.15"},
+					{Start: "10.0.0.18", End: "10.0.0.19"},
+					{Start: "10.0.0.22", End: "10.0.0.23"},
+					{Start: "10.0.0.26", End: "10.0.0.27"},
+					{Start: "10.0.0.30", End: "10.0.0.31"},
+				},
+			},
+			// Free blocks: 8 blocks of 2 IPs each = 16 total free
+			// Fragmentation = 100 - (2*100/16) = 100 - 12 = 88% (integer division)
+			wantFragPercent:    88,
+			wantLargestFree:    2,
+			wantFreeBlockCount: 8,
+			wantTotalFreeIPs:   16,
+		},
+		{
+			name: "single contiguous free block at end",
+			pool: PoolState{
+				AllocatableStart: "10.0.0.0",
+				AllocatableEnd:   "10.0.0.31",
+				ExistingAllocs: []AllocatedRange{
+					{Start: "10.0.0.0", End: "10.0.0.15"},
+				},
+			},
+			wantFragPercent:    0,
+			wantLargestFree:    16,
+			wantFreeBlockCount: 1,
+			wantTotalFreeIPs:   16,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			info, err := ComputeFragmentation(tt.pool)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if info.FragmentationPercent != tt.wantFragPercent {
+				t.Errorf("FragmentationPercent = %d, want %d", info.FragmentationPercent, tt.wantFragPercent)
+			}
+			if info.LargestFreeBlock != tt.wantLargestFree {
+				t.Errorf("LargestFreeBlock = %d, want %d", info.LargestFreeBlock, tt.wantLargestFree)
+			}
+			if info.FreeBlockCount != tt.wantFreeBlockCount {
+				t.Errorf("FreeBlockCount = %d, want %d", info.FreeBlockCount, tt.wantFreeBlockCount)
+			}
+			if info.TotalFreeIPs != tt.wantTotalFreeIPs {
+				t.Errorf("TotalFreeIPs = %d, want %d", info.TotalFreeIPs, tt.wantTotalFreeIPs)
+			}
+		})
+	}
+}
+
+// --- ValidatePoolSpec ---
+
+func TestValidatePoolSpec(t *testing.T) {
+	tests := []struct {
+		name         string
+		cidr         string
+		reserved     []string
+		allocStart   string
+		allocEnd     string
+		wantErrCount int
+	}{
+		{"valid spec", "10.40.0.0/24", []string{"10.40.0.0/26"}, "10.40.0.128", "10.40.0.255", 0},
+		{"invalid CIDR", "bad", nil, "", "", 1},
+		{"reserved outside pool", "10.40.0.0/24", []string{"10.41.0.0/24"}, "", "", 1},
+		{"alloc range outside pool", "10.40.0.0/24", nil, "10.41.0.0", "10.41.0.255", 1},
+		{"alloc start after end", "10.40.0.0/24", nil, "10.40.0.200", "10.40.0.100", 1},
+		{"multiple errors", "10.40.0.0/24", []string{"10.41.0.0/24"}, "10.42.0.0", "10.42.0.255", 2},
+		{"no alloc range", "10.40.0.0/24", []string{"10.40.0.0/26"}, "", "", 0},
+		{"invalid reserved CIDR", "10.40.0.0/24", []string{"bad"}, "", "", 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			errs := ValidatePoolSpec(tt.cidr, tt.reserved, tt.allocStart, tt.allocEnd)
+			if len(errs) != tt.wantErrCount {
+				t.Errorf("got %d errors, want %d: %v", len(errs), tt.wantErrCount, errs)
+			}
+		})
+	}
+}
+
+// --- PoolCapacityInfo ---
+
+func TestPoolCapacityInfo(t *testing.T) {
+	tests := []struct {
+		name          string
+		pool          PoolState
+		wantTotal     int32
+		wantAllocated int32
+		wantAvailable int32
+	}{
+		{
+			name: "empty pool no reserved",
+			pool: PoolState{
+				AllocatableStart: "10.0.0.0",
+				AllocatableEnd:   "10.0.0.31",
+			},
+			wantTotal: 32, wantAllocated: 0, wantAvailable: 32,
+		},
+		{
+			name: "with reserved IPs",
+			pool: PoolState{
+				AllocatableStart: "10.0.0.0",
+				AllocatableEnd:   "10.0.0.31",
+				ReservedCIDRs:    []string{"10.0.0.0/29"}, // 8 reserved
+			},
+			wantTotal: 24, wantAllocated: 0, wantAvailable: 24,
+		},
+		{
+			name: "with reserved and allocated",
+			pool: PoolState{
+				AllocatableStart: "10.0.0.0",
+				AllocatableEnd:   "10.0.0.31",
+				ReservedCIDRs:    []string{"10.0.0.0/29"}, // 8 reserved
+				ExistingAllocs: []AllocatedRange{
+					{Start: "10.0.0.8", End: "10.0.0.15"}, // 8 allocated
+				},
+			},
+			wantTotal: 24, wantAllocated: 8, wantAvailable: 16,
+		},
+		{
+			name: "fully allocated (non-reserved)",
+			pool: PoolState{
+				AllocatableStart: "10.0.0.0",
+				AllocatableEnd:   "10.0.0.15",
+				ReservedCIDRs:    []string{"10.0.0.0/29"}, // 8 reserved
+				ExistingAllocs: []AllocatedRange{
+					{Start: "10.0.0.8", End: "10.0.0.15"}, // 8 allocated
+				},
+			},
+			wantTotal: 8, wantAllocated: 8, wantAvailable: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			total, allocated, available, err := PoolCapacityInfo(tt.pool)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if total != tt.wantTotal {
+				t.Errorf("total = %d, want %d", total, tt.wantTotal)
+			}
+			if allocated != tt.wantAllocated {
+				t.Errorf("allocated = %d, want %d", allocated, tt.wantAllocated)
+			}
+			if available != tt.wantAvailable {
+				t.Errorf("available = %d, want %d", available, tt.wantAvailable)
+			}
+		})
+	}
+}
+
+// --- SortPoolRefsByPriority ---
+
+func TestSortPoolRefsByPriority(t *testing.T) {
+	p := func(v int32) *int32 { return &v }
+
+	t.Run("sorts by priority", func(t *testing.T) {
+		refs := []PoolRef{
+			{Name: "pool-c", Priority: p(10)},
+			{Name: "pool-a", Priority: p(0)},
+			{Name: "pool-b", Priority: p(5)},
+		}
+		SortPoolRefsByPriority(refs)
+		if refs[0].Name != "pool-a" || refs[1].Name != "pool-b" || refs[2].Name != "pool-c" {
+			t.Errorf("wrong order: %v, %v, %v", refs[0].Name, refs[1].Name, refs[2].Name)
+		}
+	})
+
+	t.Run("nil priority defaults to 0", func(t *testing.T) {
+		refs := []PoolRef{
+			{Name: "pool-b", Priority: p(5)},
+			{Name: "pool-a", Priority: nil},
+		}
+		SortPoolRefsByPriority(refs)
+		if refs[0].Name != "pool-a" || refs[1].Name != "pool-b" {
+			t.Errorf("nil priority should sort first: %v, %v", refs[0].Name, refs[1].Name)
+		}
+	})
+
+	t.Run("stable sort preserves order for equal priorities", func(t *testing.T) {
+		refs := []PoolRef{
+			{Name: "pool-a", Priority: p(0)},
+			{Name: "pool-b", Priority: p(0)},
+			{Name: "pool-c", Priority: p(0)},
+		}
+		SortPoolRefsByPriority(refs)
+		if refs[0].Name != "pool-a" || refs[1].Name != "pool-b" || refs[2].Name != "pool-c" {
+			t.Errorf("stable sort should preserve order: %v, %v, %v", refs[0].Name, refs[1].Name, refs[2].Name)
+		}
+	})
+}
+
+// --- ParseIPRange ---
+
+func TestParseIPRange(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		wantStart string
+		wantEnd   string
+		wantErr   bool
+	}{
+		{"CIDR /29", "10.0.0.0/29", "10.0.0.0", "10.0.0.7", false},
+		{"CIDR /32", "10.0.0.1/32", "10.0.0.1", "10.0.0.1", false},
+		{"dash range", "10.0.0.10-10.0.0.20", "10.0.0.10", "10.0.0.20", false},
+		{"dash range with spaces", "10.0.0.10 - 10.0.0.20", "10.0.0.10", "10.0.0.20", false},
+		{"single IP", "10.0.0.5", "10.0.0.5", "10.0.0.5", false},
+		{"invalid CIDR", "bad/24", "", "", true},
+		{"invalid dash range", "bad-10.0.0.1", "", "", true},
+		{"invalid single", "bad", "", "", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			start, end, err := ParseIPRange(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("error = %v, wantErr = %v", err, tt.wantErr)
+			}
+			if !tt.wantErr {
+				if start != tt.wantStart {
+					t.Errorf("start = %s, want %s", start, tt.wantStart)
+				}
+				if end != tt.wantEnd {
+					t.Errorf("end = %s, want %s", end, tt.wantEnd)
+				}
+			}
+		})
+	}
+}
+
+// --- findFreeBlocks ---
+
+func TestFindFreeBlocks(t *testing.T) {
+	tests := []struct {
+		name    string
+		bitmap  []bool
+		want    int // number of free blocks
+		wantMax uint32
+	}{
+		{"all free", []bool{false, false, false, false}, 1, 4},
+		{"all used", []bool{true, true, true, true}, 0, 0},
+		{"one free at start", []bool{false, true, true, true}, 1, 1},
+		{"one free at end", []bool{true, true, true, false}, 1, 1},
+		{"two blocks", []bool{false, false, true, false, false, false}, 2, 3},
+		{"alternating", []bool{false, true, false, true, false, true, false, true}, 4, 1},
+		{"empty bitmap", []bool{}, 0, 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			blocks := findFreeBlocks(tt.bitmap)
+			if len(blocks) != tt.want {
+				t.Errorf("got %d blocks, want %d", len(blocks), tt.want)
+			}
+			var maxSize uint32
+			for _, b := range blocks {
+				if b.Size > maxSize {
+					maxSize = b.Size
+				}
+			}
+			if maxSize != tt.wantMax {
+				t.Errorf("max block size = %d, want %d", maxSize, tt.wantMax)
+			}
+		})
+	}
+}
+
+// --- Integration-style tests ---
+
+func TestAllocateAndRelease_Workflow(t *testing.T) {
+	// Simulate a real-world workflow:
+	// 1. Create 4 allocations of 8 IPs each
+	// 2. Release the 2nd allocation
+	// 3. Allocate 4 IPs — best-fit should use the freed gap
+	// 4. Allocate 8 IPs — should use remaining space
+
+	pool := PoolState{
+		AllocatableStart: "10.0.0.0",
+		AllocatableEnd:   "10.0.0.63",
+	}
+
+	// Step 1: 4 allocations of 8
+	allocs := make([]*AllocationResult, 4)
+	for i := 0; i < 4; i++ {
+		result, err := AllocateRange(pool, 8)
+		if err != nil {
+			t.Fatalf("allocation %d failed: %v", i, err)
+		}
+		allocs[i] = result
+		pool.ExistingAllocs = append(pool.ExistingAllocs, AllocatedRange{
+			Start: result.Start, End: result.End,
+		})
+	}
+
+	// Verify layout: .0-.7, .8-.15, .16-.23, .24-.31
+	if allocs[0].Start != "10.0.0.0" || allocs[1].Start != "10.0.0.8" ||
+		allocs[2].Start != "10.0.0.16" || allocs[3].Start != "10.0.0.24" {
+		t.Fatalf("unexpected initial layout")
+	}
+
+	// Step 2: Release 2nd allocation (.8-.15)
+	pool.ExistingAllocs = []AllocatedRange{
+		{Start: "10.0.0.0", End: "10.0.0.7"},
+		{Start: "10.0.0.16", End: "10.0.0.23"},
+		{Start: "10.0.0.24", End: "10.0.0.31"},
+	}
+
+	// Step 3: Allocate 4 IPs
+	// Free blocks: .8-.15 (8 IPs), .32-.63 (32 IPs)
+	// Best-fit picks .8-.15 (size 8, smallest >= 4)
+	result4, err := AllocateRange(pool, 4)
+	if err != nil {
+		t.Fatalf("4-IP allocation failed: %v", err)
+	}
+	if result4.Start != "10.0.0.8" || result4.End != "10.0.0.11" {
+		t.Errorf("4-IP alloc: got %s-%s, want 10.0.0.8-10.0.0.11", result4.Start, result4.End)
+	}
+
+	pool.ExistingAllocs = append(pool.ExistingAllocs, AllocatedRange{
+		Start: result4.Start, End: result4.End,
+	})
+
+	// Step 4: Allocate 8 IPs
+	// Free blocks: .12-.15 (4 IPs), .32-.63 (32 IPs)
+	// Best-fit cannot use .12-.15 (too small), uses .32-.63
+	result8, err := AllocateRange(pool, 8)
+	if err != nil {
+		t.Fatalf("8-IP allocation failed: %v", err)
+	}
+	// Should NOT be .12-.15 (only 4 free) — should be from the large block
+	if result8.Start != "10.0.0.32" || result8.End != "10.0.0.39" {
+		t.Errorf("8-IP alloc: got %s-%s, want 10.0.0.32-10.0.0.39", result8.Start, result8.End)
+	}
+}
+
+func TestAllocateRange_CIDRNotation(t *testing.T) {
+	// Verify power-of-2 aligned allocations produce CIDR notation
+	pool := PoolState{
+		AllocatableStart: "10.0.0.0",
+		AllocatableEnd:   "10.0.0.255",
+	}
+
+	// Allocate 8 IPs starting at .0 — should be 10.0.0.0/29
+	result, err := AllocateRange(pool, 8)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.CIDR != "10.0.0.0/29" {
+		t.Errorf("CIDR = %s, want 10.0.0.0/29", result.CIDR)
+	}
+
+	// Allocate 5 IPs — not power of 2, should be range format
+	pool.ExistingAllocs = []AllocatedRange{
+		{Start: "10.0.0.0", End: "10.0.0.7"},
+	}
+	result, err = AllocateRange(pool, 5)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.CIDR != "10.0.0.8-10.0.0.12" {
+		t.Errorf("CIDR = %s, want 10.0.0.8-10.0.0.12", result.CIDR)
+	}
+}
+
+func TestAllocatePinnedRange(t *testing.T) {
+	pool := PoolState{
+		AllocatableStart: "10.40.0.0",
+		AllocatableEnd:   "10.40.0.255",
+	}
+
+	tests := []struct {
+		name        string
+		pool        PoolState
+		start       string
+		end         string
+		wantErr     bool
+		errContains string
+		wantCount   int32
+	}{
+		{
+			name:      "valid pinned range",
+			pool:      pool,
+			start:     "10.40.0.10",
+			end:       "10.40.0.17",
+			wantCount: 8,
+		},
+		{
+			name:      "single IP",
+			pool:      pool,
+			start:     "10.40.0.100",
+			end:       "10.40.0.100",
+			wantCount: 1,
+		},
+		{
+			name:        "start after end",
+			pool:        pool,
+			start:       "10.40.0.20",
+			end:         "10.40.0.10",
+			wantErr:     true,
+			errContains: "start",
+		},
+		{
+			name:        "outside pool - before",
+			pool:        PoolState{AllocatableStart: "10.40.0.64", AllocatableEnd: "10.40.0.127"},
+			start:       "10.40.0.10",
+			end:         "10.40.0.17",
+			wantErr:     true,
+			errContains: "outside pool",
+		},
+		{
+			name:        "outside pool - after",
+			pool:        PoolState{AllocatableStart: "10.40.0.0", AllocatableEnd: "10.40.0.127"},
+			start:       "10.40.0.200",
+			end:         "10.40.0.207",
+			wantErr:     true,
+			errContains: "outside pool",
+		},
+		{
+			name: "conflicts with reserved",
+			pool: PoolState{
+				AllocatableStart: "10.40.0.0",
+				AllocatableEnd:   "10.40.0.255",
+				ReservedCIDRs:    []string{"10.40.0.0/28"},
+			},
+			start:       "10.40.0.10",
+			end:         "10.40.0.17",
+			wantErr:     true,
+			errContains: "conflicts",
+		},
+		{
+			name: "conflicts with existing allocation",
+			pool: PoolState{
+				AllocatableStart: "10.40.0.0",
+				AllocatableEnd:   "10.40.0.255",
+				ExistingAllocs:   []AllocatedRange{{Start: "10.40.0.10", End: "10.40.0.17"}},
+			},
+			start:       "10.40.0.14",
+			end:         "10.40.0.21",
+			wantErr:     true,
+			errContains: "conflicts",
+		},
+		{
+			name: "adjacent to existing - no conflict",
+			pool: PoolState{
+				AllocatableStart: "10.40.0.0",
+				AllocatableEnd:   "10.40.0.255",
+				ExistingAllocs:   []AllocatedRange{{Start: "10.40.0.10", End: "10.40.0.17"}},
+			},
+			start:     "10.40.0.18",
+			end:       "10.40.0.25",
+			wantCount: 8,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := AllocatePinnedRange(tt.pool, tt.start, tt.end)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tt.errContains)
+				}
+				if !strings.Contains(err.Error(), tt.errContains) {
+					t.Errorf("error %q does not contain %q", err.Error(), tt.errContains)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if result.Start != tt.start {
+				t.Errorf("start = %s, want %s", result.Start, tt.start)
+			}
+			if result.End != tt.end {
+				t.Errorf("end = %s, want %s", result.End, tt.end)
+			}
+			if result.Count != tt.wantCount {
+				t.Errorf("count = %d, want %d", result.Count, tt.wantCount)
+			}
+			if len(result.Addresses) != int(tt.wantCount) {
+				t.Errorf("addresses len = %d, want %d", len(result.Addresses), tt.wantCount)
+			}
+		})
+	}
+}
+
+func TestAllocatePinnedRange_MigrationWorkflow(t *testing.T) {
+	// Simulate migrating 3 existing TCs with manual LB pools into IPAM
+	pool := PoolState{
+		AllocatableStart: "10.40.6.0",
+		AllocatableEnd:   "10.40.6.255",
+	}
+
+	// Import existing assignments
+	existingPools := []struct {
+		start string
+		end   string
+	}{
+		{"10.40.6.10", "10.40.6.30"},  // butlerlabs-site-dev
+		{"10.40.6.50", "10.40.6.55"},  // gateway-test
+		{"10.40.6.100", "10.40.6.115"}, // another cluster
+	}
+
+	for i, ep := range existingPools {
+		result, err := AllocatePinnedRange(pool, ep.start, ep.end)
+		if err != nil {
+			t.Fatalf("migration %d failed: %v", i, err)
+		}
+		pool.ExistingAllocs = append(pool.ExistingAllocs, AllocatedRange{
+			Start: result.Start, End: result.End,
+		})
+	}
+
+	// Verify new allocation doesn't conflict with migrated ranges
+	newResult, err := AllocateRange(pool, 8)
+	if err != nil {
+		t.Fatalf("new allocation after migration failed: %v", err)
+	}
+
+	// Verify no overlap with any migrated range
+	newStart := IPToUint32(net.ParseIP(newResult.Start).To4())
+	newEnd := IPToUint32(net.ParseIP(newResult.End).To4())
+	for _, ep := range existingPools {
+		epStart := IPToUint32(net.ParseIP(ep.start).To4())
+		epEnd := IPToUint32(net.ParseIP(ep.end).To4())
+		if newStart <= epEnd && newEnd >= epStart {
+			t.Errorf("new allocation %s-%s overlaps with migrated range %s-%s",
+				newResult.Start, newResult.End, ep.start, ep.end)
+		}
+	}
+}
+
+func TestAllocateRange_RealisticDatacenter(t *testing.T) {
+	// Simulate a realistic datacenter scenario:
+	// /24 pool (256 IPs), reserved .0-.15 for management, 5 nodes + 8 LB per tenant
+	pool := PoolState{
+		AllocatableStart: "10.40.0.0",
+		AllocatableEnd:   "10.40.0.255",
+		ReservedCIDRs:    []string{"10.40.0.0/28"}, // .0-.15 reserved for management
+	}
+
+	// Allocate for 10 tenants (5 node IPs + 8 LB IPs each = 13 per tenant)
+	for i := 0; i < 10; i++ {
+		// Node IPs
+		nodeResult, err := AllocateRange(pool, 5)
+		if err != nil {
+			t.Fatalf("tenant %d node allocation failed: %v", i, err)
+		}
+		pool.ExistingAllocs = append(pool.ExistingAllocs, AllocatedRange{
+			Start: nodeResult.Start, End: nodeResult.End,
+		})
+
+		// LB IPs
+		lbResult, err := AllocateRange(pool, 8)
+		if err != nil {
+			t.Fatalf("tenant %d LB allocation failed: %v", i, err)
+		}
+		pool.ExistingAllocs = append(pool.ExistingAllocs, AllocatedRange{
+			Start: lbResult.Start, End: lbResult.End,
+		})
+	}
+
+	// Verify capacity
+	total, allocated, available, err := PoolCapacityInfo(pool)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectedAllocated := int32(10 * 13) // 130 IPs allocated
+	expectedTotal := int32(240)          // 256 - 16 reserved
+	expectedAvailable := expectedTotal - expectedAllocated
+
+	if total != expectedTotal {
+		t.Errorf("total = %d, want %d", total, expectedTotal)
+	}
+	if allocated != expectedAllocated {
+		t.Errorf("allocated = %d, want %d", allocated, expectedAllocated)
+	}
+	if available != expectedAvailable {
+		t.Errorf("available = %d, want %d", available, expectedAvailable)
+	}
+}

--- a/internal/webhook/networkpool_webhook.go
+++ b/internal/webhook/networkpool_webhook.go
@@ -1,0 +1,170 @@
+/*
+Copyright 2026 The Butler Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhook
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	butlerv1alpha1 "github.com/butlerdotdev/butler-api/api/v1alpha1"
+	"github.com/butlerdotdev/butler-controller/internal/ipam"
+)
+
+// NetworkPoolValidator validates NetworkPool resources on admission.
+type NetworkPoolValidator struct {
+	Client client.Client
+}
+
+// +kubebuilder:webhook:path=/validate-butler-butlerlabs-dev-v1alpha1-networkpool,mutating=false,failurePolicy=fail,sideEffects=None,groups=butler.butlerlabs.dev,resources=networkpools,verbs=create;update;delete,versions=v1alpha1,name=vnetworkpool.kb.io,admissionReviewVersions=v1
+
+// ValidateCreate validates a NetworkPool on creation.
+func (v *NetworkPoolValidator) ValidateCreate(_ context.Context, obj runtime.Object) (admission.Warnings, error) {
+	pool, ok := obj.(*butlerv1alpha1.NetworkPool)
+	if !ok {
+		return nil, fmt.Errorf("expected NetworkPool, got %T", obj)
+	}
+
+	return v.validatePoolSpec(pool)
+}
+
+// ValidateUpdate validates a NetworkPool on update.
+func (v *NetworkPoolValidator) ValidateUpdate(_ context.Context, oldObj, newObj runtime.Object) (admission.Warnings, error) {
+	oldPool, ok := oldObj.(*butlerv1alpha1.NetworkPool)
+	if !ok {
+		return nil, fmt.Errorf("expected NetworkPool for old object, got %T", oldObj)
+	}
+
+	newPool, ok := newObj.(*butlerv1alpha1.NetworkPool)
+	if !ok {
+		return nil, fmt.Errorf("expected NetworkPool for new object, got %T", newObj)
+	}
+
+	// Validate the new spec.
+	warnings, err := v.validatePoolSpec(newPool)
+	if err != nil {
+		return warnings, err
+	}
+
+	// Validate that the new CIDR contains the old CIDR to prevent shrinking
+	// below existing allocations.
+	if newPool.Spec.CIDR != oldPool.Spec.CIDR {
+		var allErrs field.ErrorList
+
+		contained, cidrErr := ipam.ValidateCIDRContains(newPool.Spec.CIDR, oldPool.Spec.CIDR)
+		if cidrErr != nil {
+			allErrs = append(allErrs, field.Invalid(
+				field.NewPath("spec", "cidr"),
+				newPool.Spec.CIDR,
+				fmt.Sprintf("failed to validate CIDR containment: %v", cidrErr),
+			))
+		} else if !contained {
+			allErrs = append(allErrs, field.Forbidden(
+				field.NewPath("spec", "cidr"),
+				fmt.Sprintf(
+					"new CIDR %q does not contain the previous CIDR %q; shrinking a pool may orphan existing allocations",
+					newPool.Spec.CIDR, oldPool.Spec.CIDR,
+				),
+			))
+		}
+
+		if len(allErrs) > 0 {
+			return nil, allErrs.ToAggregate()
+		}
+	}
+
+	return nil, nil
+}
+
+// ValidateDelete validates a NetworkPool on deletion.
+func (v *NetworkPoolValidator) ValidateDelete(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
+	pool, ok := obj.(*butlerv1alpha1.NetworkPool)
+	if !ok {
+		return nil, fmt.Errorf("expected NetworkPool, got %T", obj)
+	}
+
+	// Check for active IPAllocations that reference this pool.
+	var allocList butlerv1alpha1.IPAllocationList
+	if err := v.Client.List(ctx, &allocList, client.MatchingLabels{
+		butlerv1alpha1.LabelNetworkPool: pool.Name,
+	}); err != nil {
+		return nil, fmt.Errorf("failed to list IPAllocations for pool %q: %w", pool.Name, err)
+	}
+
+	for i := range allocList.Items {
+		if allocList.Items[i].Status.Phase == butlerv1alpha1.IPAllocationPhaseAllocated {
+			return nil, field.ErrorList{field.Forbidden(
+				field.NewPath("metadata", "name"),
+				fmt.Sprintf(
+					"cannot delete NetworkPool %q: IPAllocation %q in namespace %q is still in phase %s",
+					pool.Name,
+					allocList.Items[i].Name,
+					allocList.Items[i].Namespace,
+					butlerv1alpha1.IPAllocationPhaseAllocated,
+				),
+			)}.ToAggregate()
+		}
+	}
+
+	return nil, nil
+}
+
+// validatePoolSpec validates the internal consistency of a NetworkPool spec using the ipam package.
+func (v *NetworkPoolValidator) validatePoolSpec(pool *butlerv1alpha1.NetworkPool) (admission.Warnings, error) {
+	// Collect reserved CIDRs.
+	reservedCIDRs := make([]string, 0, len(pool.Spec.Reserved))
+	for _, r := range pool.Spec.Reserved {
+		reservedCIDRs = append(reservedCIDRs, r.CIDR)
+	}
+
+	// Determine allocation range.
+	allocStart := ""
+	allocEnd := ""
+	if pool.Spec.TenantAllocation != nil {
+		allocStart = pool.Spec.TenantAllocation.Start
+		allocEnd = pool.Spec.TenantAllocation.End
+	}
+
+	errs := ipam.ValidatePoolSpec(pool.Spec.CIDR, reservedCIDRs, allocStart, allocEnd)
+	if len(errs) > 0 {
+		var allErrs field.ErrorList
+		for _, errMsg := range errs {
+			allErrs = append(allErrs, field.Invalid(
+				field.NewPath("spec"),
+				pool.Spec.CIDR,
+				errMsg,
+			))
+		}
+		return nil, allErrs.ToAggregate()
+	}
+
+	return nil, nil
+}
+
+// SetupWebhookWithManager registers the NetworkPool validating webhook with the manager.
+func (v *NetworkPoolValidator) SetupWebhookWithManager(mgr ctrl.Manager) error {
+	v.Client = mgr.GetClient()
+	return ctrl.NewWebhookManagedBy(mgr).
+		For(&butlerv1alpha1.NetworkPool{}).
+		WithValidator(v).
+		Complete()
+}

--- a/internal/webhook/providerconfig_webhook.go
+++ b/internal/webhook/providerconfig_webhook.go
@@ -1,0 +1,216 @@
+/*
+Copyright 2026 The Butler Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhook
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	butlerv1alpha1 "github.com/butlerdotdev/butler-api/api/v1alpha1"
+)
+
+// ProviderConfigValidator validates ProviderConfig resources on admission.
+type ProviderConfigValidator struct {
+	Client client.Client
+}
+
+// +kubebuilder:webhook:path=/validate-butler-butlerlabs-dev-v1alpha1-providerconfig,mutating=false,failurePolicy=fail,sideEffects=None,groups=butler.butlerlabs.dev,resources=providerconfigs,verbs=create;update;delete,versions=v1alpha1,name=vproviderconfig.kb.io,admissionReviewVersions=v1
+
+// ValidateCreate validates a ProviderConfig on creation.
+func (v *ProviderConfigValidator) ValidateCreate(_ context.Context, obj runtime.Object) (admission.Warnings, error) {
+	pc, ok := obj.(*butlerv1alpha1.ProviderConfig)
+	if !ok {
+		return nil, fmt.Errorf("expected ProviderConfig, got %T", obj)
+	}
+
+	return v.validateCreateUpdate(pc)
+}
+
+// ValidateUpdate validates a ProviderConfig on update.
+func (v *ProviderConfigValidator) ValidateUpdate(_ context.Context, _, newObj runtime.Object) (admission.Warnings, error) {
+	pc, ok := newObj.(*butlerv1alpha1.ProviderConfig)
+	if !ok {
+		return nil, fmt.Errorf("expected ProviderConfig, got %T", newObj)
+	}
+
+	return v.validateCreateUpdate(pc)
+}
+
+// ValidateDelete validates a ProviderConfig on deletion.
+func (v *ProviderConfigValidator) ValidateDelete(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
+	pc, ok := obj.(*butlerv1alpha1.ProviderConfig)
+	if !ok {
+		return nil, fmt.Errorf("expected ProviderConfig, got %T", obj)
+	}
+
+	// Check for TenantClusters that reference this ProviderConfig.
+	var tcList butlerv1alpha1.TenantClusterList
+	if err := v.Client.List(ctx, &tcList); err != nil {
+		return nil, fmt.Errorf("failed to list TenantClusters: %w", err)
+	}
+
+	for i := range tcList.Items {
+		tc := &tcList.Items[i]
+		if tc.Spec.ProviderConfigRef == nil {
+			continue
+		}
+
+		refNamespace := tc.Spec.ProviderConfigRef.Namespace
+		if refNamespace == "" {
+			refNamespace = defaultProviderConfigNamespace
+		}
+
+		if tc.Spec.ProviderConfigRef.Name == pc.Name && refNamespace == pc.Namespace {
+			return nil, field.ErrorList{field.Forbidden(
+				field.NewPath("metadata", "name"),
+				fmt.Sprintf(
+					"cannot delete ProviderConfig %q: TenantCluster %s/%s still references it",
+					pc.Name, tc.Namespace, tc.Name,
+				),
+			)}.ToAggregate()
+		}
+	}
+
+	return nil, nil
+}
+
+// validateCreateUpdate contains shared validation logic for create and update operations.
+func (v *ProviderConfigValidator) validateCreateUpdate(pc *butlerv1alpha1.ProviderConfig) (admission.Warnings, error) {
+	var allErrs field.ErrorList
+
+	// Validate provider-specific configuration exists.
+	switch pc.Spec.Provider {
+	case butlerv1alpha1.ProviderTypeAzure:
+		if pc.Spec.Azure == nil {
+			allErrs = append(allErrs, field.Required(
+				field.NewPath("spec", "azure"),
+				"azure configuration is required when provider is \"azure\"",
+			))
+		} else {
+			if pc.Spec.Azure.SubscriptionID == "" {
+				allErrs = append(allErrs, field.Required(
+					field.NewPath("spec", "azure", "subscriptionID"),
+					"subscriptionID is required for Azure provider",
+				))
+			}
+			if pc.Spec.Azure.ResourceGroup == "" {
+				allErrs = append(allErrs, field.Required(
+					field.NewPath("spec", "azure", "resourceGroup"),
+					"resourceGroup is required for Azure provider",
+				))
+			}
+		}
+
+	case butlerv1alpha1.ProviderTypeAWS:
+		if pc.Spec.AWS == nil {
+			allErrs = append(allErrs, field.Required(
+				field.NewPath("spec", "aws"),
+				"aws configuration is required when provider is \"aws\"",
+			))
+		} else {
+			if pc.Spec.AWS.Region == "" {
+				allErrs = append(allErrs, field.Required(
+					field.NewPath("spec", "aws", "region"),
+					"region is required for AWS provider",
+				))
+			}
+		}
+
+	case butlerv1alpha1.ProviderTypeGCP:
+		if pc.Spec.GCP == nil {
+			allErrs = append(allErrs, field.Required(
+				field.NewPath("spec", "gcp"),
+				"gcp configuration is required when provider is \"gcp\"",
+			))
+		} else {
+			if pc.Spec.GCP.ProjectID == "" {
+				allErrs = append(allErrs, field.Required(
+					field.NewPath("spec", "gcp", "projectID"),
+					"projectID is required for GCP provider",
+				))
+			}
+			if pc.Spec.GCP.Region == "" {
+				allErrs = append(allErrs, field.Required(
+					field.NewPath("spec", "gcp", "region"),
+					"region is required for GCP provider",
+				))
+			}
+		}
+	}
+
+	// Validate scope configuration.
+	if pc.Spec.Scope != nil && pc.Spec.Scope.Type == butlerv1alpha1.ProviderConfigScopeTeam {
+		if pc.Spec.Scope.TeamRef == nil {
+			allErrs = append(allErrs, field.Required(
+				field.NewPath("spec", "scope", "teamRef"),
+				"teamRef is required when scope type is \"team\"",
+			))
+		}
+	}
+
+	// Validate network configuration.
+	if pc.Spec.Network != nil && pc.Spec.Network.Mode == "ipam" {
+		// IPAM mode requires at least one pool reference.
+		if len(pc.Spec.Network.PoolRefs) == 0 {
+			allErrs = append(allErrs, field.Required(
+				field.NewPath("spec", "network", "poolRefs"),
+				"at least one poolRef is required when network mode is \"ipam\"",
+			))
+		}
+
+		// IPAM mode is not supported for cloud providers.
+		if isCloudProvider(pc.Spec.Provider) {
+			allErrs = append(allErrs, field.Forbidden(
+				field.NewPath("spec", "network", "mode"),
+				"IPAM mode is not supported for cloud providers",
+			))
+		}
+	}
+
+	if len(allErrs) > 0 {
+		return nil, allErrs.ToAggregate()
+	}
+
+	return nil, nil
+}
+
+// isCloudProvider returns true if the provider type is a public cloud provider.
+func isCloudProvider(provider butlerv1alpha1.ProviderType) bool {
+	switch provider {
+	case butlerv1alpha1.ProviderTypeAzure,
+		butlerv1alpha1.ProviderTypeAWS,
+		butlerv1alpha1.ProviderTypeGCP:
+		return true
+	default:
+		return false
+	}
+}
+
+// SetupWebhookWithManager registers the ProviderConfig validating webhook with the manager.
+func (v *ProviderConfigValidator) SetupWebhookWithManager(mgr ctrl.Manager) error {
+	v.Client = mgr.GetClient()
+	return ctrl.NewWebhookManagedBy(mgr).
+		For(&butlerv1alpha1.ProviderConfig{}).
+		WithValidator(v).
+		Complete()
+}

--- a/internal/webhook/tenantcluster_webhook.go
+++ b/internal/webhook/tenantcluster_webhook.go
@@ -1,0 +1,188 @@
+/*
+Copyright 2026 The Butler Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhook
+
+import (
+	"context"
+	"fmt"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	butlerv1alpha1 "github.com/butlerdotdev/butler-api/api/v1alpha1"
+)
+
+const defaultProviderConfigNamespace = "butler-system"
+
+// TenantClusterValidator validates TenantCluster resources on admission.
+type TenantClusterValidator struct {
+	Client client.Client
+}
+
+// +kubebuilder:webhook:path=/validate-butler-butlerlabs-dev-v1alpha1-tenantcluster,mutating=false,failurePolicy=fail,sideEffects=None,groups=butler.butlerlabs.dev,resources=tenantclusters,verbs=create;update,versions=v1alpha1,name=vtenantcluster.kb.io,admissionReviewVersions=v1
+
+// ValidateCreate validates a TenantCluster on creation.
+func (v *TenantClusterValidator) ValidateCreate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
+	tc, ok := obj.(*butlerv1alpha1.TenantCluster)
+	if !ok {
+		return nil, fmt.Errorf("expected TenantCluster, got %T", obj)
+	}
+
+	return v.validateCreateUpdate(ctx, tc)
+}
+
+// ValidateUpdate validates a TenantCluster on update.
+func (v *TenantClusterValidator) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Object) (admission.Warnings, error) {
+	tc, ok := newObj.(*butlerv1alpha1.TenantCluster)
+	if !ok {
+		return nil, fmt.Errorf("expected TenantCluster, got %T", newObj)
+	}
+
+	return v.validateCreateUpdate(ctx, tc)
+}
+
+// ValidateDelete validates a TenantCluster on deletion.
+func (v *TenantClusterValidator) ValidateDelete(_ context.Context, _ runtime.Object) (admission.Warnings, error) {
+	return nil, nil
+}
+
+// validateCreateUpdate contains shared validation logic for create and update operations.
+func (v *TenantClusterValidator) validateCreateUpdate(ctx context.Context, tc *butlerv1alpha1.TenantCluster) (admission.Warnings, error) {
+	var allErrs field.ErrorList
+
+	if tc.Spec.ProviderConfigRef == nil {
+		return nil, nil
+	}
+
+	// Resolve the ProviderConfig namespace.
+	pcNamespace := tc.Spec.ProviderConfigRef.Namespace
+	if pcNamespace == "" {
+		pcNamespace = defaultProviderConfigNamespace
+	}
+
+	// Fetch the referenced ProviderConfig.
+	pc := &butlerv1alpha1.ProviderConfig{}
+	pcKey := types.NamespacedName{
+		Name:      tc.Spec.ProviderConfigRef.Name,
+		Namespace: pcNamespace,
+	}
+	if err := v.Client.Get(ctx, pcKey, pc); err != nil {
+		if apierrors.IsNotFound(err) {
+			allErrs = append(allErrs, field.NotFound(
+				field.NewPath("spec", "providerConfigRef", "name"),
+				tc.Spec.ProviderConfigRef.Name,
+			))
+			return nil, allErrs.ToAggregate()
+		}
+		return nil, fmt.Errorf("failed to fetch ProviderConfig %s/%s: %w", pcNamespace, tc.Spec.ProviderConfigRef.Name, err)
+	}
+
+	// Validate team scope if the ProviderConfig is team-scoped.
+	if pc.Spec.Scope != nil && pc.Spec.Scope.Type == butlerv1alpha1.ProviderConfigScopeTeam {
+		if pc.Spec.Scope.TeamRef != nil {
+			tcTeamName := ""
+			if tc.Spec.TeamRef != nil {
+				tcTeamName = tc.Spec.TeamRef.Name
+			}
+			if tcTeamName != pc.Spec.Scope.TeamRef.Name {
+				allErrs = append(allErrs, field.Forbidden(
+					field.NewPath("spec", "providerConfigRef"),
+					fmt.Sprintf(
+						"ProviderConfig %q is scoped to team %q, but TenantCluster references team %q",
+						pc.Name, pc.Spec.Scope.TeamRef.Name, tcTeamName,
+					),
+				))
+			}
+		}
+	}
+
+	// Enforce per-team cluster limit.
+	if pc.Spec.Limits != nil && pc.Spec.Limits.MaxClustersPerTeam != nil {
+		maxClusters := *pc.Spec.Limits.MaxClustersPerTeam
+
+		var tcList butlerv1alpha1.TenantClusterList
+		if err := v.Client.List(ctx, &tcList, client.InNamespace(tc.Namespace)); err != nil {
+			return nil, fmt.Errorf("failed to list TenantClusters in namespace %s: %w", tc.Namespace, err)
+		}
+
+		// Count existing clusters, excluding self on update.
+		existingCount := int32(0)
+		for i := range tcList.Items {
+			if tcList.Items[i].Name != tc.Name {
+				existingCount++
+			}
+		}
+
+		if existingCount >= maxClusters {
+			allErrs = append(allErrs, field.Forbidden(
+				field.NewPath("spec"),
+				fmt.Sprintf(
+					"team namespace %q already has %d cluster(s); ProviderConfig %q limits to %d",
+					tc.Namespace, existingCount, pc.Name, maxClusters,
+				),
+			))
+		}
+	}
+
+	// Enforce per-team node limit.
+	if pc.Spec.Limits != nil && pc.Spec.Limits.MaxNodesPerTeam != nil {
+		maxNodes := *pc.Spec.Limits.MaxNodesPerTeam
+
+		var tcList butlerv1alpha1.TenantClusterList
+		if err := v.Client.List(ctx, &tcList, client.InNamespace(tc.Namespace)); err != nil {
+			return nil, fmt.Errorf("failed to list TenantClusters in namespace %s: %w", tc.Namespace, err)
+		}
+
+		// Sum worker replicas across all TCs in the namespace, excluding self.
+		totalNodes := tc.Spec.Workers.Replicas
+		for i := range tcList.Items {
+			if tcList.Items[i].Name != tc.Name {
+				totalNodes += tcList.Items[i].Spec.Workers.Replicas
+			}
+		}
+
+		if totalNodes > maxNodes {
+			allErrs = append(allErrs, field.Forbidden(
+				field.NewPath("spec", "workers", "replicas"),
+				fmt.Sprintf(
+					"total worker replicas (%d) would exceed ProviderConfig %q per-team node limit (%d)",
+					totalNodes, pc.Name, maxNodes,
+				),
+			))
+		}
+	}
+
+	if len(allErrs) > 0 {
+		return nil, allErrs.ToAggregate()
+	}
+
+	return nil, nil
+}
+
+// SetupWebhookWithManager registers the TenantCluster validating webhook with the manager.
+func (v *TenantClusterValidator) SetupWebhookWithManager(mgr ctrl.Manager) error {
+	v.Client = mgr.GetClient()
+	return ctrl.NewWebhookManagedBy(mgr).
+		For(&butlerv1alpha1.TenantCluster{}).
+		WithValidator(v).
+		Complete()
+}


### PR DESCRIPTION
## Summary

- **IPAM library** (`internal/ipam/`): bitmap-based best-fit IP allocator with pinned range support for migration, fragmentation computation, pool capacity reporting
- **NetworkPool controller**: sole allocator for IP ranges (PVC/PV provisioner pattern), Prometheus metrics (7 gauges + 1 counter), Kubernetes events for capacity warnings and allocation lifecycle
- **IPAllocation controller**: thin lifecycle controller with finalizers and audit trail (allocatedAt, releasedAt, allocatedBy)
- **ProviderConfig controller**: credential validation, IPAM pool availability, team scope validation, readiness metrics
- **TenantCluster controller updates**: provider scope/limits enforcement (webhook + reconcile loop), IPAM integration with multi-pool failover, cloud mode passthrough (NetworkReady=True immediately)
- **Admission webhooks**: ValidatingWebhook for TenantCluster (scope, limits, capacity), NetworkPool (CIDR math), ProviderConfig (required fields, scope, pool refs)
- **ADR-008**: Enterprise Networking and IPAM architecture decision record

## Test plan

- [x] Unit tests: 30+ table-driven IPAM tests including pinned ranges, fragmentation, large pool (/16)
- [x] Integration tests: envtest suites for NetworkPool, ProviderConfig controllers
- [x] E2E on butler-beta: pool creation, allocation, pinned allocation, conflict detection
- [x] E2E: multi-pool failover (pool-a exhausted -> falls back to pool-b)
- [x] E2E: cloud mode (network.mode: cloud skips IPAM, NetworkReady=True)
- [x] E2E: provider limits enforcement (maxClustersPerTeam, maxNodesPerTeam)
- [x] E2E: Prometheus metrics verified via /metrics endpoint
- [x] E2E: Kubernetes events verified (IPsAllocated on NetworkPool)
- [x] E2E: backward compatibility (existing TCs with manual loadBalancerPool remain Ready)
- [x] E2E: print columns on kubectl get np/ipa/providerconfigs