### PR TITLE
fix: use ubuntu-latest for multi-arch image builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
   image:
     needs: build
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: butler-runners
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.24-alpine AS builder
+FROM --platform=$BUILDPLATFORM golang:1.24-alpine AS builder
 ARG TARGETOS
 ARG TARGETARCH
 WORKDIR /workspace
@@ -16,18 +16,19 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o ma
 
 # Final image with tools
 FROM alpine:3.21
+ARG TARGETARCH
 
 # Install kubectl, helm, and talosctl
 ARG KUBECTL_VERSION=v1.31.2
 ARG HELM_VERSION=v3.17.0
 ARG TALOS_VERSION=v1.9.3
 RUN apk add --no-cache ca-certificates curl bash && \
-    curl -Lo /usr/local/bin/kubectl "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl" && \
+    curl -Lo /usr/local/bin/kubectl "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${TARGETARCH}/kubectl" && \
     chmod +x /usr/local/bin/kubectl && \
-    curl -fsSL "https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz" | tar xz && \
-    mv linux-amd64/helm /usr/local/bin/helm && \
-    rm -rf linux-amd64 && \
-    curl -fsSL "https://github.com/siderolabs/talos/releases/download/${TALOS_VERSION}/talosctl-linux-amd64" \
+    curl -fsSL "https://get.helm.sh/helm-${HELM_VERSION}-linux-${TARGETARCH}.tar.gz" | tar xz && \
+    mv linux-${TARGETARCH}/helm /usr/local/bin/helm && \
+    rm -rf linux-${TARGETARCH} && \
+    curl -fsSL "https://github.com/siderolabs/talos/releases/download/${TALOS_VERSION}/talosctl-linux-${TARGETARCH}" \
       -o /usr/local/bin/talosctl && \
     chmod +x /usr/local/bin/talosctl
 


### PR DESCRIPTION
## Summary
- Move `image` CI job from `butler-runners` to `ubuntu-latest` — self-hosted Talos runners lack `binfmt_misc` kernel module needed by `docker/setup-qemu-action` for cross-platform builds
- Add `--platform=$BUILDPLATFORM` to Dockerfile builder stage for native Go cross-compilation (avoids QEMU emulation during compile)
- Use `$TARGETARCH` for kubectl, helm, and talosctl downloads so arm64 images get correct binaries

## Test plan
- [ ] CI image job runs on ubuntu-latest and completes successfully
- [ ] Multi-arch image (amd64 + arm64) pushed to GHCR