### PR TITLE
fix: use uri instead of address for vector-agent http sink

### DIFF
--- a/internal/controller/tenantcluster/tenantcluster_controller.go
+++ b/internal/controller/tenantcluster/tenantcluster_controller.go
@@ -21,7 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"gopkg.in/yaml.v3"
-	"net/url"
+
 	"strings"
 	"time"
 
@@ -687,16 +687,11 @@ func buildVectorAgentValues(pipeline *butlerv1alpha1.ObservabilityPipelineConfig
 		return nil
 	}
 
-	host := pipeline.LogEndpoint
-	if u, err := url.Parse(pipeline.LogEndpoint); err == nil && u.Hostname() != "" {
-		host = u.Hostname()
-	}
-
 	values := map[string]interface{}{
 		"customConfig": map[string]interface{}{
 			"sinks": map[string]interface{}{
 				"aggregator": map[string]interface{}{
-					"address": fmt.Sprintf("%s:6000", host),
+					"uri": pipeline.LogEndpoint,
 				},
 			},
 		},


### PR DESCRIPTION
## Summary

- The vector-agent auto-enroll was setting an `address` field on the aggregator sink, but the sink type is `http` which uses `uri`
- This caused agents to not forward logs to the pipeline aggregator (port 6000 was never exposed, and `address` is the wrong field for http sinks)
- Now uses the `logEndpoint` from ButlerConfig directly as the sink `uri`, matching the AddonDefinition default config

## Test plan

- [ ] Deploy to butler-beta, delete existing auto-enrolled vector-agent addons so they recreate with corrected values
- [ ] Verify vector-agent pods connect to aggregator on port 8080
- [ ] Verify logs appear in Victoria Logs