### PR TITLE
feat: add TenantAddon value merging and ValuesJSON support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/butlerdotdev/butler-controller
 go 1.24.6
 
 require (
-	github.com/butlerdotdev/butler-api v0.3.1-0.20260215211731-ce8b92b32168
+	github.com/butlerdotdev/butler-api v0.4.1-0.20260228030305-140667362f7c
 	github.com/onsi/ginkgo/v2 v2.22.0
 	github.com/onsi/gomega v1.36.1
 	github.com/prometheus/client_golang v1.22.0

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
-github.com/butlerdotdev/butler-api v0.3.1-0.20260215211731-ce8b92b32168 h1:pQ4d7U1lH4nNSfPb6X0z68BhcInQKp09iKSNtgx+P8c=
-github.com/butlerdotdev/butler-api v0.3.1-0.20260215211731-ce8b92b32168/go.mod h1:q/RjPFM/r2ELq4DqR78OiAxerKBvH5D4nTGsVLKbjqY=
+github.com/butlerdotdev/butler-api v0.4.1-0.20260228030305-140667362f7c h1:AFEK56foqZf82tEG39PFHU0yaso+PrHhE3u7LXZVPZk=
+github.com/butlerdotdev/butler-api v0.4.1-0.20260228030305-140667362f7c/go.mod h1:q/RjPFM/r2ELq4DqR78OiAxerKBvH5D4nTGsVLKbjqY=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/internal/addons/installer.go
+++ b/internal/addons/installer.go
@@ -54,6 +54,7 @@ type ChartInstallOptions struct {
 	Namespace   string            // e.g., "velero"
 	Version     string            // e.g., "7.2.1"
 	Values      map[string]string // Optional helm --set values
+	ValuesJSON  []byte            // Optional JSON values written to temp file and passed via --values
 	Timeout     string            // Optional, defaults to "10m"
 }
 
@@ -673,6 +674,21 @@ func (i *Installer) InstallChart(ctx context.Context, kubeconfig []byte, opts Ch
 		"--version", opts.Version,
 		"--wait",
 		"--timeout", timeout,
+	}
+
+	// Add JSON values file if provided
+	if len(opts.ValuesJSON) > 0 {
+		valuesFile, err := os.CreateTemp("", "helm-values-*.json")
+		if err != nil {
+			return fmt.Errorf("failed to create values file: %w", err)
+		}
+		defer os.Remove(valuesFile.Name())
+		if _, err := valuesFile.Write(opts.ValuesJSON); err != nil {
+			valuesFile.Close()
+			return fmt.Errorf("failed to write values file: %w", err)
+		}
+		valuesFile.Close()
+		args = append(args, "--values", valuesFile.Name())
 	}
 
 	// Add any custom values

--- a/internal/controller/tenantaddon/tenantaddon_controller.go
+++ b/internal/controller/tenantaddon/tenantaddon_controller.go
@@ -18,6 +18,7 @@ package tenantaddon
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
@@ -152,6 +153,13 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		"namespace", addonDef.GetNamespace(),
 		"release", addonDef.GetReleaseName())
 
+	// Merge AddonDefinition defaults with TenantAddon spec values (spec overrides defaults)
+	mergedValues, err := mergeValues(addonDef.Spec.Defaults.Values, addon.Spec.Values)
+	if err != nil {
+		logger.Error(err, "failed to merge values")
+		return r.setFailedStatus(ctx, req, ReasonInstallFailed, "failed to merge values: "+err.Error())
+	}
+
 	if err := r.Installer.InstallChart(ctx, kubeconfig, addons.ChartInstallOptions{
 		RepoName:    "butler-" + addon.Spec.Addon,
 		RepoURL:     addonDef.Spec.Chart.Repository,
@@ -159,7 +167,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		ReleaseName: addonDef.GetReleaseName(),
 		Namespace:   addonDef.GetNamespace(),
 		Version:     version,
-		Values:      nil, // TODO: merge addon.Spec.Values with addonDef.Spec.Defaults.Values
+		ValuesJSON:  mergedValues,
 	}); err != nil {
 		logger.Error(err, "failed to install addon")
 		return r.setFailedStatus(ctx, req, ReasonInstallFailed, err.Error())
@@ -373,6 +381,46 @@ func (r *Reconciler) setPendingStatus(ctx context.Context, req ctrl.Request, rea
 	}
 
 	return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
+}
+
+// mergeValues merges AddonDefinition default values with TenantAddon spec values.
+// Spec values take precedence over defaults via deep merge.
+func mergeValues(defaults, overrides *butlerv1alpha1.ExtensionValues) ([]byte, error) {
+	defaultMap, err := defaults.ToMap()
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse default values: %w", err)
+	}
+	overrideMap, err := overrides.ToMap()
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse override values: %w", err)
+	}
+
+	if defaultMap == nil && overrideMap == nil {
+		return nil, nil
+	}
+
+	merged := make(map[string]interface{})
+	for k, v := range defaultMap {
+		merged[k] = v
+	}
+	deepMerge(merged, overrideMap)
+
+	return json.Marshal(merged)
+}
+
+// deepMerge recursively merges src into dst. src values override dst.
+func deepMerge(dst, src map[string]interface{}) {
+	for k, srcVal := range src {
+		if dstVal, exists := dst[k]; exists {
+			srcMap, srcOk := srcVal.(map[string]interface{})
+			dstMap, dstOk := dstVal.(map[string]interface{})
+			if srcOk && dstOk {
+				deepMerge(dstMap, srcMap)
+				continue
+			}
+		}
+		dst[k] = srcVal
+	}
 }
 
 // SetupWithManager sets up the controller with the Manager.


### PR DESCRIPTION
## Summary

- Add deep merge of AddonDefinition default values with TenantAddon spec overrides, so observability addons (otel-collector, vector-agent, etc.) ship with sensible defaults that operators can customize per-cluster
- Add `ValuesJSON` field to `ChartInstallOptions` that writes structured JSON values to a temp file and passes via `helm --values`, complementing the existing `--set key=value` approach
- Update butler-api dependency to include observability types and ExtensionValues helpers

## Test plan

- [ ] `CGO_ENABLED=0 go vet ./internal/...` passes
- [ ] TenantAddon with both AddonDefinition defaults and spec overrides installs with merged values
- [ ] TenantAddon with only defaults (no overrides) works correctly
- [ ] TenantAddon with only overrides (no defaults) works correctly
- [ ] TenantAddon with neither defaults nor overrides skips --values flag