### PR TITLE
feat: elastic IPAM, quota enforcement, and MetalLB multi-range

### DIFF
--- a/internal/addons/installer.go
+++ b/internal/addons/installer.go
@@ -528,6 +528,60 @@ spec:
 	return nil
 }
 
+// UpdateMetalLBPool updates the MetalLB IPAddressPool with the given address ranges.
+// This is used by elastic IPAM to configure multiple address ranges.
+func (i *Installer) UpdateMetalLBPool(ctx context.Context, kubeconfig []byte, ranges []string) error {
+	logger := log.FromContext(ctx)
+
+	kubeconfigPath, cleanup, err := i.writeKubeconfig(kubeconfig)
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+
+	// Build addresses YAML list
+	var addressLines string
+	for _, r := range ranges {
+		addressLines += fmt.Sprintf("    - %s\n", r)
+	}
+
+	poolManifest := fmt.Sprintf(`apiVersion: metallb.io/v1beta1
+kind: IPAddressPool
+metadata:
+  name: default-pool
+  namespace: metallb-system
+spec:
+  addresses:
+%s---
+apiVersion: metallb.io/v1beta1
+kind: L2Advertisement
+metadata:
+  name: default
+  namespace: metallb-system
+spec:
+  ipAddressPools:
+    - default-pool
+`, addressLines)
+
+	tmpFile, err := os.CreateTemp("", "metallb-pool-*.yaml")
+	if err != nil {
+		return fmt.Errorf("failed to create temp file: %w", err)
+	}
+	defer os.Remove(tmpFile.Name())
+
+	if _, err := tmpFile.WriteString(poolManifest); err != nil {
+		return fmt.Errorf("failed to write pool manifest: %w", err)
+	}
+	tmpFile.Close()
+
+	if err := i.runKubectl(ctx, kubeconfigPath, "apply", "-f", tmpFile.Name()); err != nil {
+		return fmt.Errorf("failed to apply MetalLB pool: %w", err)
+	}
+
+	logger.Info("updated MetalLB IP pool", "ranges", ranges)
+	return nil
+}
+
 // InstallTraefik installs Traefik ingress controller.
 func (i *Installer) InstallTraefik(ctx context.Context, kubeconfig []byte, version string) error {
 	logger := log.FromContext(ctx)

--- a/internal/controller/networkpool/networkpool_controller.go
+++ b/internal/controller/networkpool/networkpool_controller.go
@@ -51,6 +51,7 @@ type Reconciler struct {
 // +kubebuilder:rbac:groups=butler.butlerlabs.dev,resources=networkpools/finalizers,verbs=update
 // +kubebuilder:rbac:groups=butler.butlerlabs.dev,resources=ipallocations,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=butler.butlerlabs.dev,resources=ipallocations/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=butler.butlerlabs.dev,resources=tenantclusters,verbs=get
 // +kubebuilder:rbac:groups="",resources=events,verbs=create;patch
 
 func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
@@ -103,6 +104,12 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		client.MatchingFields{"spec.poolRef.name": pool.Name},
 	); err != nil {
 		return ctrl.Result{}, err
+	}
+
+	// Garbage collect orphaned allocations (TenantCluster deleted but allocation remains)
+	if gcCount := r.gcOrphanedAllocations(ctx, pool, allocList); gcCount > 0 {
+		logger.Info("garbage collected orphaned allocations", "count", gcCount)
+		return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
 	}
 
 	// Process pending allocations (FIFO by creation timestamp)
@@ -413,6 +420,53 @@ func (r *Reconciler) updatePoolStatus(ctx context.Context, pool *butlerv1alpha1.
 	}
 
 	return r.Status().Update(ctx, pool)
+}
+
+// gcOrphanedAllocations deletes IPAllocations whose tenantClusterRef points
+// to a TenantCluster that no longer exists. Returns the number of allocations deleted.
+func (r *Reconciler) gcOrphanedAllocations(ctx context.Context, pool *butlerv1alpha1.NetworkPool, allocList *butlerv1alpha1.IPAllocationList) int {
+	logger := log.FromContext(ctx)
+	deleted := 0
+
+	for i := range allocList.Items {
+		alloc := &allocList.Items[i]
+
+		// Only GC allocated entries — pending/failed are transient
+		if alloc.Status.Phase != butlerv1alpha1.IPAllocationPhaseAllocated {
+			continue
+		}
+
+		// Skip allocations without a tenant cluster ref
+		ref := alloc.Spec.TenantClusterRef
+		if ref.Name == "" || ref.Namespace == "" {
+			continue
+		}
+
+		// Check if the referenced TenantCluster still exists
+		tc := &butlerv1alpha1.TenantCluster{}
+		err := r.Get(ctx, client.ObjectKey{Name: ref.Name, Namespace: ref.Namespace}, tc)
+		if err == nil {
+			continue // TC exists, allocation is valid
+		}
+		if !apierrors.IsNotFound(err) {
+			logger.Error(err, "failed to check TenantCluster existence", "name", ref.Name, "namespace", ref.Namespace)
+			continue
+		}
+
+		// TenantCluster is gone — delete the orphaned allocation
+		logger.Info("garbage collecting orphaned IPAllocation",
+			"allocation", alloc.Name, "tenant", ref.Name, "namespace", ref.Namespace)
+		if err := r.Delete(ctx, alloc); err != nil && !apierrors.IsNotFound(err) {
+			logger.Error(err, "failed to delete orphaned IPAllocation", "name", alloc.Name)
+			continue
+		}
+		r.Recorder.Eventf(pool, "Normal", "OrphanedAllocationGC",
+			"Garbage collected IPAllocation %s (TenantCluster %s/%s no longer exists)",
+			alloc.Name, ref.Namespace, ref.Name)
+		deleted++
+	}
+
+	return deleted
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/internal/controller/team/team_controller.go
+++ b/internal/controller/team/team_controller.go
@@ -25,6 +25,7 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -484,11 +485,43 @@ func (r *Reconciler) reconcileStatus(ctx context.Context, team *butlerv1alpha1.T
 	team.Status.ClusterCount = clusterCount
 
 	// Calculate resource usage
-	resourceUsage, err := r.calculateResourceUsage(ctx, team.Name)
+	resourceUsage, err := r.calculateResourceUsage(ctx, team)
 	if err != nil {
 		return err
 	}
 	team.Status.ResourceUsage = resourceUsage
+
+	// Set QuotaExceeded condition based on utilization
+	quotaExceeded := false
+	if usage := resourceUsage; usage != nil {
+		if usage.ClusterUtilization != nil && *usage.ClusterUtilization >= 100 {
+			quotaExceeded = true
+		}
+		if usage.NodeUtilization != nil && *usage.NodeUtilization >= 100 {
+			quotaExceeded = true
+		}
+		if usage.CPUUtilization != nil && *usage.CPUUtilization >= 100 {
+			quotaExceeded = true
+		}
+		if usage.MemoryUtilization != nil && *usage.MemoryUtilization >= 100 {
+			quotaExceeded = true
+		}
+	}
+	if quotaExceeded {
+		meta.SetStatusCondition(&team.Status.Conditions, metav1.Condition{
+			Type:    butlerv1alpha1.TeamConditionQuotaExceeded,
+			Status:  metav1.ConditionTrue,
+			Reason:  "QuotaExceeded",
+			Message: "Team has exceeded one or more resource quotas",
+		})
+	} else {
+		meta.SetStatusCondition(&team.Status.Conditions, metav1.Condition{
+			Type:    butlerv1alpha1.TeamConditionQuotaExceeded,
+			Status:  metav1.ConditionFalse,
+			Reason:  "WithinQuota",
+			Message: "Team is within resource quotas",
+		})
+	}
 
 	// Update observed generation
 	team.Status.ObservedGeneration = team.Generation
@@ -528,9 +561,9 @@ func (r *Reconciler) countTenantClusters(ctx context.Context, namespace string) 
 }
 
 // calculateResourceUsage calculates the total resource usage for all TenantClusters.
-func (r *Reconciler) calculateResourceUsage(ctx context.Context, namespace string) (*butlerv1alpha1.TeamResourceUsage, error) {
+func (r *Reconciler) calculateResourceUsage(ctx context.Context, team *butlerv1alpha1.Team) (*butlerv1alpha1.TeamResourceUsage, error) {
 	clusterList := &butlerv1alpha1.TenantClusterList{}
-	if err := r.List(ctx, clusterList, client.InNamespace(namespace)); err != nil {
+	if err := r.List(ctx, clusterList, client.InNamespace(team.Name)); err != nil {
 		return nil, err
 	}
 
@@ -539,11 +572,67 @@ func (r *Reconciler) calculateResourceUsage(ctx context.Context, namespace strin
 	}
 
 	var totalWorkers int32
+	totalCPU := resource.NewQuantity(0, resource.DecimalSI)
+	totalMemory := resource.NewQuantity(0, resource.BinarySI)
+	totalStorage := resource.NewQuantity(0, resource.BinarySI)
+
 	for _, cluster := range clusterList.Items {
-		totalWorkers += cluster.Spec.Workers.Replicas
-		// TODO: Calculate CPU and Memory from MachineTemplate when needed
+		replicas := cluster.Spec.Workers.Replicas
+		totalWorkers += replicas
+
+		mt := cluster.Spec.Workers.MachineTemplate
+		// CPU: int32 cores * replicas
+		cpuPerCluster := resource.NewQuantity(int64(mt.CPU)*int64(replicas), resource.DecimalSI)
+		totalCPU.Add(*cpuPerCluster)
+
+		// Memory: resource.Quantity * replicas
+		if !mt.Memory.IsZero() {
+			memPerNode := mt.Memory.DeepCopy()
+			for i := int32(0); i < replicas; i++ {
+				totalMemory.Add(memPerNode)
+			}
+		}
+
+		// Storage: resource.Quantity * replicas
+		if !mt.DiskSize.IsZero() {
+			diskPerNode := mt.DiskSize.DeepCopy()
+			for i := int32(0); i < replicas; i++ {
+				totalStorage.Add(diskPerNode)
+			}
+		}
 	}
+
 	usage.TotalNodes = totalWorkers
+
+	if !totalCPU.IsZero() {
+		usage.TotalCPU = totalCPU
+	}
+	if !totalMemory.IsZero() {
+		usage.TotalMemory = totalMemory
+	}
+	if !totalStorage.IsZero() {
+		usage.TotalStorage = totalStorage
+	}
+
+	// Compute utilization percentages against TeamResourceLimits
+	if limits := team.Spec.ResourceLimits; limits != nil {
+		if limits.MaxClusters != nil && *limits.MaxClusters > 0 {
+			pct := int32(int64(usage.Clusters) * 100 / int64(*limits.MaxClusters))
+			usage.ClusterUtilization = &pct
+		}
+		if limits.MaxTotalNodes != nil && *limits.MaxTotalNodes > 0 {
+			pct := int32(int64(totalWorkers) * 100 / int64(*limits.MaxTotalNodes))
+			usage.NodeUtilization = &pct
+		}
+		if limits.MaxCPUCores != nil && !limits.MaxCPUCores.IsZero() && usage.TotalCPU != nil {
+			pct := int32(usage.TotalCPU.Value() * 100 / limits.MaxCPUCores.Value())
+			usage.CPUUtilization = &pct
+		}
+		if limits.MaxMemory != nil && !limits.MaxMemory.IsZero() && usage.TotalMemory != nil {
+			pct := int32(usage.TotalMemory.Value() * 100 / limits.MaxMemory.Value())
+			usage.MemoryUtilization = &pct
+		}
+	}
 
 	return usage, nil
 }

--- a/internal/controller/tenantcluster/tenantcluster_controller.go
+++ b/internal/controller/tenantcluster/tenantcluster_controller.go
@@ -169,6 +169,12 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		// Don't fail the reconcile, just log - scaling is not critical path
 	}
 
+	// Elastic IPAM: grow/shrink LB IP allocations for Ready clusters
+	if err := r.reconcileElasticIPAM(ctx, tc, butlerConfig); err != nil {
+		logger.Error(err, "elastic IPAM reconciliation failed")
+		// Non-fatal: don't fail the reconcile
+	}
+
 	// For Talos clusters, run apply-config and talosconfig as a safety net for Ready
 	// clusters (e.g. new workers from scaling). The primary apply-config happens in
 	// reconcileInfrastructure before addon installation.
@@ -2063,7 +2069,16 @@ func (r *Reconciler) reconcileIPAllocation(ctx context.Context, tc *butlerv1alph
 	}
 
 	// Create new allocation — try pools in priority order
-	lbCount := r.getLBPoolSize(tc, pc)
+	lbCount := r.getInitialLBPoolSize(tc, pc)
+
+	// Enforce quota on initial allocation
+	if pc.Spec.Network.QuotaPerTenant != nil && pc.Spec.Network.QuotaPerTenant.MaxLoadBalancerIPs != nil {
+		maxLB := *pc.Spec.Network.QuotaPerTenant.MaxLoadBalancerIPs
+		if lbCount > maxLB {
+			lbCount = maxLB
+		}
+	}
+
 	allocName := fmt.Sprintf("%s-%s-lb", tc.Namespace, tc.Name)
 
 	for _, poolRef := range pc.Spec.Network.PoolRefs {
@@ -2089,9 +2104,10 @@ func (r *Reconciler) reconcileIPAllocation(ctx context.Context, tc *butlerv1alph
 				Name:      allocName,
 				Namespace: "butler-system",
 				Labels: map[string]string{
-					butlerv1alpha1.LabelNetworkPool: poolRef.Name,
-					butlerv1alpha1.LabelTeam:        tc.Namespace,
-					butlerv1alpha1.LabelTenant:      tc.Name,
+					butlerv1alpha1.LabelNetworkPool:    poolRef.Name,
+					butlerv1alpha1.LabelTeam:           tc.Namespace,
+					butlerv1alpha1.LabelTenant:         tc.Name,
+					butlerv1alpha1.LabelAllocationType: "loadbalancer",
 				},
 			},
 			Spec: butlerv1alpha1.IPAllocationSpec{
@@ -2126,23 +2142,273 @@ func (r *Reconciler) reconcileIPAllocation(ctx context.Context, tc *butlerv1alph
 	return false, nil
 }
 
-func (r *Reconciler) getLBPoolSize(tc *butlerv1alpha1.TenantCluster, pc *butlerv1alpha1.ProviderConfig) int32 {
+func (r *Reconciler) getInitialLBPoolSize(tc *butlerv1alpha1.TenantCluster, pc *butlerv1alpha1.ProviderConfig) int32 {
 	// TC override takes priority
 	if tc.Spec.Networking.LBPoolSize != nil {
 		return *tc.Spec.Networking.LBPoolSize
 	}
-	// Then provider default
-	if pc.Spec.Network != nil && pc.Spec.Network.LoadBalancer != nil && pc.Spec.Network.LoadBalancer.DefaultPoolSize != nil {
-		return *pc.Spec.Network.LoadBalancer.DefaultPoolSize
+	if pc.Spec.Network != nil && pc.Spec.Network.LoadBalancer != nil {
+		lb := pc.Spec.Network.LoadBalancer
+		if lb.AllocationMode == "elastic" {
+			if lb.InitialPoolSize != nil {
+				return *lb.InitialPoolSize
+			}
+			return 2
+		}
+		if lb.DefaultPoolSize != nil {
+			return *lb.DefaultPoolSize
+		}
 	}
 	return 8
 }
 
-// cleanupIPAllocations deletes IPAllocations referenced by the TenantCluster.
+func (r *Reconciler) isElasticIPAM(pc *butlerv1alpha1.ProviderConfig) bool {
+	return pc.Spec.Network != nil &&
+		pc.Spec.Network.Mode == "ipam" &&
+		pc.Spec.Network.LoadBalancer != nil &&
+		pc.Spec.Network.LoadBalancer.AllocationMode == "elastic"
+}
+
+func (r *Reconciler) getGrowthIncrement(pc *butlerv1alpha1.ProviderConfig) int32 {
+	if pc.Spec.Network != nil && pc.Spec.Network.LoadBalancer != nil && pc.Spec.Network.LoadBalancer.GrowthIncrement != nil {
+		return *pc.Spec.Network.LoadBalancer.GrowthIncrement
+	}
+	return 2
+}
+
+// listLBAllocations returns all LB IPAllocations for a given tenant cluster.
+func (r *Reconciler) listLBAllocations(ctx context.Context, tc *butlerv1alpha1.TenantCluster) ([]butlerv1alpha1.IPAllocation, error) {
+	allocList := &butlerv1alpha1.IPAllocationList{}
+	if err := r.List(ctx, allocList, client.InNamespace("butler-system"),
+		client.MatchingLabels{
+			butlerv1alpha1.LabelTeam:           tc.Namespace,
+			butlerv1alpha1.LabelTenant:         tc.Name,
+			butlerv1alpha1.LabelAllocationType: "loadbalancer",
+		}); err != nil {
+		return nil, err
+	}
+	return allocList.Items, nil
+}
+
+// countUsedLBIPs counts the number of LoadBalancer services with assigned IPs on a tenant cluster.
+func (r *Reconciler) countUsedLBIPs(ctx context.Context, kubeconfig []byte) (int32, error) {
+	restConfig, err := clientcmd.RESTConfigFromKubeConfig(kubeconfig)
+	if err != nil {
+		return 0, fmt.Errorf("failed to build REST config: %w", err)
+	}
+
+	clientset, err := kubernetes.NewForConfig(restConfig)
+	if err != nil {
+		return 0, fmt.Errorf("failed to create clientset: %w", err)
+	}
+
+	svcList, err := clientset.CoreV1().Services("").List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return 0, fmt.Errorf("failed to list services: %w", err)
+	}
+
+	var count int32
+	for _, svc := range svcList.Items {
+		if svc.Spec.Type != corev1.ServiceTypeLoadBalancer {
+			continue
+		}
+		for _, ing := range svc.Status.LoadBalancer.Ingress {
+			if ing.IP != "" {
+				count++
+				break
+			}
+		}
+	}
+	return count, nil
+}
+
+// reconcileElasticIPAM handles dynamic LB IP allocation growth and shrink for Ready clusters.
+func (r *Reconciler) reconcileElasticIPAM(ctx context.Context, tc *butlerv1alpha1.TenantCluster, butlerConfig *butlerv1alpha1.ButlerConfig) error {
+	if tc.Status.Phase != butlerv1alpha1.TenantClusterPhaseReady {
+		return nil
+	}
+
+	logger := log.FromContext(ctx)
+
+	pc, err := r.getProviderConfig(ctx, tc)
+	if err != nil {
+		return nil // Can't get provider, skip silently
+	}
+
+	if !r.isElasticIPAM(pc) {
+		return nil
+	}
+
+	// Get all LB allocations for this tenant
+	allocs, err := r.listLBAllocations(ctx, tc)
+	if err != nil {
+		return fmt.Errorf("failed to list LB allocations: %w", err)
+	}
+
+	if len(allocs) == 0 {
+		return nil // No allocations yet, initial allocation handles this
+	}
+
+	// Count total allocated and available IPs
+	var totalAllocated int32
+	for _, alloc := range allocs {
+		if alloc.Status.Phase == butlerv1alpha1.IPAllocationPhaseAllocated {
+			if alloc.Spec.Count != nil {
+				totalAllocated += *alloc.Spec.Count
+			}
+		}
+	}
+
+	// Count used IPs from tenant cluster
+	kubeconfig, err := r.getTenantKubeconfig(ctx, tc, butlerConfig)
+	if err != nil {
+		logger.V(1).Info("cannot get tenant kubeconfig for elastic IPAM, skipping", "error", err)
+		return nil
+	}
+
+	usedIPs, err := r.countUsedLBIPs(ctx, kubeconfig)
+	if err != nil {
+		logger.V(1).Info("cannot count used LB IPs, skipping", "error", err)
+		return nil
+	}
+
+	availableIPs := totalAllocated - usedIPs
+	growthIncrement := r.getGrowthIncrement(pc)
+
+	logger.V(1).Info("elastic IPAM status",
+		"totalAllocated", totalAllocated, "usedIPs", usedIPs,
+		"availableIPs", availableIPs, "growthIncrement", growthIncrement)
+
+	// Grow: if fewer than 1 IP is available
+	if availableIPs < 1 {
+		// Check quota
+		if pc.Spec.Network.QuotaPerTenant != nil && pc.Spec.Network.QuotaPerTenant.MaxLoadBalancerIPs != nil {
+			maxLB := *pc.Spec.Network.QuotaPerTenant.MaxLoadBalancerIPs
+			if totalAllocated+growthIncrement > maxLB {
+				logger.Info("elastic IPAM growth blocked by quota",
+					"totalAllocated", totalAllocated, "maxLB", maxLB)
+				return nil
+			}
+		}
+
+		// Find next allocation index
+		nextIdx := len(allocs)
+		allocName := fmt.Sprintf("%s-%s-lb-%d", tc.Namespace, tc.Name, nextIdx)
+
+		// Find a pool with capacity
+		for _, poolRef := range pc.Spec.Network.PoolRefs {
+			pool := &butlerv1alpha1.NetworkPool{}
+			if err := r.Get(ctx, types.NamespacedName{
+				Name: poolRef.Name, Namespace: "butler-system",
+			}, pool); err != nil {
+				continue
+			}
+			if pool.Status.AvailableIPs < growthIncrement {
+				continue
+			}
+
+			alloc := &butlerv1alpha1.IPAllocation{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      allocName,
+					Namespace: "butler-system",
+					Labels: map[string]string{
+						butlerv1alpha1.LabelNetworkPool:    poolRef.Name,
+						butlerv1alpha1.LabelTeam:           tc.Namespace,
+						butlerv1alpha1.LabelTenant:         tc.Name,
+						butlerv1alpha1.LabelAllocationType: "loadbalancer",
+					},
+				},
+				Spec: butlerv1alpha1.IPAllocationSpec{
+					PoolRef:          butlerv1alpha1.LocalObjectReference{Name: poolRef.Name},
+					TenantClusterRef: butlerv1alpha1.NamespacedObjectReference{Name: tc.Name, Namespace: tc.Namespace},
+					Type:             butlerv1alpha1.IPAllocationTypeLoadBalancer,
+					Count:            &growthIncrement,
+				},
+			}
+
+			if err := r.Create(ctx, alloc); err != nil {
+				if apierrors.IsAlreadyExists(err) {
+					return nil // Already created
+				}
+				return fmt.Errorf("failed to create growth allocation: %w", err)
+			}
+			logger.Info("elastic IPAM: created growth allocation",
+				"allocation", allocName, "pool", poolRef.Name, "count", growthIncrement)
+			break
+		}
+	}
+
+	// Shrink: if we have more than 1 allocation and enough spare IPs
+	if len(allocs) > 1 && availableIPs > growthIncrement {
+		// Find the newest allocation that is fully unused and older than 10 minutes
+		var shrinkCandidate *butlerv1alpha1.IPAllocation
+		for i := len(allocs) - 1; i >= 1; i-- { // Skip index 0 (initial allocation)
+			alloc := &allocs[i]
+			if alloc.Status.Phase != butlerv1alpha1.IPAllocationPhaseAllocated {
+				continue
+			}
+			if alloc.Spec.Count == nil {
+				continue
+			}
+			// Only shrink allocations older than 10 minutes to avoid thrashing
+			if time.Since(alloc.CreationTimestamp.Time) < 10*time.Minute {
+				continue
+			}
+			shrinkCandidate = alloc
+			break
+		}
+
+		if shrinkCandidate != nil {
+			logger.Info("elastic IPAM: shrinking unused allocation",
+				"allocation", shrinkCandidate.Name, "availableIPs", availableIPs)
+			if err := r.Delete(ctx, shrinkCandidate); err != nil && !apierrors.IsNotFound(err) {
+				return fmt.Errorf("failed to delete shrink allocation: %w", err)
+			}
+		}
+	}
+
+	// Update MetalLB pool with all current allocated ranges
+	if err := r.updateMetalLBPool(ctx, tc, butlerConfig, allocs); err != nil {
+		logger.Error(err, "failed to update MetalLB pool")
+	}
+
+	return nil
+}
+
+// updateMetalLBPool configures MetalLB on the tenant cluster with all allocated IP ranges.
+func (r *Reconciler) updateMetalLBPool(ctx context.Context, tc *butlerv1alpha1.TenantCluster, butlerConfig *butlerv1alpha1.ButlerConfig, allocs []butlerv1alpha1.IPAllocation) error {
+	var ranges []string
+	for _, alloc := range allocs {
+		if alloc.Status.Phase != butlerv1alpha1.IPAllocationPhaseAllocated {
+			continue
+		}
+		if alloc.Status.StartAddress != "" && alloc.Status.EndAddress != "" {
+			ranges = append(ranges, fmt.Sprintf("%s-%s", alloc.Status.StartAddress, alloc.Status.EndAddress))
+		} else if alloc.Status.CIDR != "" {
+			ranges = append(ranges, alloc.Status.CIDR)
+		}
+	}
+
+	if len(ranges) == 0 {
+		return nil
+	}
+
+	kubeconfig, err := r.getTenantKubeconfig(ctx, tc, butlerConfig)
+	if err != nil {
+		return err
+	}
+
+	return r.Installer.UpdateMetalLBPool(ctx, kubeconfig, ranges)
+}
+
+// cleanupIPAllocations deletes IPAllocations referenced by the TenantCluster
+// and any additional elastic allocations discovered by labels.
 func (r *Reconciler) cleanupIPAllocations(ctx context.Context, tc *butlerv1alpha1.TenantCluster) {
 	logger := log.FromContext(ctx)
 
+	// Delete referenced allocations
 	refs := []*butlerv1alpha1.LocalObjectReference{tc.Status.IPAllocationRef, tc.Status.LBAllocationRef}
+	deleted := make(map[string]bool)
 	for _, ref := range refs {
 		if ref == nil {
 			continue
@@ -2158,6 +2424,29 @@ func (r *Reconciler) cleanupIPAllocations(ctx context.Context, tc *butlerv1alpha
 			logger.Error(err, "failed to delete IPAllocation", "name", ref.Name)
 		} else {
 			logger.Info("deleted IPAllocation during cleanup", "name", ref.Name)
+		}
+		deleted[ref.Name] = true
+	}
+
+	// Also clean up any elastic growth allocations discovered by labels
+	allocList := &butlerv1alpha1.IPAllocationList{}
+	if err := r.List(ctx, allocList, client.InNamespace("butler-system"),
+		client.MatchingLabels{
+			butlerv1alpha1.LabelTeam:   tc.Namespace,
+			butlerv1alpha1.LabelTenant: tc.Name,
+		}); err != nil {
+		logger.Error(err, "failed to list IPAllocations for cleanup")
+		return
+	}
+	for i := range allocList.Items {
+		alloc := &allocList.Items[i]
+		if deleted[alloc.Name] {
+			continue
+		}
+		if err := r.Delete(ctx, alloc); err != nil && !apierrors.IsNotFound(err) {
+			logger.Error(err, "failed to delete elastic IPAllocation", "name", alloc.Name)
+		} else {
+			logger.Info("deleted elastic IPAllocation during cleanup", "name", alloc.Name)
 		}
 	}
 }

--- a/internal/webhook/tenantcluster_webhook.go
+++ b/internal/webhook/tenantcluster_webhook.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -168,6 +169,104 @@ func (v *TenantClusterValidator) validateCreateUpdate(ctx context.Context, tc *b
 					totalNodes, pc.Name, maxNodes,
 				),
 			))
+		}
+	}
+
+	// Enforce team-level CPU, Memory, and Storage quotas.
+	if tc.Spec.TeamRef != nil {
+		team := &butlerv1alpha1.Team{}
+		if err := v.Client.Get(ctx, types.NamespacedName{Name: tc.Spec.TeamRef.Name}, team); err == nil {
+			if limits := team.Spec.ResourceLimits; limits != nil {
+				// List existing clusters for resource accounting
+				var tcList butlerv1alpha1.TenantClusterList
+				if err := v.Client.List(ctx, &tcList, client.InNamespace(tc.Namespace)); err == nil {
+					mt := tc.Spec.Workers.MachineTemplate
+					replicas := tc.Spec.Workers.Replicas
+
+					// CPU quota check
+					if limits.MaxCPUCores != nil && !limits.MaxCPUCores.IsZero() {
+						requestedCPU := resource.NewQuantity(int64(mt.CPU)*int64(replicas), resource.DecimalSI)
+						currentCPU := resource.NewQuantity(0, resource.DecimalSI)
+						for i := range tcList.Items {
+							if tcList.Items[i].Name != tc.Name {
+								other := tcList.Items[i]
+								otherCPU := resource.NewQuantity(
+									int64(other.Spec.Workers.MachineTemplate.CPU)*int64(other.Spec.Workers.Replicas),
+									resource.DecimalSI,
+								)
+								currentCPU.Add(*otherCPU)
+							}
+						}
+						totalCPU := currentCPU.DeepCopy()
+						totalCPU.Add(*requestedCPU)
+						if totalCPU.Cmp(*limits.MaxCPUCores) > 0 {
+							allErrs = append(allErrs, field.Forbidden(
+								field.NewPath("spec", "workers"),
+								fmt.Sprintf(
+									"total CPU (%s) would exceed team %q CPU quota (%s)",
+									totalCPU.String(), team.Name, limits.MaxCPUCores.String(),
+								),
+							))
+						}
+					}
+
+					// Memory quota check
+					if limits.MaxMemory != nil && !limits.MaxMemory.IsZero() {
+						requestedMemory := resource.NewQuantity(0, resource.BinarySI)
+						for i := int32(0); i < replicas; i++ {
+							requestedMemory.Add(mt.Memory)
+						}
+						currentMemory := resource.NewQuantity(0, resource.BinarySI)
+						for i := range tcList.Items {
+							if tcList.Items[i].Name != tc.Name {
+								other := tcList.Items[i]
+								for j := int32(0); j < other.Spec.Workers.Replicas; j++ {
+									currentMemory.Add(other.Spec.Workers.MachineTemplate.Memory)
+								}
+							}
+						}
+						totalMemory := currentMemory.DeepCopy()
+						totalMemory.Add(*requestedMemory)
+						if totalMemory.Cmp(*limits.MaxMemory) > 0 {
+							allErrs = append(allErrs, field.Forbidden(
+								field.NewPath("spec", "workers"),
+								fmt.Sprintf(
+									"total memory (%s) would exceed team %q memory quota (%s)",
+									totalMemory.String(), team.Name, limits.MaxMemory.String(),
+								),
+							))
+						}
+					}
+
+					// Storage quota check
+					if limits.MaxStorage != nil && !limits.MaxStorage.IsZero() {
+						requestedStorage := resource.NewQuantity(0, resource.BinarySI)
+						for i := int32(0); i < replicas; i++ {
+							requestedStorage.Add(mt.DiskSize)
+						}
+						currentStorage := resource.NewQuantity(0, resource.BinarySI)
+						for i := range tcList.Items {
+							if tcList.Items[i].Name != tc.Name {
+								other := tcList.Items[i]
+								for j := int32(0); j < other.Spec.Workers.Replicas; j++ {
+									currentStorage.Add(other.Spec.Workers.MachineTemplate.DiskSize)
+								}
+							}
+						}
+						totalStorage := currentStorage.DeepCopy()
+						totalStorage.Add(*requestedStorage)
+						if totalStorage.Cmp(*limits.MaxStorage) > 0 {
+							allErrs = append(allErrs, field.Forbidden(
+								field.NewPath("spec", "workers"),
+								fmt.Sprintf(
+									"total storage (%s) would exceed team %q storage quota (%s)",
+									totalStorage.String(), team.Name, limits.MaxStorage.String(),
+								),
+							))
+						}
+					}
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary
- Add elastic LB IP allocation in tenant cluster reconciler (grow/shrink based on service count)
- Add per-tenant network quota enforcement (MaxNodeIPs, MaxLoadBalancerIPs)
- Add MetalLB multi-range IPAddressPool support for split node/LB allocations
- Add team-level resource quota enforcement in team controller
- Add NetworkPool controller capacity tracking and fragmentation metrics
- Add TenantCluster validating webhook for quota checks at admission time

## Changed Files
- `internal/controller/tenantcluster/tenantcluster_controller.go` — Elastic IPAM + quota enforcement
- `internal/controller/networkpool/networkpool_controller.go` — Capacity tracking
- `internal/controller/team/team_controller.go` — Team resource quota enforcement
- `internal/addons/installer.go` — MetalLB multi-range pool configuration
- `internal/webhook/tenantcluster_webhook.go` — Admission quota validation

## Dependencies
- Requires `butler-api` feat/elastic-ipam branch (elastic IPAM types)

## Test plan
- [ ] `go build ./...` succeeds
- [ ] `make test` passes
- [ ] `make lint` passes
- [ ] Elastic allocation: create tenant → uses InitialPoolSize → add services → grows by GrowthIncrement
- [ ] Quota enforcement: exceed MaxLoadBalancerIPs → webhook rejects