### PR TITLE
feat: configurable control plane resources

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/butlerdotdev/butler-controller
 go 1.24.6
 
 require (
-	github.com/butlerdotdev/butler-api v0.4.1-0.20260303164109-066beaa85548
+	github.com/butlerdotdev/butler-api v0.5.0
 	github.com/onsi/ginkgo/v2 v2.22.0
 	github.com/onsi/gomega v1.36.1
 	github.com/prometheus/client_golang v1.22.0

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/butlerdotdev/butler-controller
 go 1.24.6
 
 require (
-	github.com/butlerdotdev/butler-api v0.4.1-0.20260228135713-24a3d9923dcf
+	github.com/butlerdotdev/butler-api v0.4.1-0.20260303164109-066beaa85548
 	github.com/onsi/ginkgo/v2 v2.22.0
 	github.com/onsi/gomega v1.36.1
 	github.com/prometheus/client_golang v1.22.0

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,7 @@
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
-github.com/butlerdotdev/butler-api v0.4.1-0.20260228030305-140667362f7c h1:AFEK56foqZf82tEG39PFHU0yaso+PrHhE3u7LXZVPZk=
-github.com/butlerdotdev/butler-api v0.4.1-0.20260228030305-140667362f7c/go.mod h1:q/RjPFM/r2ELq4DqR78OiAxerKBvH5D4nTGsVLKbjqY=
-github.com/butlerdotdev/butler-api v0.4.1-0.20260228135713-24a3d9923dcf h1:fc0lGJJr20BeDCSuAWWOakiHqiKRR9CvuKdWqURhOdY=
-github.com/butlerdotdev/butler-api v0.4.1-0.20260228135713-24a3d9923dcf/go.mod h1:q/RjPFM/r2ELq4DqR78OiAxerKBvH5D4nTGsVLKbjqY=
+github.com/butlerdotdev/butler-api v0.4.1-0.20260303164109-066beaa85548 h1:5dSOGwfm/aBVzqsJ4jTIpbmtF+NYbhSPxzWgP2pl0ik=
+github.com/butlerdotdev/butler-api v0.4.1-0.20260303164109-066beaa85548/go.mod h1:q/RjPFM/r2ELq4DqR78OiAxerKBvH5D4nTGsVLKbjqY=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
-github.com/butlerdotdev/butler-api v0.4.1-0.20260303164109-066beaa85548 h1:5dSOGwfm/aBVzqsJ4jTIpbmtF+NYbhSPxzWgP2pl0ik=
-github.com/butlerdotdev/butler-api v0.4.1-0.20260303164109-066beaa85548/go.mod h1:q/RjPFM/r2ELq4DqR78OiAxerKBvH5D4nTGsVLKbjqY=
+github.com/butlerdotdev/butler-api v0.5.0 h1:A3leCabrNM2oX6b+HJfQVBMjleETM6Cims6qkf6IzVs=
+github.com/butlerdotdev/butler-api v0.5.0/go.mod h1:q/RjPFM/r2ELq4DqR78OiAxerKBvH5D4nTGsVLKbjqY=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/internal/capi/builder.go
+++ b/internal/capi/builder.go
@@ -394,6 +394,20 @@ func (b *Builder) buildStewardControlPlane(name string) *unstructured.Unstructur
 		"network": network,
 	}
 
+	// Add control plane resources if configured (ButlerConfig defaults + TenantCluster overrides)
+	resources := b.resolveControlPlaneResources()
+	if resources != nil {
+		if resources.APIServer != nil {
+			spec["apiServer"] = b.componentResourceMap(resources.APIServer)
+		}
+		if resources.ControllerManager != nil {
+			spec["controllerManager"] = b.componentResourceMap(resources.ControllerManager)
+		}
+		if resources.Scheduler != nil {
+			spec["scheduler"] = b.componentResourceMap(resources.Scheduler)
+		}
+	}
+
 	// Add certSANs if specified
 	if len(b.tc.Spec.ControlPlane.CertSANs) > 0 {
 		certSANs := make([]interface{}, len(b.tc.Spec.ControlPlane.CertSANs))
@@ -1012,6 +1026,79 @@ func (b *Builder) needsIngressHostsEntry() bool {
 	mode := b.butlerConfig.GetControlPlaneExposureMode()
 	return mode == butlerv1alpha1.ControlPlaneExposureModeIngress ||
 		mode == butlerv1alpha1.ControlPlaneExposureModeGateway
+}
+
+// resolveControlPlaneResources merges ButlerConfig defaults with TenantCluster overrides.
+// Returns nil if no resources are configured (BestEffort QoS).
+func (b *Builder) resolveControlPlaneResources() *butlerv1alpha1.ControlPlaneResourcesSpec {
+	// Start with platform defaults
+	var result *butlerv1alpha1.ControlPlaneResourcesSpec
+	if b.butlerConfig != nil {
+		result = b.butlerConfig.GetDefaultControlPlaneResources()
+	}
+
+	// Per-cluster overrides replace per-component
+	tcResources := b.tc.Spec.ControlPlane.Resources
+	if tcResources == nil {
+		return result
+	}
+
+	// If no platform defaults, use TC resources directly
+	if result == nil {
+		return tcResources
+	}
+
+	// Merge: TC component overrides replace entire component from ButlerConfig
+	merged := result.DeepCopy()
+	if tcResources.APIServer != nil {
+		merged.APIServer = tcResources.APIServer
+	}
+	if tcResources.ControllerManager != nil {
+		merged.ControllerManager = tcResources.ControllerManager
+	}
+	if tcResources.Scheduler != nil {
+		merged.Scheduler = tcResources.Scheduler
+	}
+	return merged
+}
+
+// componentResourceMap converts a ComponentResources to an unstructured map
+// matching the StewardControlPlane's ControlPlaneComponent shape (which wraps
+// corev1.ResourceRequirements under a "resources" key).
+func (b *Builder) componentResourceMap(cr *butlerv1alpha1.ComponentResources) map[string]interface{} {
+	result := map[string]interface{}{}
+	resMap := map[string]interface{}{}
+
+	if cr.Requests != nil {
+		reqMap := map[string]interface{}{}
+		if cr.Requests.CPU != nil {
+			reqMap["cpu"] = cr.Requests.CPU.String()
+		}
+		if cr.Requests.Memory != nil {
+			reqMap["memory"] = cr.Requests.Memory.String()
+		}
+		if len(reqMap) > 0 {
+			resMap["requests"] = reqMap
+		}
+	}
+
+	if cr.Limits != nil {
+		limMap := map[string]interface{}{}
+		if cr.Limits.CPU != nil {
+			limMap["cpu"] = cr.Limits.CPU.String()
+		}
+		if cr.Limits.Memory != nil {
+			limMap["memory"] = cr.Limits.Memory.String()
+		}
+		if len(limMap) > 0 {
+			resMap["limits"] = limMap
+		}
+	}
+
+	if len(resMap) > 0 {
+		result["resources"] = resMap
+	}
+	return result
 }
 
 // buildMachineDeployment constructs the MachineDeployment resource.

--- a/internal/capi/builder_test.go
+++ b/internal/capi/builder_test.go
@@ -19,6 +19,7 @@ package capi
 import (
 	"testing"
 
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -517,6 +518,284 @@ func TestCommonLabels(t *testing.T) {
 	}
 	if labels[butlerv1alpha1.LabelTeam] != "team-alpha" {
 		t.Error("expected team label when teamRef is set")
+	}
+}
+
+func TestResolveControlPlaneResources_NoConfig(t *testing.T) {
+	tc := newTestTenantCluster("test", "default")
+	pc := newTestProviderConfig("harvester")
+
+	builder := NewBuilder(tc, pc, "ns")
+	result := builder.resolveControlPlaneResources()
+
+	if result != nil {
+		t.Error("expected nil when no ButlerConfig and no TC resources")
+	}
+}
+
+func TestResolveControlPlaneResources_ButlerConfigOnly(t *testing.T) {
+	tc := newTestTenantCluster("test", "default")
+	pc := newTestProviderConfig("harvester")
+	bc := newTestButlerConfig()
+	bc.Spec.DefaultControlPlaneResources = &butlerv1alpha1.ControlPlaneResourcesSpec{
+		APIServer: &butlerv1alpha1.ComponentResources{
+			Requests: &butlerv1alpha1.ResourceQuantities{
+				CPU:    quantityPtr("100m"),
+				Memory: quantityPtr("256Mi"),
+			},
+		},
+	}
+
+	builder := NewBuilder(tc, pc, "ns").WithButlerConfig(bc)
+	result := builder.resolveControlPlaneResources()
+
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+	if result.APIServer == nil {
+		t.Fatal("expected APIServer to be set")
+	}
+	if result.APIServer.Requests.CPU.String() != "100m" {
+		t.Errorf("expected CPU 100m, got %s", result.APIServer.Requests.CPU.String())
+	}
+}
+
+func TestResolveControlPlaneResources_TCOnly(t *testing.T) {
+	tc := newTestTenantCluster("test", "default")
+	tc.Spec.ControlPlane.Resources = &butlerv1alpha1.ControlPlaneResourcesSpec{
+		Scheduler: &butlerv1alpha1.ComponentResources{
+			Requests: &butlerv1alpha1.ResourceQuantities{
+				CPU: quantityPtr("50m"),
+			},
+		},
+	}
+	pc := newTestProviderConfig("harvester")
+
+	builder := NewBuilder(tc, pc, "ns")
+	result := builder.resolveControlPlaneResources()
+
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+	if result.Scheduler == nil {
+		t.Fatal("expected Scheduler to be set")
+	}
+	if result.Scheduler.Requests.CPU.String() != "50m" {
+		t.Errorf("expected CPU 50m, got %s", result.Scheduler.Requests.CPU.String())
+	}
+	if result.APIServer != nil {
+		t.Error("expected APIServer to be nil")
+	}
+}
+
+func TestResolveControlPlaneResources_MergeOverride(t *testing.T) {
+	tc := newTestTenantCluster("test", "default")
+	tc.Spec.ControlPlane.Resources = &butlerv1alpha1.ControlPlaneResourcesSpec{
+		APIServer: &butlerv1alpha1.ComponentResources{
+			Requests: &butlerv1alpha1.ResourceQuantities{
+				CPU:    quantityPtr("500m"),
+				Memory: quantityPtr("1Gi"),
+			},
+		},
+		// ControllerManager NOT set — should inherit from ButlerConfig
+	}
+
+	pc := newTestProviderConfig("harvester")
+	bc := newTestButlerConfig()
+	bc.Spec.DefaultControlPlaneResources = &butlerv1alpha1.ControlPlaneResourcesSpec{
+		APIServer: &butlerv1alpha1.ComponentResources{
+			Requests: &butlerv1alpha1.ResourceQuantities{
+				CPU:    quantityPtr("100m"),
+				Memory: quantityPtr("256Mi"),
+			},
+		},
+		ControllerManager: &butlerv1alpha1.ComponentResources{
+			Requests: &butlerv1alpha1.ResourceQuantities{
+				CPU: quantityPtr("50m"),
+			},
+		},
+	}
+
+	builder := NewBuilder(tc, pc, "ns").WithButlerConfig(bc)
+	result := builder.resolveControlPlaneResources()
+
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+
+	// APIServer should be overridden by TC
+	if result.APIServer.Requests.CPU.String() != "500m" {
+		t.Errorf("expected APIServer CPU 500m (TC override), got %s", result.APIServer.Requests.CPU.String())
+	}
+
+	// ControllerManager should inherit from ButlerConfig
+	if result.ControllerManager == nil {
+		t.Fatal("expected ControllerManager to inherit from ButlerConfig")
+	}
+	if result.ControllerManager.Requests.CPU.String() != "50m" {
+		t.Errorf("expected ControllerManager CPU 50m (BC default), got %s", result.ControllerManager.Requests.CPU.String())
+	}
+}
+
+func TestResolveControlPlaneResources_PartialOverride(t *testing.T) {
+	tc := newTestTenantCluster("test", "default")
+	tc.Spec.ControlPlane.Resources = &butlerv1alpha1.ControlPlaneResourcesSpec{
+		Scheduler: &butlerv1alpha1.ComponentResources{
+			Requests: &butlerv1alpha1.ResourceQuantities{
+				CPU: quantityPtr("200m"),
+			},
+		},
+	}
+
+	pc := newTestProviderConfig("harvester")
+	bc := newTestButlerConfig()
+	bc.Spec.DefaultControlPlaneResources = &butlerv1alpha1.ControlPlaneResourcesSpec{
+		APIServer: &butlerv1alpha1.ComponentResources{
+			Requests: &butlerv1alpha1.ResourceQuantities{
+				CPU: quantityPtr("100m"),
+			},
+		},
+		Scheduler: &butlerv1alpha1.ComponentResources{
+			Requests: &butlerv1alpha1.ResourceQuantities{
+				CPU: quantityPtr("25m"),
+			},
+		},
+	}
+
+	builder := NewBuilder(tc, pc, "ns").WithButlerConfig(bc)
+	result := builder.resolveControlPlaneResources()
+
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+
+	// APIServer from ButlerConfig (not overridden)
+	if result.APIServer == nil || result.APIServer.Requests.CPU.String() != "100m" {
+		t.Error("expected APIServer CPU 100m from ButlerConfig")
+	}
+
+	// Scheduler from TC (overridden)
+	if result.Scheduler == nil || result.Scheduler.Requests.CPU.String() != "200m" {
+		t.Error("expected Scheduler CPU 200m from TC override")
+	}
+}
+
+func TestComponentResourceMap(t *testing.T) {
+	tc := newTestTenantCluster("test", "default")
+	pc := newTestProviderConfig("harvester")
+	builder := NewBuilder(tc, pc, "ns")
+
+	cr := &butlerv1alpha1.ComponentResources{
+		Requests: &butlerv1alpha1.ResourceQuantities{
+			CPU:    quantityPtr("100m"),
+			Memory: quantityPtr("256Mi"),
+		},
+		Limits: &butlerv1alpha1.ResourceQuantities{
+			CPU:    quantityPtr("2"),
+			Memory: quantityPtr("1Gi"),
+		},
+	}
+
+	result := builder.componentResourceMap(cr)
+	resMap, ok := result["resources"].(map[string]interface{})
+	if !ok {
+		t.Fatal("expected resources key in result")
+	}
+
+	reqMap, ok := resMap["requests"].(map[string]interface{})
+	if !ok {
+		t.Fatal("expected requests in resources")
+	}
+	if reqMap["cpu"] != "100m" {
+		t.Errorf("expected cpu 100m, got %v", reqMap["cpu"])
+	}
+	if reqMap["memory"] != "256Mi" {
+		t.Errorf("expected memory 256Mi, got %v", reqMap["memory"])
+	}
+
+	limMap, ok := resMap["limits"].(map[string]interface{})
+	if !ok {
+		t.Fatal("expected limits in resources")
+	}
+	if limMap["cpu"] != "2" {
+		t.Errorf("expected cpu 2, got %v", limMap["cpu"])
+	}
+	if limMap["memory"] != "1Gi" {
+		t.Errorf("expected memory 1Gi, got %v", limMap["memory"])
+	}
+}
+
+func TestSCPIncludesResources(t *testing.T) {
+	tc := newTestTenantCluster("test", "default")
+	pc := newTestProviderConfig("harvester")
+	bc := newTestButlerConfig()
+	bc.Spec.DefaultControlPlaneResources = &butlerv1alpha1.ControlPlaneResourcesSpec{
+		APIServer: &butlerv1alpha1.ComponentResources{
+			Requests: &butlerv1alpha1.ResourceQuantities{
+				CPU:    quantityPtr("100m"),
+				Memory: quantityPtr("256Mi"),
+			},
+		},
+	}
+
+	builder := NewBuilder(tc, pc, "test-ns").WithButlerConfig(bc)
+	rs, err := builder.Build()
+	if err != nil {
+		t.Fatalf("failed to build: %v", err)
+	}
+
+	spec := rs.ControlPlane.Object["spec"].(map[string]interface{})
+
+	// Should have apiServer key with resources
+	apiServer, ok := spec["apiServer"].(map[string]interface{})
+	if !ok {
+		t.Fatal("expected apiServer key in SCP spec")
+	}
+	resMap, ok := apiServer["resources"].(map[string]interface{})
+	if !ok {
+		t.Fatal("expected resources in apiServer")
+	}
+	reqMap := resMap["requests"].(map[string]interface{})
+	if reqMap["cpu"] != "100m" {
+		t.Errorf("expected cpu 100m, got %v", reqMap["cpu"])
+	}
+}
+
+func TestSCPNoResourcesWhenNotConfigured(t *testing.T) {
+	tc := newTestTenantCluster("test", "default")
+	pc := newTestProviderConfig("harvester")
+
+	builder := NewBuilder(tc, pc, "test-ns")
+	rs, err := builder.Build()
+	if err != nil {
+		t.Fatalf("failed to build: %v", err)
+	}
+
+	spec := rs.ControlPlane.Object["spec"].(map[string]interface{})
+
+	// Should NOT have apiServer, controllerManager, or scheduler keys
+	if _, ok := spec["apiServer"]; ok {
+		t.Error("expected no apiServer key when resources not configured")
+	}
+	if _, ok := spec["controllerManager"]; ok {
+		t.Error("expected no controllerManager key when resources not configured")
+	}
+	if _, ok := spec["scheduler"]; ok {
+		t.Error("expected no scheduler key when resources not configured")
+	}
+}
+
+func quantityPtr(s string) *resource.Quantity {
+	q := resource.MustParse(s)
+	return &q
+}
+
+func newTestButlerConfig() *butlerv1alpha1.ButlerConfig {
+	return &butlerv1alpha1.ButlerConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "butler",
+		},
+		Spec: butlerv1alpha1.ButlerConfigSpec{},
 	}
 }
 


### PR DESCRIPTION
## Summary

- Adds `resolveControlPlaneResources()` to merge ButlerConfig platform defaults with TenantCluster per-cluster overrides
- Injects resolved resources into the StewardControlPlane spec (apiserver, controller-manager, scheduler)
- Per-component merge: TC overrides fully replace ButlerConfig defaults for that component; unset components inherit
- No resources configured = BestEffort QoS (backward compatible, edge-friendly)

Depends on: https://github.com/butlerdotdev/butler-api/pull/19

## Test plan

- [x] Unit tests for all resolution scenarios (no config, ButlerConfig only, TC only, merge, partial override)
- [x] Unit tests for componentResourceMap helper
- [x] Integration test: SCP includes resources when configured
- [x] Integration test: SCP omits resources when not configured
- [ ] E2E: deploy to butler-beta, create TC with resources, verify SCP → TCP → Pod propagation