### PR TITLE
fix: talos apply-config ordering, WorkersReady, and Traefik timeout

### DIFF
--- a/internal/addons/installer.go
+++ b/internal/addons/installer.go
@@ -563,7 +563,7 @@ func (i *Installer) InstallTraefik(ctx context.Context, kubeconfig []byte, versi
 		"--set", "ingressClass.isDefaultClass=true",
 		"--set", "service.type=LoadBalancer",
 		"--wait",
-		"--timeout", "5m",
+		"--timeout", "2m",
 	}
 
 	if err := i.runHelm(ctx, kubeconfigPath, args...); err != nil {

--- a/internal/controller/tenantcluster/tenantcluster_controller.go
+++ b/internal/controller/tenantcluster/tenantcluster_controller.go
@@ -333,12 +333,17 @@ func (r *Reconciler) reconcileInfrastructure(ctx context.Context, tc *butlerv1al
 		r.setCondition(tc, butlerv1alpha1.TenantClusterConditionControlPlaneReady,
 			metav1.ConditionTrue, ReasonControlPlaneReady, "Control plane is ready")
 
-		// For Talos clusters, create the bootstrap Secret as soon as CP is ready.
-		// This MUST happen inside reconcileInfrastructure because CAPI Machines
-		// reference this Secret via dataSecretName and will block until it exists.
+		// For Talos clusters, create the bootstrap Secret and apply config to workers
+		// as soon as CP is ready. Bootstrap MUST happen here because CAPI Machines
+		// reference the Secret via dataSecretName and block until it exists.
+		// Apply-config also runs here so workers get configured during provisioning
+		// (before addon installation), not after the cluster reaches Ready phase.
 		if isTalosCluster(tc) {
 			if err := r.reconcileTalosBootstrap(ctx, tc, butlerConfig); err != nil {
 				logger.Error(err, "failed to reconcile Talos bootstrap")
+			}
+			if err := r.reconcileTalosApplyConfig(ctx, tc); err != nil {
+				logger.Error(err, "failed to apply Talos config to workers")
 			}
 		}
 

--- a/internal/controller/tenantcluster/tenantcluster_controller.go
+++ b/internal/controller/tenantcluster/tenantcluster_controller.go
@@ -1621,9 +1621,8 @@ func (r *Reconciler) reconcileTalosconfig(ctx context.Context, tc *butlerv1alpha
 		},
 	}
 
-	if err := ctrl.SetControllerReference(tc, secret, r.Scheme); err != nil {
-		return fmt.Errorf("setting owner reference: %w", err)
-	}
+	// Skip owner reference — TC is in a different namespace than the Secret.
+	// Labels track ownership instead.
 
 	if err := r.Create(ctx, secret); err != nil {
 		if apierrors.IsAlreadyExists(err) {

--- a/internal/controller/tenantcluster/tenantcluster_controller.go
+++ b/internal/controller/tenantcluster/tenantcluster_controller.go
@@ -169,15 +169,14 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		// Don't fail the reconcile, just log - scaling is not critical path
 	}
 
-	// For Talos clusters, reconcile bootstrap config, apply-config to workers, and
-	// create talosconfig Secret for CLI access. This runs outside reconcileInfrastructure
-	// so it executes for Ready clusters too — workers may still be in maintenance mode
-	// even after the cluster reaches Ready phase.
+	// For Talos clusters, run apply-config and talosconfig as a safety net for Ready
+	// clusters (e.g. new workers from scaling). The primary apply-config happens in
+	// reconcileInfrastructure before addon installation.
 	if isTalosCluster(tc) {
 		if err := r.reconcileTalosBootstrap(ctx, tc, butlerConfig); err != nil {
 			logger.Error(err, "failed to reconcile Talos bootstrap")
 		}
-		if err := r.reconcileTalosApplyConfig(ctx, tc); err != nil {
+		if _, err := r.reconcileTalosApplyConfig(ctx, tc); err != nil {
 			logger.Error(err, "failed to apply Talos config to workers")
 		}
 		if err := r.reconcileTalosconfig(ctx, tc); err != nil {
@@ -329,6 +328,14 @@ func (r *Reconciler) reconcileInfrastructure(ctx context.Context, tc *butlerv1al
 			metav1.ConditionFalse, ReasonInfraProvisioning, "Infrastructure cluster is provisioning")
 	}
 
+	if workersReady {
+		r.setCondition(tc, butlerv1alpha1.TenantClusterConditionWorkersReady,
+			metav1.ConditionTrue, ReasonWorkersReady, "Workers are ready")
+	} else {
+		r.setCondition(tc, butlerv1alpha1.TenantClusterConditionWorkersReady,
+			metav1.ConditionFalse, ReasonWorkersProvisioning, "Workers are provisioning")
+	}
+
 	if controlPlaneReady {
 		r.setCondition(tc, butlerv1alpha1.TenantClusterConditionControlPlaneReady,
 			metav1.ConditionTrue, ReasonControlPlaneReady, "Control plane is ready")
@@ -336,20 +343,25 @@ func (r *Reconciler) reconcileInfrastructure(ctx context.Context, tc *butlerv1al
 		// For Talos clusters, create the bootstrap Secret and apply config to workers
 		// as soon as CP is ready. Bootstrap MUST happen here because CAPI Machines
 		// reference the Secret via dataSecretName and block until it exists.
-		// Apply-config also runs here so workers get configured during provisioning
-		// (before addon installation), not after the cluster reaches Ready phase.
+		// Config must be applied BEFORE addon installation — workers need to leave
+		// maintenance mode and join the cluster before Cilium and other addons can
+		// schedule pods on them.
 		if isTalosCluster(tc) {
 			if err := r.reconcileTalosBootstrap(ctx, tc, butlerConfig); err != nil {
 				logger.Error(err, "failed to reconcile Talos bootstrap")
 			}
-			if err := r.reconcileTalosApplyConfig(ctx, tc); err != nil {
+			allApplied, err := r.reconcileTalosApplyConfig(ctx, tc)
+			if err != nil {
 				logger.Error(err, "failed to apply Talos config to workers")
+			}
+			if !allApplied {
+				logger.Info("waiting for Talos config to be applied to all workers before installing addons")
+				return ctrl.Result{RequeueAfter: 15 * time.Second}, nil
 			}
 		}
 
-		// Install addons as soon as control plane is accessible
-		// Don't wait for workers - Cilium has tolerations for not-ready nodes
-		// Skip installation if already ready
+		// Install addons after workers have config applied (Talos) or as soon as
+		// control plane is accessible (non-Talos). Skip if already ready.
 		if tc.Status.Phase == butlerv1alpha1.TenantClusterPhaseReady {
 			return ctrl.Result{}, nil
 		}
@@ -364,14 +376,6 @@ func (r *Reconciler) reconcileInfrastructure(ctx context.Context, tc *butlerv1al
 	} else {
 		r.setCondition(tc, butlerv1alpha1.TenantClusterConditionControlPlaneReady,
 			metav1.ConditionFalse, ReasonInfraProvisioning, "Control plane is provisioning")
-	}
-
-	if workersReady {
-		r.setCondition(tc, butlerv1alpha1.TenantClusterConditionWorkersReady,
-			metav1.ConditionTrue, ReasonWorkersReady, "Workers are ready")
-	} else {
-		r.setCondition(tc, butlerv1alpha1.TenantClusterConditionWorkersReady,
-			metav1.ConditionFalse, ReasonWorkersProvisioning, "Workers are provisioning")
 	}
 
 	if !infraReady || !controlPlaneReady || !workersReady {
@@ -1478,12 +1482,15 @@ func (r *Reconciler) getExposureIP(ctx context.Context, butlerConfig *butlerv1al
 // reconcileTalosApplyConfig applies Talos machine configs to CAPI Machines in maintenance mode.
 // It discovers Machine IPs, checks whether config was already applied (via annotation),
 // and runs talosctl apply-config --insecure for each unconfigured Machine.
-func (r *Reconciler) reconcileTalosApplyConfig(ctx context.Context, tc *butlerv1alpha1.TenantCluster) error {
+// reconcileTalosApplyConfig applies Talos machine config to CAPI Machines via talosctl.
+// Returns (allApplied, error) where allApplied is true when all Machines with IPs
+// have their config applied (or are already configured).
+func (r *Reconciler) reconcileTalosApplyConfig(ctx context.Context, tc *butlerv1alpha1.TenantCluster) (bool, error) {
 	logger := log.FromContext(ctx)
 
 	tenantNS := tc.Status.TenantNamespace
 	if tenantNS == "" {
-		return nil
+		return false, nil
 	}
 
 	// Read bootstrap Secret to get the machine config
@@ -1491,34 +1498,35 @@ func (r *Reconciler) reconcileTalosApplyConfig(ctx context.Context, tc *butlerv1
 	bootstrapSecret := &corev1.Secret{}
 	if err := r.Get(ctx, types.NamespacedName{Name: secretName, Namespace: tenantNS}, bootstrapSecret); err != nil {
 		if apierrors.IsNotFound(err) {
-			return nil // Bootstrap Secret not ready yet
+			return false, nil // Bootstrap Secret not ready yet
 		}
-		return fmt.Errorf("failed to get bootstrap Secret: %w", err)
+		return false, fmt.Errorf("failed to get bootstrap Secret: %w", err)
 	}
 
 	machineConfig := bootstrapSecret.Data["value"]
 	if len(machineConfig) == 0 {
-		return fmt.Errorf("bootstrap Secret %s has empty machine config", secretName)
+		return false, fmt.Errorf("bootstrap Secret %s has empty machine config", secretName)
 	}
 
 	// Get CAPI Machine addresses
 	machines, err := talos.GetMachineAddresses(ctx, r.Client, tc.Name, tenantNS)
 	if err != nil {
-		return fmt.Errorf("getting Machine addresses: %w", err)
+		return false, fmt.Errorf("getting Machine addresses: %w", err)
 	}
 	if len(machines) == 0 {
-		logger.V(1).Info("no CAPI Machines with addresses found yet")
-		return nil
+		logger.Info("waiting for CAPI Machines to get IP addresses")
+		return false, nil
 	}
 
 	// Apply config to each Machine that hasn't been configured yet
 	talosClient := talos.NewClient()
-	var failCount int
+	var failCount, pendingCount int
 	for _, machine := range machines {
 		if machine.Annotations != nil && machine.Annotations["butler.butlerlabs.dev/talos-config-applied"] == "true" {
 			continue
 		}
 
+		pendingCount++
 		logger.Info("applying Talos config to Machine", "machine", machine.Name, "ip", machine.IP)
 		if err := talosClient.ApplyConfig(ctx, machine.IP, machineConfig); err != nil {
 			// "certificate required" means the node left maintenance mode and already has config.
@@ -1537,13 +1545,15 @@ func (r *Reconciler) reconcileTalosApplyConfig(ctx context.Context, tc *butlerv1
 		if err := r.annotateMachine(ctx, machine.Name, tenantNS); err != nil {
 			logger.Error(err, "failed to annotate Machine after config apply", "machine", machine.Name)
 		}
+		pendingCount--
 	}
 
 	if failCount > 0 && failCount == len(machines) {
-		return fmt.Errorf("failed to apply Talos config to all %d Machines", failCount)
+		return false, fmt.Errorf("failed to apply Talos config to all %d Machines", failCount)
 	}
 
-	return nil
+	allApplied := pendingCount == 0 && failCount == 0
+	return allApplied, nil
 }
 
 // annotateMachine adds the talos-config-applied annotation to a CAPI Machine.

--- a/internal/controller/tenantcluster/tenantcluster_controller.go
+++ b/internal/controller/tenantcluster/tenantcluster_controller.go
@@ -169,6 +169,18 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		// Don't fail the reconcile, just log - scaling is not critical path
 	}
 
+	// For Talos clusters, reconcile bootstrap config and apply-config to workers.
+	// This runs outside reconcileInfrastructure so it executes for Ready clusters too —
+	// workers may still be in maintenance mode even after the cluster reaches Ready phase.
+	if isTalosCluster(tc) {
+		if err := r.reconcileTalosBootstrap(ctx, tc, butlerConfig); err != nil {
+			logger.Error(err, "failed to reconcile Talos bootstrap")
+		}
+		if err := r.reconcileTalosApplyConfig(ctx, tc); err != nil {
+			logger.Error(err, "failed to apply Talos config to workers")
+		}
+	}
+
 	tc.Status.ObservedGeneration = tc.Generation
 	if err := r.Status().Update(ctx, tc); err != nil {
 		return ctrl.Result{}, err
@@ -316,19 +328,6 @@ func (r *Reconciler) reconcileInfrastructure(ctx context.Context, tc *butlerv1al
 	if controlPlaneReady {
 		r.setCondition(tc, butlerv1alpha1.TenantClusterConditionControlPlaneReady,
 			metav1.ConditionTrue, ReasonControlPlaneReady, "Control plane is ready")
-
-		// For Talos clusters, generate bootstrap Secret after control plane is ready.
-		// This creates the Talos machine config and kubeadm bootstrap token needed
-		// for workers to join. CAPI's dataSecretName mechanism waits for this Secret.
-		if isTalosCluster(tc) {
-			if err := r.reconcileTalosBootstrap(ctx, tc, butlerConfig); err != nil {
-				logger.Error(err, "failed to reconcile Talos bootstrap")
-				// Don't fail — requeue and retry
-			}
-			if err := r.reconcileTalosApplyConfig(ctx, tc); err != nil {
-				logger.Error(err, "failed to apply Talos config to workers")
-			}
-		}
 
 		// Install addons as soon as control plane is accessible
 		// Don't wait for workers - Cilium has tolerations for not-ready nodes

--- a/internal/controller/tenantcluster/tenantcluster_controller.go
+++ b/internal/controller/tenantcluster/tenantcluster_controller.go
@@ -333,6 +333,15 @@ func (r *Reconciler) reconcileInfrastructure(ctx context.Context, tc *butlerv1al
 		r.setCondition(tc, butlerv1alpha1.TenantClusterConditionControlPlaneReady,
 			metav1.ConditionTrue, ReasonControlPlaneReady, "Control plane is ready")
 
+		// For Talos clusters, create the bootstrap Secret as soon as CP is ready.
+		// This MUST happen inside reconcileInfrastructure because CAPI Machines
+		// reference this Secret via dataSecretName and will block until it exists.
+		if isTalosCluster(tc) {
+			if err := r.reconcileTalosBootstrap(ctx, tc, butlerConfig); err != nil {
+				logger.Error(err, "failed to reconcile Talos bootstrap")
+			}
+		}
+
 		// Install addons as soon as control plane is accessible
 		// Don't wait for workers - Cilium has tolerations for not-ready nodes
 		// Skip installation if already ready

--- a/internal/controller/tenantcluster/tenantcluster_controller.go
+++ b/internal/controller/tenantcluster/tenantcluster_controller.go
@@ -1876,9 +1876,9 @@ func (r *Reconciler) reconcileTalosBootstrap(ctx context.Context, tc *butlerv1al
 		},
 	}
 
-	if err := ctrl.SetControllerReference(tc, bootstrapSecret, r.Scheme); err != nil {
-		return fmt.Errorf("failed to set owner reference on bootstrap Secret: %w", err)
-	}
+	// Skip owner reference — TC is in butler-tenants namespace but bootstrap Secret
+	// is in the tenant namespace. Cross-namespace owner refs are disallowed.
+	// Labels track ownership instead.
 
 	if err := r.Create(ctx, bootstrapSecret); err != nil {
 		if apierrors.IsAlreadyExists(err) {

--- a/internal/controller/tenantcluster/tenantcluster_controller.go
+++ b/internal/controller/tenantcluster/tenantcluster_controller.go
@@ -169,15 +169,19 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		// Don't fail the reconcile, just log - scaling is not critical path
 	}
 
-	// For Talos clusters, reconcile bootstrap config and apply-config to workers.
-	// This runs outside reconcileInfrastructure so it executes for Ready clusters too —
-	// workers may still be in maintenance mode even after the cluster reaches Ready phase.
+	// For Talos clusters, reconcile bootstrap config, apply-config to workers, and
+	// create talosconfig Secret for CLI access. This runs outside reconcileInfrastructure
+	// so it executes for Ready clusters too — workers may still be in maintenance mode
+	// even after the cluster reaches Ready phase.
 	if isTalosCluster(tc) {
 		if err := r.reconcileTalosBootstrap(ctx, tc, butlerConfig); err != nil {
 			logger.Error(err, "failed to reconcile Talos bootstrap")
 		}
 		if err := r.reconcileTalosApplyConfig(ctx, tc); err != nil {
 			logger.Error(err, "failed to apply Talos config to workers")
+		}
+		if err := r.reconcileTalosconfig(ctx, tc); err != nil {
+			logger.Error(err, "failed to create talosconfig Secret")
 		}
 	}
 
@@ -1503,9 +1507,16 @@ func (r *Reconciler) reconcileTalosApplyConfig(ctx context.Context, tc *butlerv1
 
 		logger.Info("applying Talos config to Machine", "machine", machine.Name, "ip", machine.IP)
 		if err := talosClient.ApplyConfig(ctx, machine.IP, machineConfig); err != nil {
-			logger.Error(err, "failed to apply Talos config", "machine", machine.Name, "ip", machine.IP)
-			failCount++
-			continue
+			// "certificate required" means the node left maintenance mode and already has config.
+			// Treat as success and annotate.
+			if strings.Contains(err.Error(), "certificate required") {
+				logger.Info("node already configured (requires TLS client cert), marking as applied",
+					"machine", machine.Name, "ip", machine.IP)
+			} else {
+				logger.Error(err, "failed to apply Talos config", "machine", machine.Name, "ip", machine.IP)
+				failCount++
+				continue
+			}
 		}
 
 		// Annotate the Machine to mark config as applied
@@ -1516,11 +1527,6 @@ func (r *Reconciler) reconcileTalosApplyConfig(ctx context.Context, tc *butlerv1
 
 	if failCount > 0 && failCount == len(machines) {
 		return fmt.Errorf("failed to apply Talos config to all %d Machines", failCount)
-	}
-
-	// Create talosconfig Secret for CLI access
-	if err := r.reconcileTalosconfig(ctx, tc); err != nil {
-		logger.Error(err, "failed to create talosconfig Secret")
 	}
 
 	return nil


### PR DESCRIPTION
## Summary

- Gate addon installation on Talos config being applied to all workers — prevents Cilium from blocking on `--wait` while workers haven't joined yet
- Move talos reconciliation (bootstrap, apply-config, talosconfig) to run for Ready clusters too, not just during provisioning
- Handle already-configured nodes (`certificate required` = already left maintenance mode)
- Fix cross-namespace owner reference errors for bootstrap and talosconfig Secrets (TC in `butler-tenants`, Secrets in tenant namespace)
- Fix WorkersReady condition never being set (was bypassed by `return reconcileAddons()`)
- Reduce Traefik helm `--wait` timeout from 5m to 2m

## E2E Tested

Full lifecycle verified on butler-beta with Talos worker (KubeVirt provider, LB mode):
1. TC created → Steward TCP provisioned → CAPI Machine created
2. Controller waits for Machine IP (requeues every 15s)
3. Machine gets IP → `talosctl apply-config` runs → annotates Machine
4. Addon installation starts: Cilium (21s), cert-manager, Longhorn, MetalLB, Traefik
5. TC reaches Ready in single reconcile pass (no status conflicts)
6. Talosconfig Secret created with admin credentials from steward trustd-creds
7. CSR auto-approved, worker node Ready in tenant cluster

## Test plan

- [x] Fresh TC creation with `os.type: talos` reaches Ready
- [x] Bootstrap Secret created during provisioning (before addons)
- [x] Apply-config gates addon installation
- [x] Talosconfig Secret created with valid CA, admin cert, admin key
- [x] Machine annotated with `talos-config-applied: true`
- [x] WorkersReady condition appears in TC status
- [x] CSR approved for worker node
- [x] No cross-namespace owner reference errors
- [x] No status update conflicts