### PR TITLE
fix: use correct labels on auto-enrolled TenantAddons

### DIFF
--- a/internal/controller/tenantcluster/tenantcluster_controller.go
+++ b/internal/controller/tenantcluster/tenantcluster_controller.go
@@ -643,10 +643,11 @@ func (r *Reconciler) ensureAutoEnrolledAddon(ctx context.Context, tc *butlerv1al
 			Name:      addonName,
 			Namespace: tc.Namespace,
 			Labels: map[string]string{
-				butlerv1alpha1.LabelManagedBy:         "butler",
-				butlerv1alpha1.LabelTeam:              tc.Labels[butlerv1alpha1.LabelTeam],
-				butlerv1alpha1.LabelTenant:            tc.Name,
-				"butler.butlerlabs.dev/auto-enrolled": "true",
+				butlerv1alpha1.LabelManagedBy:              "butler",
+				butlerv1alpha1.LabelTeam:                   tc.Labels[butlerv1alpha1.LabelTeam],
+				"butler.butlerlabs.dev/cluster":            tc.Name,
+				"butler.butlerlabs.dev/addon-definition":   addonDefName,
+				"butler.butlerlabs.dev/auto-enrolled":      "true",
 			},
 		},
 		Spec: butlerv1alpha1.TenantAddonSpec{


### PR DESCRIPTION
## Summary

- Auto-enrolled TenantAddons were created with `butler.butlerlabs.dev/tenant` label but the server lists addons using `butler.butlerlabs.dev/cluster`
- This made auto-enrolled addons invisible in the API and console fleet table
- Added `butler.butlerlabs.dev/addon-definition` label to match manually-created addons

## Test plan

- [ ] Delete existing auto-enrolled addons on butler-beta (wrong labels)
- [ ] Deploy new image, trigger reconcile
- [ ] Verify new auto-enrolled addons appear in console fleet table