### PR TITLE
docs: add branding and replace Kamaji with Steward

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,24 @@
-# butler-controller
+<p align="center">
+  <img src="https://raw.githubusercontent.com/butlerdotdev/butler/main/assets/mascots/butler.png" alt="Butler" width="150"/>
+</p>
 
-[![Release](https://img.shields.io/github/v/release/butlerdotdev/butler-controller)](https://github.com/butlerdotdev/butler-controller/releases)
-[![License](https://img.shields.io/github/license/butlerdotdev/butler-controller)](LICENSE)
-[![Go Version](https://img.shields.io/github/go-mod/go-version/butlerdotdev/butler-controller)](go.mod)
+<h1 align="center">Butler Controller</h1>
 
-Kubernetes controller for managing tenant clusters on the Butler platform.
+<p align="center">
+  Tenant cluster lifecycle and addon management controller for the <a href="https://github.com/butlerdotdev/butler">Butler</a> platform.
+</p>
+
+<p align="center">
+  <a href="https://github.com/butlerdotdev/butler-controller/releases"><img src="https://img.shields.io/github/v/release/butlerdotdev/butler-controller" alt="Release"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/github/license/butlerdotdev/butler-controller" alt="License"></a>
+  <img src="https://img.shields.io/github/go-mod/go-version/butlerdotdev/butler-controller" alt="Go Version">
+</p>
+
+<p align="center">
+  <a href="https://github.com/butlerdotdev/butler">Butler</a> · <a href="https://docs.butlerlabs.dev">Docs</a> · <a href="https://butlerlabs.dev">Website</a>
+</p>
+
+---
 
 ## Table of Contents
 

--- a/README.md
+++ b/README.md
@@ -34,12 +34,12 @@
 
 butler-controller is the core controller responsible for tenant cluster lifecycle management in the Butler platform. It handles:
 
-- **Tenant Cluster Provisioning**: Creates and manages Kubernetes clusters using CAPI and Kamaji
+- **Tenant Cluster Provisioning**: Creates and manages Kubernetes clusters using CAPI and Steward
 - **Multi-Tenancy**: Team-based isolation with RBAC and resource quotas
 - **Addon Management**: Installs and manages cluster addons (CNI, storage, ingress, etc.)
 - **GitOps Integration**: Optional Flux bootstrap for declarative cluster management
 
-butler-controller runs in the Butler management cluster and watches for TenantCluster custom resources. When a TenantCluster is created, the controller orchestrates VM provisioning, control plane setup via Kamaji, worker node joining, and addon installation.
+butler-controller runs in the Butler management cluster and watches for TenantCluster custom resources. When a TenantCluster is created, the controller orchestrates VM provisioning, control plane setup via Steward, worker node joining, and addon installation.
 
 ## Architecture
 
@@ -48,14 +48,14 @@ flowchart TD
     subgraph MC[Management Cluster]
         BC[butler-controller]
         CAPI[Cluster API]
-        Kamaji[Kamaji]
+        Steward[Steward]
         
         BC -->|Creates| TC[TenantCluster CR]
         BC -->|Creates| CAPIC[CAPI Cluster]
-        BC -->|Creates| KCP[KamajiControlPlane]
+        BC -->|Creates| SCP[StewardControlPlane]
         BC -->|Creates| MD[MachineDeployment]
         
-        Kamaji -->|Hosts| API[Tenant API Server]
+        Steward -->|Hosts| API[Tenant API Server]
     end
     
     subgraph TC1[Tenant Cluster]
@@ -77,10 +77,10 @@ flowchart TD
 |------------|---------|----------------|
 | ButlerConfigReconciler | ButlerConfig | Platform-wide configuration singleton |
 | TeamReconciler | Team | Creates namespaces and RBAC for teams |
-| TenantClusterReconciler | TenantCluster | Full cluster lifecycle (CAPI, Kamaji, addons) |
+| TenantClusterReconciler | TenantCluster | Full cluster lifecycle (CAPI, Steward, addons) |
 | TenantAddonReconciler | TenantAddon | Post-creation addon management |
-| KamajiSecretReconciler | Secrets | Kubeconfig format translation for CAPI |
-| KamajiStatusReconciler | TenantControlPlane | CAPI status synchronization |
+| StewardSecretReconciler | Secrets | Kubeconfig format translation for CAPI |
+| StewardStatusReconciler | TenantControlPlane | CAPI status synchronization |
 
 ## Custom Resources
 
@@ -193,7 +193,7 @@ Team/acme (cluster-scoped)
     ├── TenantCluster/production
     │   └── Creates: Namespace/production-a7b8c9
     │       ├── CAPI Cluster
-    │       ├── KamajiControlPlane
+    │       ├── StewardControlPlane
     │       └── MachineDeployment
     ├── TenantCluster/staging
     └── TenantAddon/production-argocd


### PR DESCRIPTION
## Summary

- Add Butler mascot, badges, and ecosystem navigation links to README header
- Replace all Kamaji references with Steward in architecture diagram, controller table, and descriptions
- Update mermaid diagram node names (KamajiControlPlane -> StewardControlPlane)

## Checklist

- [x] I have read the CONTRIBUTING guide
- [x] I have signed off my commits (DCO)