### PR TITLE
feat: add ImageSync controller and TenantCluster integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Clean up runner disk space
+        run: |
+          go clean -cache -testcache 2>/dev/null || true
+          rm -rf /tmp/go-build* 2>/dev/null || true
+          docker system prune -f 2>/dev/null || true
+
       - name: Install build dependencies
         run: |
           if ! command -v make &> /dev/null; then

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -34,6 +34,7 @@ import (
 
 	"github.com/butlerdotdev/butler-controller/internal/addons"
 	"github.com/butlerdotdev/butler-controller/internal/controller/butlerconfig"
+	"github.com/butlerdotdev/butler-controller/internal/controller/imagesync"
 	"github.com/butlerdotdev/butler-controller/internal/controller/ipallocation"
 	"github.com/butlerdotdev/butler-controller/internal/controller/kamajisecret"
 	"github.com/butlerdotdev/butler-controller/internal/controller/kamajistatus"
@@ -188,6 +189,15 @@ func main() {
 		os.Exit(1)
 	}
 
+	// ImageSync controller. Thin controller for image sync lifecycle management
+	if err = (&imagesync.Reconciler{
+		Client: mgr.GetClient(),
+		Scheme: mgr.GetScheme(),
+	}).SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create controller", "controller", "ImageSync")
+		os.Exit(1)
+	}
+
 	// ProviderConfig controller. Health checks and capacity reporting
 	if err = (&providerconfig.Reconciler{
 		Client:   mgr.GetClient(),
@@ -260,7 +270,7 @@ func main() {
 	}
 
 	setupLog.Info("starting manager",
-		"controllers", []string{"ButlerConfig", "Team", "TenantCluster", "TenantAddon", "ManagementAddon", "NetworkPool", "IPAllocation", "ProviderConfig", "Workspace", "KamajiSecret", "KamajiStatus"})
+		"controllers", []string{"ButlerConfig", "Team", "TenantCluster", "TenantAddon", "ManagementAddon", "NetworkPool", "IPAllocation", "ImageSync", "ProviderConfig", "Workspace", "KamajiSecret", "KamajiStatus"})
 
 	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
 		setupLog.Error(err, "problem running manager")

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -189,7 +189,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	// ImageSync controller. Thin controller for image sync lifecycle management
+	// ImageSync controller. Fulfills image syncs from factory to providers
 	if err = (&imagesync.Reconciler{
 		Client: mgr.GetClient(),
 		Scheme: mgr.GetScheme(),

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/butlerdotdev/butler-controller
 go 1.24.6
 
 require (
-	github.com/butlerdotdev/butler-api v0.5.0
+	github.com/butlerdotdev/butler-api v0.6.0
 	github.com/onsi/ginkgo/v2 v2.22.0
 	github.com/onsi/gomega v1.36.1
 	github.com/prometheus/client_golang v1.22.0
@@ -74,5 +74,3 @@ require (
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.0 // indirect
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )
-
-replace github.com/butlerdotdev/butler-api => ../butler-api

--- a/go.mod
+++ b/go.mod
@@ -74,3 +74,5 @@ require (
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.0 // indirect
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )
+
+replace github.com/butlerdotdev/butler-api => ../butler-api

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,5 @@
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
-github.com/butlerdotdev/butler-api v0.5.0 h1:A3leCabrNM2oX6b+HJfQVBMjleETM6Cims6qkf6IzVs=
-github.com/butlerdotdev/butler-api v0.5.0/go.mod h1:q/RjPFM/r2ELq4DqR78OiAxerKBvH5D4nTGsVLKbjqY=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
+github.com/butlerdotdev/butler-api v0.6.0 h1:rB/eh6pMMGBK5vYsMkRdg+LwWJFZ4/aZvM3CfCjRSH8=
+github.com/butlerdotdev/butler-api v0.6.0/go.mod h1:q/RjPFM/r2ELq4DqR78OiAxerKBvH5D4nTGsVLKbjqY=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/internal/controller/imagesync/harvester.go
+++ b/internal/controller/imagesync/harvester.go
@@ -148,6 +148,7 @@ func (r *Reconciler) checkHarvesterVMIStatus(ctx context.Context, is *butlerv1al
 		}
 		condType, _, _ := unstructured.NestedString(condMap, "type")
 		condStatus, _, _ := unstructured.NestedString(condMap, "status")
+		message, _, _ := unstructured.NestedString(condMap, "message")
 
 		if condType == "Imported" && condStatus == "True" {
 			// Image is ready
@@ -157,10 +158,24 @@ func (r *Reconciler) checkHarvesterVMIStatus(ctx context.Context, is *butlerv1al
 
 		if condType == "Imported" && condStatus == "False" {
 			reason, _, _ := unstructured.NestedString(condMap, "reason")
-			message, _, _ := unstructured.NestedString(condMap, "message")
 			if reason == "ImportFailed" || reason == "Failed" {
 				return r.setFailed(ctx, is, "HarvesterImportFailed",
 					fmt.Sprintf("VirtualMachineImage import failed: %s", message))
+			}
+		}
+
+		// Harvester CDI retry limit exceeded — terminal failure
+		if condType == "RetryLimitExceeded" && condStatus == "True" {
+			return r.setFailed(ctx, is, "HarvesterRetryLimitExceeded",
+				fmt.Sprintf("VirtualMachineImage download failed after retries: %s", message))
+		}
+
+		// Harvester CDI initialization failed
+		if condType == "Initialized" && condStatus == "False" {
+			reason, _, _ := unstructured.NestedString(condMap, "reason")
+			if reason == "Failed" || reason == "ImportFailed" {
+				return r.setFailed(ctx, is, "HarvesterInitFailed",
+					fmt.Sprintf("VirtualMachineImage initialization failed: %s", message))
 			}
 		}
 	}

--- a/internal/controller/imagesync/harvester.go
+++ b/internal/controller/imagesync/harvester.go
@@ -1,0 +1,214 @@
+/*
+Copyright 2026 The Butler Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package imagesync
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/tools/clientcmd"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	butlerv1alpha1 "github.com/butlerdotdev/butler-api/api/v1alpha1"
+)
+
+var vmiImageGVR = schema.GroupVersionResource{
+	Group:    "harvesterhci.io",
+	Version:  "v1beta1",
+	Resource: "virtualmachineimages",
+}
+
+// reconcileHarvester handles image sync for Harvester providers.
+// Direct mode: creates a VirtualMachineImage with sourceType=download.
+// Proxy mode: not yet implemented (requires CDI upload proxy).
+func (r *Reconciler) reconcileHarvester(ctx context.Context, is *butlerv1alpha1.ImageSync, pc *butlerv1alpha1.ProviderConfig, imageName, artifactURL string) (ctrl.Result, error) {
+	logger := log.FromContext(ctx)
+
+	// Get Harvester credentials (kubeconfig)
+	creds, err := r.getProviderCredentials(ctx, pc)
+	if err != nil {
+		return r.setFailed(ctx, is, "CredentialsError", fmt.Sprintf("failed to get Harvester credentials: %v", err))
+	}
+
+	kubeconfigData, ok := creds["kubeconfig"]
+	if !ok {
+		return r.setFailed(ctx, is, "CredentialsError", "Harvester credentials secret missing 'kubeconfig' key")
+	}
+
+	dynClient, err := newHarvesterDynamicClient(kubeconfigData)
+	if err != nil {
+		return r.setFailed(ctx, is, "ClientError", fmt.Sprintf("failed to create Harvester client: %v", err))
+	}
+
+	namespace := "default"
+	if pc.Spec.Harvester != nil && pc.Spec.Harvester.Namespace != "" {
+		namespace = pc.Spec.Harvester.Namespace
+	}
+
+	// Check if VMI already exists
+	existing, err := dynClient.Resource(vmiImageGVR).Namespace(namespace).Get(ctx, imageName, metav1.GetOptions{})
+	if err == nil {
+		// VMI exists — check its status
+		return r.checkHarvesterVMIStatus(ctx, is, existing, namespace, imageName)
+	}
+
+	// VMI doesn't exist — create it
+	if is.Spec.TransferMode == butlerv1alpha1.TransferModeProxy {
+		return r.setFailed(ctx, is, "UnsupportedTransferMode",
+			"proxy transfer mode for Harvester is not yet implemented; use direct mode")
+	}
+
+	logger.Info("creating Harvester VirtualMachineImage", "name", imageName, "url", artifactURL)
+
+	vmi := buildHarvesterVMI(imageName, namespace, artifactURL, is.Spec.DisplayName)
+	_, err = dynClient.Resource(vmiImageGVR).Namespace(namespace).Create(ctx, vmi, metav1.CreateOptions{})
+	if err != nil {
+		return r.setFailed(ctx, is, "CreateImageFailed", fmt.Sprintf("failed to create VirtualMachineImage: %v", err))
+	}
+
+	// Transition to Downloading (Harvester CDI pulls the image)
+	is.SetPhase(butlerv1alpha1.ImageSyncPhaseDownloading)
+	is.Status.ObservedGeneration = is.Generation
+	meta.SetStatusCondition(&is.Status.Conditions, metav1.Condition{
+		Type:               butlerv1alpha1.ConditionTypeProgressing,
+		Status:             metav1.ConditionTrue,
+		Reason:             butlerv1alpha1.ReasonImageDownloading,
+		Message:            fmt.Sprintf("Harvester is downloading image from %s", artifactURL),
+		ObservedGeneration: is.Generation,
+	})
+	if err := r.Status().Update(ctx, is); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	return ctrl.Result{RequeueAfter: requeueShort}, nil
+}
+
+// pollHarvesterImage checks the status of a Harvester VirtualMachineImage.
+func (r *Reconciler) pollHarvesterImage(ctx context.Context, is *butlerv1alpha1.ImageSync, pc *butlerv1alpha1.ProviderConfig, imageName string) (ctrl.Result, error) {
+	creds, err := r.getProviderCredentials(ctx, pc)
+	if err != nil {
+		return ctrl.Result{RequeueAfter: requeueShort}, nil
+	}
+
+	kubeconfigData, ok := creds["kubeconfig"]
+	if !ok {
+		return ctrl.Result{RequeueAfter: requeueShort}, nil
+	}
+
+	dynClient, err := newHarvesterDynamicClient(kubeconfigData)
+	if err != nil {
+		return ctrl.Result{RequeueAfter: requeueShort}, nil
+	}
+
+	namespace := "default"
+	if pc.Spec.Harvester != nil && pc.Spec.Harvester.Namespace != "" {
+		namespace = pc.Spec.Harvester.Namespace
+	}
+
+	vmi, err := dynClient.Resource(vmiImageGVR).Namespace(namespace).Get(ctx, imageName, metav1.GetOptions{})
+	if err != nil {
+		return ctrl.Result{RequeueAfter: requeueShort}, nil
+	}
+
+	return r.checkHarvesterVMIStatus(ctx, is, vmi, namespace, imageName)
+}
+
+// checkHarvesterVMIStatus inspects VMI conditions and transitions phases.
+func (r *Reconciler) checkHarvesterVMIStatus(ctx context.Context, is *butlerv1alpha1.ImageSync, vmi *unstructured.Unstructured, namespace, imageName string) (ctrl.Result, error) {
+	conditions, found, _ := unstructured.NestedSlice(vmi.Object, "status", "conditions")
+	if !found {
+		// No conditions yet — still importing
+		return ctrl.Result{RequeueAfter: requeueShort}, nil
+	}
+
+	for _, c := range conditions {
+		condMap, ok := c.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		condType, _, _ := unstructured.NestedString(condMap, "type")
+		condStatus, _, _ := unstructured.NestedString(condMap, "status")
+
+		if condType == "Imported" && condStatus == "True" {
+			// Image is ready
+			providerRef := fmt.Sprintf("%s/%s", namespace, imageName)
+			return r.setReady(ctx, is, providerRef)
+		}
+
+		if condType == "Imported" && condStatus == "False" {
+			reason, _, _ := unstructured.NestedString(condMap, "reason")
+			message, _, _ := unstructured.NestedString(condMap, "message")
+			if reason == "ImportFailed" || reason == "Failed" {
+				return r.setFailed(ctx, is, "HarvesterImportFailed",
+					fmt.Sprintf("VirtualMachineImage import failed: %s", message))
+			}
+		}
+	}
+
+	// Still importing — keep polling
+	if is.Status.Phase == butlerv1alpha1.ImageSyncPhasePending {
+		is.SetPhase(butlerv1alpha1.ImageSyncPhaseDownloading)
+		is.Status.ObservedGeneration = is.Generation
+		if err := r.Status().Update(ctx, is); err != nil {
+			return ctrl.Result{}, err
+		}
+	}
+	return ctrl.Result{RequeueAfter: requeueShort}, nil
+}
+
+// buildHarvesterVMI constructs a VirtualMachineImage with sourceType=download.
+func buildHarvesterVMI(name, namespace, downloadURL, displayName string) *unstructured.Unstructured {
+	if displayName == "" {
+		displayName = name
+	}
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "harvesterhci.io/v1beta1",
+			"kind":       "VirtualMachineImage",
+			"metadata": map[string]interface{}{
+				"name":      name,
+				"namespace": namespace,
+				"labels": map[string]interface{}{
+					"app.kubernetes.io/managed-by": "butler",
+				},
+				"annotations": map[string]interface{}{
+					"harvesterhci.io/image-download-url": downloadURL,
+				},
+			},
+			"spec": map[string]interface{}{
+				"displayName": displayName,
+				"sourceType":  "download",
+				"url":         downloadURL,
+			},
+		},
+	}
+}
+
+// newHarvesterDynamicClient creates a dynamic client for a Harvester cluster.
+func newHarvesterDynamicClient(kubeconfigData []byte) (dynamic.Interface, error) {
+	restConfig, err := clientcmd.RESTConfigFromKubeConfig(kubeconfigData)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create REST config: %w", err)
+	}
+	return dynamic.NewForConfig(restConfig)
+}

--- a/internal/controller/imagesync/imagesync_controller.go
+++ b/internal/controller/imagesync/imagesync_controller.go
@@ -1,0 +1,120 @@
+/*
+Copyright 2026 The Butler Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package imagesync
+
+import (
+	"context"
+	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	butlerv1alpha1 "github.com/butlerdotdev/butler-api/api/v1alpha1"
+)
+
+// Reconciler reconciles an ImageSync object.
+// This is a thin lifecycle controller — finalizers, phase initialization, and
+// periodic requeue. The actual image build/download/upload is handled by the
+// provider controller that watches ImageSync resources.
+type Reconciler struct {
+	client.Client
+	Scheme *runtime.Scheme
+}
+
+// +kubebuilder:rbac:groups=butler.butlerlabs.dev,resources=imagesyncs,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=butler.butlerlabs.dev,resources=imagesyncs/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=butler.butlerlabs.dev,resources=imagesyncs/finalizers,verbs=update
+
+func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := log.FromContext(ctx)
+
+	is := &butlerv1alpha1.ImageSync{}
+	if err := r.Get(ctx, req.NamespacedName, is); err != nil {
+		if apierrors.IsNotFound(err) {
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, err
+	}
+
+	logger.V(1).Info("reconciling ImageSync", "name", is.Name, "phase", is.Status.Phase)
+
+	// Handle deletion
+	if !is.DeletionTimestamp.IsZero() {
+		return r.handleDeletion(ctx, is)
+	}
+
+	// Add finalizer
+	if !controllerutil.ContainsFinalizer(is, butlerv1alpha1.FinalizerImageSync) {
+		controllerutil.AddFinalizer(is, butlerv1alpha1.FinalizerImageSync)
+		if err := r.Update(ctx, is); err != nil {
+			return ctrl.Result{}, err
+		}
+	}
+
+	// Set initial phase if not set
+	if is.Status.Phase == "" {
+		is.Status.Phase = butlerv1alpha1.ImageSyncPhasePending
+		is.Status.ObservedGeneration = is.Generation
+		if err := r.Status().Update(ctx, is); err != nil {
+			return ctrl.Result{}, err
+		}
+		// Return immediately — the provider controller will pick this up
+		return ctrl.Result{}, nil
+	}
+
+	switch is.Status.Phase {
+	case butlerv1alpha1.ImageSyncPhasePending,
+		butlerv1alpha1.ImageSyncPhaseBuilding,
+		butlerv1alpha1.ImageSyncPhaseDownloading,
+		butlerv1alpha1.ImageSyncPhaseUploading:
+		// In-progress — periodic check
+		return ctrl.Result{RequeueAfter: 15 * time.Second}, nil
+	case butlerv1alpha1.ImageSyncPhaseFailed:
+		// Backstop retry — primary retry is event-driven via provider controller
+		return ctrl.Result{RequeueAfter: 60 * time.Second}, nil
+	case butlerv1alpha1.ImageSyncPhaseReady:
+		// Healthy — periodic check
+		return ctrl.Result{RequeueAfter: 10 * time.Minute}, nil
+	}
+
+	return ctrl.Result{}, nil
+}
+
+func (r *Reconciler) handleDeletion(ctx context.Context, is *butlerv1alpha1.ImageSync) (ctrl.Result, error) {
+	logger := log.FromContext(ctx)
+
+	if !controllerutil.ContainsFinalizer(is, butlerv1alpha1.FinalizerImageSync) {
+		return ctrl.Result{}, nil
+	}
+
+	logger.Info("removing ImageSync finalizer", "name", is.Name)
+
+	controllerutil.RemoveFinalizer(is, butlerv1alpha1.FinalizerImageSync)
+	return ctrl.Result{}, r.Update(ctx, is)
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&butlerv1alpha1.ImageSync{}).
+		Named("imagesync").
+		Complete(r)
+}

--- a/internal/controller/imagesync/imagesync_controller.go
+++ b/internal/controller/imagesync/imagesync_controller.go
@@ -300,6 +300,8 @@ func (r *Reconciler) getProviderCredentials(ctx context.Context, pc *butlerv1alp
 }
 
 // buildArtifactURL constructs the factory download URL for an image.
+// Uses the Talos Image Factory URL format: {factory}/image/{schematic}/{version}/{platform}-{arch}.{format}
+// The platform is "nocloud" for KubeVirt/cloud-init targets (Harvester, Nutanix).
 func buildArtifactURL(factoryURL string, ref butlerv1alpha1.ImageFactoryRef, format string) string {
 	factoryURL = strings.TrimSuffix(factoryURL, "/")
 	if format == "" {
@@ -309,7 +311,11 @@ func buildArtifactURL(factoryURL string, ref butlerv1alpha1.ImageFactoryRef, for
 	if arch == "" {
 		arch = "amd64"
 	}
-	return fmt.Sprintf("%s/image/%s/%s/talos-%s.%s", factoryURL, ref.SchematicID, ref.Version, arch, format)
+	platform := ref.Platform
+	if platform == "" {
+		platform = "nocloud"
+	}
+	return fmt.Sprintf("%s/image/%s/%s/%s-%s.%s", factoryURL, ref.SchematicID, ref.Version, platform, arch, format)
 }
 
 // buildProviderImageName generates a deterministic image name for the provider.

--- a/internal/controller/imagesync/imagesync_controller.go
+++ b/internal/controller/imagesync/imagesync_controller.go
@@ -19,6 +19,7 @@ package imagesync
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"strings"
 	"time"
 
@@ -300,8 +301,16 @@ func (r *Reconciler) getProviderCredentials(ctx context.Context, pc *butlerv1alp
 }
 
 // buildArtifactURL constructs the factory download URL for an image.
-// Uses the Talos Image Factory URL format: {factory}/image/{schematic}/{version}/{platform}-{arch}.{format}
-// The platform is "nocloud" for KubeVirt/cloud-init targets (Harvester, Nutanix).
+// URL format: {factory}/image/{schematic}/{version}/{platform}-{arch}.{format}
+//
+// The Platform field in FactoryRef serves as the artifact name prefix, which has
+// different semantics depending on the factory:
+//   - Siderolabs factory (factory.talos.dev): platform identifier (nocloud, metal, vmware, aws, gcp)
+//   - Butler Image Factory: OS type (talos, flatcar, kairos, bottlerocket)
+//
+// The ImageSync creator (user, TC reconciler, or bootstrap reconciler) is responsible
+// for setting the correct Platform value. If unset, defaults to "nocloud" for
+// backward compatibility with factory.talos.dev.
 func buildArtifactURL(factoryURL string, ref butlerv1alpha1.ImageFactoryRef, format string) string {
 	factoryURL = strings.TrimSuffix(factoryURL, "/")
 	if format == "" {
@@ -323,7 +332,12 @@ func buildProviderImageName(is *butlerv1alpha1.ImageSync) string {
 	if is.Spec.DisplayName != "" {
 		return sanitizeName(is.Spec.DisplayName)
 	}
-	// Build from schematic + version: talos-v1-12-4-amd64-butler
+	// Build from platform + version: talos-v1-12-4-amd64-butler
+	// Platform is the OS type for Butler factory, or platform name for Siderolabs factory.
+	platform := is.Spec.FactoryRef.Platform
+	if platform == "" {
+		platform = "nocloud"
+	}
 	version := strings.ReplaceAll(is.Spec.FactoryRef.Version, ".", "-")
 	arch := is.Spec.FactoryRef.Arch
 	if arch == "" {
@@ -333,21 +347,30 @@ func buildProviderImageName(is *butlerv1alpha1.ImageSync) string {
 	if len(schematicPrefix) > 8 {
 		schematicPrefix = schematicPrefix[:8]
 	}
-	name := fmt.Sprintf("talos-%s-%s-%s-butler", version, arch, schematicPrefix)
+	name := fmt.Sprintf("%s-%s-%s-%s-butler", platform, version, arch, schematicPrefix)
 	return sanitizeName(name)
 }
 
-// sanitizeName converts a string into a valid Kubernetes resource name.
+// invalidDNSChars matches any character not allowed in DNS subdomain names.
+var invalidDNSChars = regexp.MustCompile(`[^a-z0-9.-]`)
+
+// sanitizeName converts a string into a valid Kubernetes DNS subdomain name.
 func sanitizeName(name string) string {
 	name = strings.ToLower(name)
 	name = strings.ReplaceAll(name, " ", "-")
 	name = strings.ReplaceAll(name, "_", "-")
+	// Remove any remaining invalid characters (parentheses, etc.)
+	name = invalidDNSChars.ReplaceAllString(name, "")
+	// Collapse multiple consecutive hyphens
+	for strings.Contains(name, "--") {
+		name = strings.ReplaceAll(name, "--", "-")
+	}
 	// Truncate to 63 chars (K8s label limit)
 	if len(name) > 63 {
 		name = name[:63]
 	}
-	// Trim trailing hyphens
-	name = strings.TrimRight(name, "-")
+	// Trim leading/trailing hyphens and dots
+	name = strings.Trim(name, "-.")
 	return name
 }
 

--- a/internal/controller/imagesync/imagesync_controller.go
+++ b/internal/controller/imagesync/imagesync_controller.go
@@ -18,10 +18,16 @@ package imagesync
 
 import (
 	"context"
+	"fmt"
+	"strings"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -30,10 +36,21 @@ import (
 	butlerv1alpha1 "github.com/butlerdotdev/butler-api/api/v1alpha1"
 )
 
+const (
+	// ButlerConfigSingletonName is the expected name of the ButlerConfig singleton.
+	ButlerConfigSingletonName = "butler"
+
+	// Requeue intervals.
+	requeueShort = 15 * time.Second
+	requeueLong  = 60 * time.Second
+	requeueReady = 10 * time.Minute
+)
+
 // Reconciler reconciles an ImageSync object.
-// This is a thin lifecycle controller — finalizers, phase initialization, and
-// periodic requeue. The actual image build/download/upload is handled by the
-// provider controller that watches ImageSync resources.
+// This controller manages the full lifecycle of syncing an image from the
+// Butler Image Factory to an infrastructure provider. It handles finalizers,
+// phase management, and dispatches to provider-specific fulfillment logic
+// (Harvester VirtualMachineImage, Nutanix Prism Central image API).
 type Reconciler struct {
 	client.Client
 	Scheme *runtime.Scheme
@@ -42,6 +59,9 @@ type Reconciler struct {
 // +kubebuilder:rbac:groups=butler.butlerlabs.dev,resources=imagesyncs,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=butler.butlerlabs.dev,resources=imagesyncs/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=butler.butlerlabs.dev,resources=imagesyncs/finalizers,verbs=update
+// +kubebuilder:rbac:groups=butler.butlerlabs.dev,resources=providerconfigs,verbs=get;list;watch
+// +kubebuilder:rbac:groups=butler.butlerlabs.dev,resources=butlerconfigs,verbs=get;list;watch
+// +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch
 
 func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
@@ -71,33 +91,84 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 
 	// Set initial phase if not set
 	if is.Status.Phase == "" {
-		is.Status.Phase = butlerv1alpha1.ImageSyncPhasePending
+		is.SetPhase(butlerv1alpha1.ImageSyncPhasePending)
 		is.Status.ObservedGeneration = is.Generation
 		if err := r.Status().Update(ctx, is); err != nil {
 			return ctrl.Result{}, err
 		}
-		// Return immediately — the provider controller will pick this up
-		return ctrl.Result{}, nil
+		return ctrl.Result{Requeue: true}, nil
 	}
 
+	// Fetch ProviderConfig
+	pc, err := r.getProviderConfig(ctx, is)
+	if err != nil {
+		return r.setFailed(ctx, is, "ProviderConfigNotFound", err.Error())
+	}
+
+	// Fetch ButlerConfig for factory URL
+	bc, err := r.getButlerConfig(ctx)
+	if err != nil {
+		return r.setFailed(ctx, is, "ButlerConfigNotFound", err.Error())
+	}
+
+	if !bc.IsImageFactoryConfigured() {
+		return r.setFailed(ctx, is, "ImageFactoryNotConfigured", "ButlerConfig.spec.imageFactory is not configured")
+	}
+
+	// Dispatch to phase handler
 	switch is.Status.Phase {
-	case butlerv1alpha1.ImageSyncPhasePending,
-		butlerv1alpha1.ImageSyncPhaseBuilding,
-		butlerv1alpha1.ImageSyncPhaseDownloading,
-		butlerv1alpha1.ImageSyncPhaseUploading:
-		// In-progress — periodic check
-		return ctrl.Result{RequeueAfter: 15 * time.Second}, nil
+	case butlerv1alpha1.ImageSyncPhasePending:
+		return r.reconcilePending(ctx, is, pc, bc)
+	case butlerv1alpha1.ImageSyncPhaseBuilding:
+		return ctrl.Result{RequeueAfter: requeueShort}, nil
+	case butlerv1alpha1.ImageSyncPhaseDownloading, butlerv1alpha1.ImageSyncPhaseUploading:
+		return r.reconcileInProgress(ctx, is, pc, bc)
 	case butlerv1alpha1.ImageSyncPhaseFailed:
-		// Backstop retry — primary retry is event-driven via provider controller
-		return ctrl.Result{RequeueAfter: 60 * time.Second}, nil
+		return ctrl.Result{RequeueAfter: requeueLong}, nil
 	case butlerv1alpha1.ImageSyncPhaseReady:
-		// Healthy — periodic check
-		return ctrl.Result{RequeueAfter: 10 * time.Minute}, nil
+		return ctrl.Result{RequeueAfter: requeueReady}, nil
 	}
 
 	return ctrl.Result{}, nil
 }
 
+// reconcilePending handles the Pending phase: checks if the image already
+// exists on the provider, and if not, initiates the transfer.
+func (r *Reconciler) reconcilePending(ctx context.Context, is *butlerv1alpha1.ImageSync, pc *butlerv1alpha1.ProviderConfig, bc *butlerv1alpha1.ButlerConfig) (ctrl.Result, error) {
+	factoryURL := bc.GetImageFactoryURL()
+	artifactURL := buildArtifactURL(factoryURL, is.Spec.FactoryRef, is.Spec.Format)
+	imageName := buildProviderImageName(is)
+
+	// Store artifact URL in status
+	is.Status.ArtifactURL = artifactURL
+
+	switch pc.Spec.Provider {
+	case butlerv1alpha1.ProviderTypeHarvester:
+		return r.reconcileHarvester(ctx, is, pc, imageName, artifactURL)
+	case butlerv1alpha1.ProviderTypeNutanix:
+		apiKey, _ := r.getFactoryAPIKey(ctx, bc)
+		return r.reconcileNutanix(ctx, is, pc, bc, imageName, artifactURL, apiKey)
+	default:
+		return r.setFailed(ctx, is, "UnsupportedProvider",
+			fmt.Sprintf("image sync not supported for provider type %q", pc.Spec.Provider))
+	}
+}
+
+// reconcileInProgress checks the status of an in-progress image sync.
+func (r *Reconciler) reconcileInProgress(ctx context.Context, is *butlerv1alpha1.ImageSync, pc *butlerv1alpha1.ProviderConfig, bc *butlerv1alpha1.ButlerConfig) (ctrl.Result, error) {
+	imageName := buildProviderImageName(is)
+
+	switch pc.Spec.Provider {
+	case butlerv1alpha1.ProviderTypeHarvester:
+		return r.pollHarvesterImage(ctx, is, pc, imageName)
+	case butlerv1alpha1.ProviderTypeNutanix:
+		return r.pollNutanixImage(ctx, is, pc, imageName)
+	default:
+		return ctrl.Result{RequeueAfter: requeueShort}, nil
+	}
+}
+
+// handleDeletion removes the finalizer. Provider image cleanup is best-effort.
 func (r *Reconciler) handleDeletion(ctx context.Context, is *butlerv1alpha1.ImageSync) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
 
@@ -107,8 +178,171 @@ func (r *Reconciler) handleDeletion(ctx context.Context, is *butlerv1alpha1.Imag
 
 	logger.Info("removing ImageSync finalizer", "name", is.Name)
 
+	// Re-fetch to avoid conflicts
+	if err := r.Get(ctx, types.NamespacedName{Name: is.Name, Namespace: is.Namespace}, is); err != nil {
+		return ctrl.Result{}, err
+	}
+
 	controllerutil.RemoveFinalizer(is, butlerv1alpha1.FinalizerImageSync)
 	return ctrl.Result{}, r.Update(ctx, is)
+}
+
+// setFailed sets the ImageSync to Failed phase with reason and message.
+func (r *Reconciler) setFailed(ctx context.Context, is *butlerv1alpha1.ImageSync, reason, message string) (ctrl.Result, error) {
+	logger := log.FromContext(ctx)
+	logger.Error(fmt.Errorf("%s", message), "image sync failed", "reason", reason)
+
+	is.SetFailure(reason, message)
+	is.Status.ObservedGeneration = is.Generation
+	meta.SetStatusCondition(&is.Status.Conditions, metav1.Condition{
+		Type:               butlerv1alpha1.ConditionTypeReady,
+		Status:             metav1.ConditionFalse,
+		Reason:             reason,
+		Message:            message,
+		ObservedGeneration: is.Generation,
+	})
+
+	if err := r.Status().Update(ctx, is); err != nil {
+		return ctrl.Result{}, err
+	}
+	return ctrl.Result{RequeueAfter: requeueLong}, nil
+}
+
+// setReady transitions the ImageSync to Ready phase.
+func (r *Reconciler) setReady(ctx context.Context, is *butlerv1alpha1.ImageSync, providerImageRef string) (ctrl.Result, error) {
+	logger := log.FromContext(ctx)
+	logger.Info("image sync ready", "providerImageRef", providerImageRef)
+
+	is.SetPhase(butlerv1alpha1.ImageSyncPhaseReady)
+	is.Status.ProviderImageRef = providerImageRef
+	is.Status.ObservedGeneration = is.Generation
+	is.Status.FailureReason = ""
+	is.Status.FailureMessage = ""
+	meta.SetStatusCondition(&is.Status.Conditions, metav1.Condition{
+		Type:               butlerv1alpha1.ConditionTypeReady,
+		Status:             metav1.ConditionTrue,
+		Reason:             butlerv1alpha1.ReasonImageReady,
+		Message:            fmt.Sprintf("Image synced to provider: %s", providerImageRef),
+		ObservedGeneration: is.Generation,
+	})
+
+	if err := r.Status().Update(ctx, is); err != nil {
+		return ctrl.Result{}, err
+	}
+	return ctrl.Result{RequeueAfter: requeueReady}, nil
+}
+
+// getProviderConfig fetches the ProviderConfig referenced by the ImageSync.
+func (r *Reconciler) getProviderConfig(ctx context.Context, is *butlerv1alpha1.ImageSync) (*butlerv1alpha1.ProviderConfig, error) {
+	pc := &butlerv1alpha1.ProviderConfig{}
+	ns := is.Spec.ProviderConfigRef.Namespace
+	if ns == "" {
+		ns = is.Namespace
+	}
+	if err := r.Get(ctx, types.NamespacedName{
+		Name:      is.Spec.ProviderConfigRef.Name,
+		Namespace: ns,
+	}, pc); err != nil {
+		return nil, fmt.Errorf("failed to get ProviderConfig %s/%s: %w", ns, is.Spec.ProviderConfigRef.Name, err)
+	}
+	return pc, nil
+}
+
+// getButlerConfig fetches the singleton ButlerConfig.
+func (r *Reconciler) getButlerConfig(ctx context.Context) (*butlerv1alpha1.ButlerConfig, error) {
+	bc := &butlerv1alpha1.ButlerConfig{}
+	if err := r.Get(ctx, types.NamespacedName{Name: ButlerConfigSingletonName}, bc); err != nil {
+		return nil, fmt.Errorf("failed to get ButlerConfig: %w", err)
+	}
+	return bc, nil
+}
+
+// getFactoryAPIKey retrieves the factory API key from the credentials Secret.
+func (r *Reconciler) getFactoryAPIKey(ctx context.Context, bc *butlerv1alpha1.ButlerConfig) (string, error) {
+	if bc.Spec.ImageFactory == nil || bc.Spec.ImageFactory.CredentialsRef == nil {
+		return "", nil
+	}
+
+	ref := bc.Spec.ImageFactory.CredentialsRef
+	secret, err := r.getSecret(ctx, ref.Name, ref.Namespace)
+	if err != nil {
+		return "", err
+	}
+
+	key := ref.Key
+	if key == "" {
+		key = "apiKey"
+	}
+
+	apiKey, ok := secret[key]
+	if !ok {
+		return "", fmt.Errorf("key %q not found in secret %s/%s", key, ref.Namespace, ref.Name)
+	}
+	return string(apiKey), nil
+}
+
+// getSecret fetches a Secret and returns its data map.
+func (r *Reconciler) getSecret(ctx context.Context, name, namespace string) (map[string][]byte, error) {
+	secret := &corev1.Secret{}
+	if err := r.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, secret); err != nil {
+		return nil, fmt.Errorf("failed to get secret %s/%s: %w", namespace, name, err)
+	}
+	return secret.Data, nil
+}
+
+// getProviderCredentials fetches provider credentials from the referenced Secret.
+func (r *Reconciler) getProviderCredentials(ctx context.Context, pc *butlerv1alpha1.ProviderConfig) (map[string][]byte, error) {
+	ns := pc.Spec.CredentialsRef.Namespace
+	if ns == "" {
+		ns = pc.Namespace
+	}
+	return r.getSecret(ctx, pc.Spec.CredentialsRef.Name, ns)
+}
+
+// buildArtifactURL constructs the factory download URL for an image.
+func buildArtifactURL(factoryURL string, ref butlerv1alpha1.ImageFactoryRef, format string) string {
+	factoryURL = strings.TrimSuffix(factoryURL, "/")
+	if format == "" {
+		format = "qcow2"
+	}
+	arch := ref.Arch
+	if arch == "" {
+		arch = "amd64"
+	}
+	return fmt.Sprintf("%s/image/%s/%s/talos-%s.%s", factoryURL, ref.SchematicID, ref.Version, arch, format)
+}
+
+// buildProviderImageName generates a deterministic image name for the provider.
+func buildProviderImageName(is *butlerv1alpha1.ImageSync) string {
+	if is.Spec.DisplayName != "" {
+		return sanitizeName(is.Spec.DisplayName)
+	}
+	// Build from schematic + version: talos-v1-12-4-amd64-butler
+	version := strings.ReplaceAll(is.Spec.FactoryRef.Version, ".", "-")
+	arch := is.Spec.FactoryRef.Arch
+	if arch == "" {
+		arch = "amd64"
+	}
+	schematicPrefix := is.Spec.FactoryRef.SchematicID
+	if len(schematicPrefix) > 8 {
+		schematicPrefix = schematicPrefix[:8]
+	}
+	name := fmt.Sprintf("talos-%s-%s-%s-butler", version, arch, schematicPrefix)
+	return sanitizeName(name)
+}
+
+// sanitizeName converts a string into a valid Kubernetes resource name.
+func sanitizeName(name string) string {
+	name = strings.ToLower(name)
+	name = strings.ReplaceAll(name, " ", "-")
+	name = strings.ReplaceAll(name, "_", "-")
+	// Truncate to 63 chars (K8s label limit)
+	if len(name) > 63 {
+		name = name[:63]
+	}
+	// Trim trailing hyphens
+	name = strings.TrimRight(name, "-")
+	return name
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/internal/controller/imagesync/nutanix.go
+++ b/internal/controller/imagesync/nutanix.go
@@ -79,10 +79,7 @@ func (r *Reconciler) reconcileNutanix(ctx context.Context, is *butlerv1alpha1.Im
 	// Store task UUID in status for polling
 	is.SetPhase(butlerv1alpha1.ImageSyncPhaseDownloading)
 	is.Status.ObservedGeneration = is.Generation
-	// Store task UUID in failure reason temporarily (we don't have a dedicated field)
-	// This is a pragmatic approach — the task UUID is needed for polling
-	is.Status.FailureReason = "task:" + taskUUID
-	is.Status.FailureMessage = ""
+	is.Status.ProviderTaskID = taskUUID
 	meta.SetStatusCondition(&is.Status.Conditions, metav1.Condition{
 		Type:               butlerv1alpha1.ConditionTypeProgressing,
 		Status:             metav1.ConditionTrue,
@@ -105,10 +102,7 @@ func (r *Reconciler) pollNutanixImage(ctx context.Context, is *butlerv1alpha1.Im
 	}
 
 	// Check if we have a task UUID stored
-	taskUUID := ""
-	if strings.HasPrefix(is.Status.FailureReason, "task:") {
-		taskUUID = strings.TrimPrefix(is.Status.FailureReason, "task:")
-	}
+	taskUUID := is.Status.ProviderTaskID
 
 	if taskUUID != "" {
 		// Poll task status
@@ -134,12 +128,11 @@ func (r *Reconciler) pollNutanixImage(ctx context.Context, is *butlerv1alpha1.Im
 			if imageUUID == "" {
 				return r.setFailed(ctx, is, "ImageUUIDNotFound", "task succeeded but image UUID not found")
 			}
-			// Clear the task tracking
-			is.Status.FailureReason = ""
+			is.Status.ProviderTaskID = ""
 			return r.setReady(ctx, is, imageUUID)
 
 		case "FAILED":
-			is.Status.FailureReason = ""
+			is.Status.ProviderTaskID = ""
 			return r.setFailed(ctx, is, "NutanixTaskFailed",
 				fmt.Sprintf("image creation task failed: %s", status.Message))
 		}

--- a/internal/controller/imagesync/nutanix.go
+++ b/internal/controller/imagesync/nutanix.go
@@ -1,0 +1,360 @@
+/*
+Copyright 2026 The Butler Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package imagesync
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	butlerv1alpha1 "github.com/butlerdotdev/butler-api/api/v1alpha1"
+)
+
+const (
+	nutanixAPIPath     = "/api/nutanix/v3"
+	nutanixHTTPTimeout = 30 * time.Second
+)
+
+// reconcileNutanix handles image sync for Nutanix providers.
+// Direct mode: creates an image with source_uri so Prism Central downloads directly.
+// Proxy mode: not yet implemented.
+func (r *Reconciler) reconcileNutanix(ctx context.Context, is *butlerv1alpha1.ImageSync, pc *butlerv1alpha1.ProviderConfig, bc *butlerv1alpha1.ButlerConfig, imageName, artifactURL, factoryAPIKey string) (ctrl.Result, error) {
+	logger := log.FromContext(ctx)
+
+	client, err := r.newNutanixClient(ctx, pc)
+	if err != nil {
+		return r.setFailed(ctx, is, "CredentialsError", fmt.Sprintf("failed to create Nutanix client: %v", err))
+	}
+
+	// Check if image already exists
+	existingUUID, err := client.getImageByName(ctx, imageName)
+	if err != nil {
+		return r.setFailed(ctx, is, "NutanixAPIError", fmt.Sprintf("failed to check existing image: %v", err))
+	}
+	if existingUUID != "" {
+		logger.Info("image already exists on Nutanix", "uuid", existingUUID, "name", imageName)
+		return r.setReady(ctx, is, existingUUID)
+	}
+
+	if is.Spec.TransferMode == butlerv1alpha1.TransferModeProxy {
+		return r.setFailed(ctx, is, "UnsupportedTransferMode",
+			"proxy transfer mode for Nutanix is not yet implemented; use direct mode")
+	}
+
+	// Direct mode: create image with source_uri
+	logger.Info("creating Nutanix image via direct download", "name", imageName, "url", artifactURL)
+
+	taskUUID, err := client.createImageDirect(ctx, imageName, artifactURL,
+		fmt.Sprintf("Butler Image Factory: %s %s", is.Spec.FactoryRef.Version, is.Spec.FactoryRef.SchematicID[:8]))
+	if err != nil {
+		return r.setFailed(ctx, is, "CreateImageFailed", fmt.Sprintf("failed to create Nutanix image: %v", err))
+	}
+
+	// Store task UUID in status for polling
+	is.SetPhase(butlerv1alpha1.ImageSyncPhaseDownloading)
+	is.Status.ObservedGeneration = is.Generation
+	// Store task UUID in failure reason temporarily (we don't have a dedicated field)
+	// This is a pragmatic approach — the task UUID is needed for polling
+	is.Status.FailureReason = "task:" + taskUUID
+	is.Status.FailureMessage = ""
+	meta.SetStatusCondition(&is.Status.Conditions, metav1.Condition{
+		Type:               butlerv1alpha1.ConditionTypeProgressing,
+		Status:             metav1.ConditionTrue,
+		Reason:             butlerv1alpha1.ReasonImageDownloading,
+		Message:            fmt.Sprintf("Nutanix Prism Central is downloading image (task: %s)", taskUUID),
+		ObservedGeneration: is.Generation,
+	})
+	if err := r.Status().Update(ctx, is); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	return ctrl.Result{RequeueAfter: requeueShort}, nil
+}
+
+// pollNutanixImage checks the status of a Nutanix image task.
+func (r *Reconciler) pollNutanixImage(ctx context.Context, is *butlerv1alpha1.ImageSync, pc *butlerv1alpha1.ProviderConfig, imageName string) (ctrl.Result, error) {
+	client, err := r.newNutanixClient(ctx, pc)
+	if err != nil {
+		return ctrl.Result{RequeueAfter: requeueShort}, nil
+	}
+
+	// Check if we have a task UUID stored
+	taskUUID := ""
+	if strings.HasPrefix(is.Status.FailureReason, "task:") {
+		taskUUID = strings.TrimPrefix(is.Status.FailureReason, "task:")
+	}
+
+	if taskUUID != "" {
+		// Poll task status
+		status, err := client.getTaskStatus(ctx, taskUUID)
+		if err != nil {
+			return ctrl.Result{RequeueAfter: requeueShort}, nil
+		}
+
+		switch status.Status {
+		case "SUCCEEDED":
+			// Find the image UUID from the task
+			imageUUID := ""
+			for _, ref := range status.EntityRefs {
+				if ref.Kind == "image" {
+					imageUUID = ref.UUID
+					break
+				}
+			}
+			if imageUUID == "" {
+				// Try to look up by name
+				imageUUID, _ = client.getImageByName(ctx, imageName)
+			}
+			if imageUUID == "" {
+				return r.setFailed(ctx, is, "ImageUUIDNotFound", "task succeeded but image UUID not found")
+			}
+			// Clear the task tracking
+			is.Status.FailureReason = ""
+			return r.setReady(ctx, is, imageUUID)
+
+		case "FAILED":
+			is.Status.FailureReason = ""
+			return r.setFailed(ctx, is, "NutanixTaskFailed",
+				fmt.Sprintf("image creation task failed: %s", status.Message))
+		}
+
+		// Still running
+		return ctrl.Result{RequeueAfter: requeueShort}, nil
+	}
+
+	// No task UUID — try to find image by name
+	imageUUID, err := client.getImageByName(ctx, imageName)
+	if err != nil {
+		return ctrl.Result{RequeueAfter: requeueShort}, nil
+	}
+	if imageUUID != "" {
+		return r.setReady(ctx, is, imageUUID)
+	}
+
+	// Image not found and no task — something went wrong
+	return r.setFailed(ctx, is, "ImageNotFound", "image not found on Nutanix and no active task")
+}
+
+// nutanixClient wraps HTTP calls to Prism Central.
+type nutanixClient struct {
+	httpClient *http.Client
+	baseURL    string
+	authHeader string
+}
+
+// newNutanixClient creates a Prism Central HTTP client from ProviderConfig.
+func (r *Reconciler) newNutanixClient(ctx context.Context, pc *butlerv1alpha1.ProviderConfig) (*nutanixClient, error) {
+	creds, err := r.getProviderCredentials(ctx, pc)
+	if err != nil {
+		return nil, err
+	}
+
+	username := string(creds["username"])
+	password := string(creds["password"])
+	if username == "" || password == "" {
+		return nil, fmt.Errorf("Nutanix credentials missing username or password")
+	}
+
+	if pc.Spec.Nutanix == nil {
+		return nil, fmt.Errorf("ProviderConfig missing nutanix configuration")
+	}
+
+	endpoint := strings.TrimSuffix(pc.Spec.Nutanix.Endpoint, "/")
+	port := pc.Spec.Nutanix.Port
+	if port == 0 {
+		port = 9440
+	}
+	baseURL := fmt.Sprintf("%s:%d%s", endpoint, port, nutanixAPIPath)
+
+	transport := &http.Transport{
+		TLSClientConfig: &tls.Config{
+			InsecureSkipVerify: pc.Spec.Nutanix.Insecure, //nolint:gosec // User-controlled config
+		},
+	}
+
+	auth := base64.StdEncoding.EncodeToString([]byte(username + ":" + password))
+
+	return &nutanixClient{
+		httpClient: &http.Client{Transport: transport, Timeout: nutanixHTTPTimeout},
+		baseURL:    baseURL,
+		authHeader: "Basic " + auth,
+	}, nil
+}
+
+// createImageDirect creates a Nutanix image with source_uri for direct download.
+func (c *nutanixClient) createImageDirect(ctx context.Context, name, sourceURL, description string) (string, error) {
+	body := map[string]interface{}{
+		"api_version": "3.1",
+		"metadata": map[string]interface{}{
+			"kind": "image",
+		},
+		"spec": map[string]interface{}{
+			"name":        name,
+			"description": description,
+			"resources": map[string]interface{}{
+				"image_type": "DISK_IMAGE",
+				"source_uri": sourceURL,
+			},
+		},
+	}
+
+	resp, err := c.doRequest(ctx, "POST", "/images", body)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusAccepted && resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
+		return "", fmt.Errorf("create image failed: status %d, body: %s", resp.StatusCode, string(respBody))
+	}
+
+	var createResp struct {
+		Status struct {
+			ExecutionContext struct {
+				TaskUUID string `json:"task_uuid"`
+			} `json:"execution_context"`
+		} `json:"status"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&createResp); err != nil {
+		return "", fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	return createResp.Status.ExecutionContext.TaskUUID, nil
+}
+
+// getImageByName finds a Nutanix image by name and returns its UUID.
+func (c *nutanixClient) getImageByName(ctx context.Context, name string) (string, error) {
+	body := map[string]interface{}{
+		"kind":   "image",
+		"filter": fmt.Sprintf("name==%s", name),
+	}
+
+	resp, err := c.doRequest(ctx, "POST", "/images/list", body)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("list images failed: status %d", resp.StatusCode)
+	}
+
+	var listResp struct {
+		Entities []struct {
+			Metadata struct {
+				UUID string `json:"uuid"`
+			} `json:"metadata"`
+			Status struct {
+				Name string `json:"name"`
+			} `json:"status"`
+		} `json:"entities"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&listResp); err != nil {
+		return "", err
+	}
+
+	for _, e := range listResp.Entities {
+		if e.Status.Name == name {
+			return e.Metadata.UUID, nil
+		}
+	}
+	return "", nil
+}
+
+type nutanixTaskStatus struct {
+	Status     string
+	Message    string
+	EntityRefs []struct {
+		Kind string
+		UUID string
+	}
+}
+
+// getTaskStatus checks a Nutanix task status.
+func (c *nutanixClient) getTaskStatus(ctx context.Context, taskUUID string) (*nutanixTaskStatus, error) {
+	resp, err := c.doRequest(ctx, "GET", "/tasks/"+taskUUID, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("get task failed: status %d", resp.StatusCode)
+	}
+
+	var taskResp struct {
+		Status              string `json:"status"`
+		ProgressMessage     string `json:"progress_message"`
+		EntityReferenceList []struct {
+			Kind string `json:"kind"`
+			UUID string `json:"uuid"`
+		} `json:"entity_reference_list"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&taskResp); err != nil {
+		return nil, err
+	}
+
+	result := &nutanixTaskStatus{
+		Status:  taskResp.Status,
+		Message: taskResp.ProgressMessage,
+	}
+	for _, ref := range taskResp.EntityReferenceList {
+		result.EntityRefs = append(result.EntityRefs, struct {
+			Kind string
+			UUID string
+		}{Kind: ref.Kind, UUID: ref.UUID})
+	}
+	return result, nil
+}
+
+// doRequest performs an HTTP request to Prism Central.
+func (c *nutanixClient) doRequest(ctx context.Context, method, path string, body interface{}) (*http.Response, error) {
+	url := c.baseURL + path
+
+	var reqBody io.Reader
+	if body != nil {
+		jsonBody, err := json.Marshal(body)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal request: %w", err)
+		}
+		reqBody = bytes.NewReader(jsonBody)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, url, reqBody)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("Authorization", c.authHeader)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+
+	return c.httpClient.Do(req)
+}

--- a/internal/controller/tenantcluster/tenantcluster_controller.go
+++ b/internal/controller/tenantcluster/tenantcluster_controller.go
@@ -1738,8 +1738,13 @@ func (r *Reconciler) reconcileImageSync(ctx context.Context, tc *butlerv1alpha1.
 	// Architecture defaults to amd64 — all current Butler providers target amd64.
 	// When multi-arch support is added, this should read from MachineTemplate or OS spec.
 	arch := "amd64"
-	// Platform defaults to nocloud — works for KubeVirt/cloud-init targets (Harvester, Nutanix).
-	platform := "nocloud"
+	// Platform is the artifact name prefix in the factory URL.
+	// For Butler Image Factory: use the OS type (talos, flatcar, kairos, bottlerocket).
+	// For Siderolabs factory (factory.talos.dev): use "nocloud" (or metal, vmware, etc.).
+	platform := string(tc.Spec.Workers.MachineTemplate.OS.Type)
+	if platform == "" {
+		platform = "nocloud"
+	}
 
 	// Truncate schematicID to 63 chars for label value (Kubernetes label limit)
 	labelSchematicID := schematicID

--- a/internal/controller/tenantcluster/tenantcluster_controller.go
+++ b/internal/controller/tenantcluster/tenantcluster_controller.go
@@ -153,6 +153,53 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		}
 	}
 
+	// Resolve ProviderConfig for image sync (needed before infrastructure reconciliation)
+	providerConfig, pcErr := r.getProviderConfig(ctx, tc)
+	if pcErr != nil {
+		logger.V(1).Info("ProviderConfig not yet available, skipping image sync", "error", pcErr)
+	}
+
+	// Reconcile image sync before infrastructure — ensures the OS image is available
+	// on the provider before VMs are created. The resolved provider image ref is injected
+	// into the in-memory TC spec so the CAPI builder picks it up.
+	if providerConfig != nil {
+		providerImageRef, imageSyncErr := r.reconcileImageSync(ctx, tc, providerConfig, butlerConfig)
+		if imageSyncErr != nil {
+			logger.Info("image sync not yet ready, waiting", "error", imageSyncErr)
+			if err := r.Status().Update(ctx, tc); err != nil {
+				return ctrl.Result{}, err
+			}
+			return ctrl.Result{RequeueAfter: 15 * time.Second}, nil
+		}
+
+		// Apply provider image ref to in-memory TC spec for the builder
+		if providerImageRef != "" {
+			switch providerConfig.Spec.Provider {
+			case butlerv1alpha1.ProviderTypeHarvester:
+				if tc.Spec.InfrastructureOverride == nil {
+					tc.Spec.InfrastructureOverride = &butlerv1alpha1.InfrastructureOverride{}
+				}
+				if tc.Spec.InfrastructureOverride.Harvester == nil {
+					tc.Spec.InfrastructureOverride.Harvester = &butlerv1alpha1.HarvesterOverride{}
+				}
+				tc.Spec.InfrastructureOverride.Harvester.ImageName = providerImageRef
+			case butlerv1alpha1.ProviderTypeNutanix:
+				if tc.Spec.InfrastructureOverride == nil {
+					tc.Spec.InfrastructureOverride = &butlerv1alpha1.InfrastructureOverride{}
+				}
+				if tc.Spec.InfrastructureOverride.Nutanix == nil {
+					tc.Spec.InfrastructureOverride.Nutanix = &butlerv1alpha1.NutanixOverride{}
+				}
+				tc.Spec.InfrastructureOverride.Nutanix.ImageUUID = providerImageRef
+			case butlerv1alpha1.ProviderTypeProxmox:
+				// Proxmox uses TemplateID (int) — image sync returns a string ref.
+				// Provider controller is responsible for setting the correct template.
+				logger.V(1).Info("Proxmox image ref from ImageSync not applied (TemplateID is int)",
+					"providerImageRef", providerImageRef)
+			}
+		}
+	}
+
 	result, err := r.reconcileInfrastructure(ctx, tc, butlerConfig)
 	if err != nil {
 		logger.Error(err, "failed to reconcile infrastructure")
@@ -1648,6 +1695,175 @@ func (r *Reconciler) handleDeletion(ctx context.Context, tc *butlerv1alpha1.Tena
 
 	logger.Info("TenantCluster deletion complete", "name", tc.Name)
 	return ctrl.Result{}, nil
+}
+
+// reconcileImageSync ensures the OS image is synced to the infrastructure provider
+// via the Butler Image Factory. It creates an ImageSync resource if needed, deduplicates
+// across TenantClusters sharing the same schematic+version+provider, and returns the
+// provider-specific image reference once the sync is complete.
+//
+// Returns:
+//   - providerImageRef: the provider-specific image reference (e.g., "default/talos-v1.12.4-amd64")
+//     Empty string if no sync is needed (no schematic configured or auto-sync disabled).
+//   - error: non-nil triggers a requeue (image sync in progress, failed, or creation error).
+func (r *Reconciler) reconcileImageSync(ctx context.Context, tc *butlerv1alpha1.TenantCluster, pc *butlerv1alpha1.ProviderConfig, bc *butlerv1alpha1.ButlerConfig) (string, error) {
+	logger := log.FromContext(ctx)
+
+	// Resolve schematicID: TC spec takes precedence, then ButlerConfig default
+	schematicID := tc.Spec.Workers.MachineTemplate.OS.SchematicID
+	if schematicID == "" && bc != nil && bc.Spec.ImageFactory != nil {
+		schematicID = bc.Spec.ImageFactory.DefaultSchematicID
+	}
+	if schematicID == "" {
+		// No schematic configured — no image sync needed
+		return "", nil
+	}
+
+	// Image factory must be configured if a schematicID is set
+	if bc == nil || !bc.IsImageFactoryConfigured() {
+		return "", fmt.Errorf("schematicID %q is set but Image Factory is not configured in ButlerConfig", schematicID)
+	}
+
+	// Check if auto-sync is enabled
+	if !bc.IsAutoSyncEnabled() {
+		logger.V(1).Info("image auto-sync disabled, skipping ImageSync creation")
+		return "", nil
+	}
+
+	// Resolve image version and architecture
+	version := tc.Spec.Workers.MachineTemplate.OS.Version
+	if version == "" {
+		version = "9.5" // default OS version from kubebuilder marker
+	}
+	arch := "amd64"
+
+	// Truncate schematicID to 63 chars for label value (Kubernetes label limit)
+	labelSchematicID := schematicID
+	if len(labelSchematicID) > 63 {
+		labelSchematicID = labelSchematicID[:63]
+	}
+
+	// Build label selector for deduplication
+	matchLabels := map[string]string{
+		butlerv1alpha1.LabelSchematicID:    labelSchematicID,
+		butlerv1alpha1.LabelImageVersion:   version,
+		butlerv1alpha1.LabelProviderConfig: pc.Name,
+		butlerv1alpha1.LabelImageArch:      arch,
+	}
+
+	// List existing ImageSyncs matching labels in the TC's namespace
+	var existingList butlerv1alpha1.ImageSyncList
+	if err := r.List(ctx, &existingList,
+		client.InNamespace(tc.Namespace),
+		client.MatchingLabels(matchLabels),
+	); err != nil {
+		return "", fmt.Errorf("failed to list ImageSyncs: %w", err)
+	}
+
+	if len(existingList.Items) > 0 {
+		is := &existingList.Items[0]
+
+		switch {
+		case is.IsReady():
+			logger.V(1).Info("ImageSync is ready", "name", is.Name, "providerImageRef", is.Status.ProviderImageRef)
+			r.setCondition(tc, butlerv1alpha1.TenantClusterConditionImageReady,
+				metav1.ConditionTrue, "ImageReady", "OS image synced to provider")
+			tc.Status.ImageSyncRef = &butlerv1alpha1.LocalObjectReference{Name: is.Name}
+			return is.Status.ProviderImageRef, nil
+
+		case is.IsFailed():
+			reason := is.Status.FailureReason
+			if reason == "" {
+				reason = "ImageSyncFailed"
+			}
+			message := is.Status.FailureMessage
+			if message == "" {
+				message = "Image sync failed"
+			}
+			r.setCondition(tc, butlerv1alpha1.TenantClusterConditionImageReady,
+				metav1.ConditionFalse, reason, message)
+			tc.Status.ImageSyncRef = &butlerv1alpha1.LocalObjectReference{Name: is.Name}
+			return "", fmt.Errorf("ImageSync %s failed: %s", is.Name, message)
+
+		default:
+			// In progress (Pending, Building, Downloading, Uploading)
+			logger.Info("ImageSync in progress", "name", is.Name, "phase", is.Status.Phase)
+			r.setCondition(tc, butlerv1alpha1.TenantClusterConditionImageReady,
+				metav1.ConditionFalse, "ImageSyncInProgress",
+				fmt.Sprintf("Image sync %s is %s", is.Name, is.Status.Phase))
+			tc.Status.ImageSyncRef = &butlerv1alpha1.LocalObjectReference{Name: is.Name}
+			return "", fmt.Errorf("ImageSync %s is in progress (phase: %s)", is.Name, is.Status.Phase)
+		}
+	}
+
+	// No existing ImageSync found — create one
+
+	// Build a short, DNS-safe name
+	schematicPrefix := schematicID
+	if len(schematicPrefix) > 8 {
+		schematicPrefix = schematicPrefix[:8]
+	}
+	// Sanitize version for DNS label (replace dots with dashes, strip leading 'v')
+	sanitizedVersion := strings.ReplaceAll(version, ".", "-")
+	sanitizedVersion = strings.TrimPrefix(sanitizedVersion, "v")
+	imageSyncName := fmt.Sprintf("%s-%s-%s", tc.Name, schematicPrefix, sanitizedVersion)
+	// Ensure name is DNS-safe (max 253 chars for object names, but keep it reasonable)
+	if len(imageSyncName) > 63 {
+		imageSyncName = imageSyncName[:63]
+	}
+
+	// Resolve provider config reference
+	pcRef := butlerv1alpha1.ProviderReference{
+		Name: pc.Name,
+	}
+	if pc.Namespace != "" && pc.Namespace != tc.Namespace {
+		pcRef.Namespace = pc.Namespace
+	}
+
+	is := &butlerv1alpha1.ImageSync{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      imageSyncName,
+			Namespace: tc.Namespace,
+			Labels: map[string]string{
+				butlerv1alpha1.LabelManagedBy:       "butler",
+				butlerv1alpha1.LabelTenant:          tc.Name,
+				butlerv1alpha1.LabelSchematicID:     labelSchematicID,
+				butlerv1alpha1.LabelImageVersion:    version,
+				butlerv1alpha1.LabelProviderConfig:  pc.Name,
+				butlerv1alpha1.LabelImageArch:       arch,
+			},
+		},
+		Spec: butlerv1alpha1.ImageSyncSpec{
+			FactoryRef: butlerv1alpha1.ImageFactoryRef{
+				SchematicID: schematicID,
+				Version:     version,
+				Arch:        arch,
+			},
+			ProviderConfigRef: pcRef,
+			Format:            "qcow2",
+			TransferMode:      butlerv1alpha1.TransferModeDirect,
+		},
+	}
+
+	// Set owner reference for garbage collection
+	if err := controllerutil.SetControllerReference(tc, is, r.Scheme); err != nil {
+		return "", fmt.Errorf("failed to set owner reference on ImageSync: %w", err)
+	}
+
+	logger.Info("creating ImageSync", "name", is.Name, "schematicID", schematicID, "version", version)
+	if err := r.Create(ctx, is); err != nil {
+		if apierrors.IsAlreadyExists(err) {
+			// Race condition — another reconcile created it. Requeue to pick it up.
+			return "", fmt.Errorf("ImageSync %s was just created, requeueing", imageSyncName)
+		}
+		return "", fmt.Errorf("failed to create ImageSync %s: %w", imageSyncName, err)
+	}
+
+	r.setCondition(tc, butlerv1alpha1.TenantClusterConditionImageReady,
+		metav1.ConditionFalse, "ImageSyncPending", "Image sync created, waiting for provider to process")
+	tc.Status.ImageSyncRef = &butlerv1alpha1.LocalObjectReference{Name: is.Name}
+
+	return "", fmt.Errorf("ImageSync %s created, waiting for completion", imageSyncName)
 }
 
 func (r *Reconciler) setFailedStatus(ctx context.Context, tc *butlerv1alpha1.TenantCluster, reason, message string) (ctrl.Result, error) {

--- a/internal/controller/tenantcluster/tenantcluster_controller.go
+++ b/internal/controller/tenantcluster/tenantcluster_controller.go
@@ -1730,12 +1730,16 @@ func (r *Reconciler) reconcileImageSync(ctx context.Context, tc *butlerv1alpha1.
 		return "", nil
 	}
 
-	// Resolve image version and architecture
+	// Resolve image version, architecture, and platform
 	version := tc.Spec.Workers.MachineTemplate.OS.Version
 	if version == "" {
 		version = "9.5" // default OS version from kubebuilder marker
 	}
+	// Architecture defaults to amd64 — all current Butler providers target amd64.
+	// When multi-arch support is added, this should read from MachineTemplate or OS spec.
 	arch := "amd64"
+	// Platform defaults to nocloud — works for KubeVirt/cloud-init targets (Harvester, Nutanix).
+	platform := "nocloud"
 
 	// Truncate schematicID to 63 chars for label value (Kubernetes label limit)
 	labelSchematicID := schematicID
@@ -1838,6 +1842,7 @@ func (r *Reconciler) reconcileImageSync(ctx context.Context, tc *butlerv1alpha1.
 				SchematicID: schematicID,
 				Version:     version,
 				Arch:        arch,
+				Platform:    platform,
 			},
 			ProviderConfigRef: pcRef,
 			Format:            "qcow2",


### PR DESCRIPTION
## Summary
- Add thin ImageSync lifecycle controller (finalizer, phase management, requeue)
- Integrate `reconcileImageSync()` into TenantCluster reconciler before infrastructure provisioning
- Label-based deduplication: same schematic/version/provider reuses existing ImageSync
- Provider image ref injection into CAPI builder for Harvester and Nutanix

## Context
Part of the Butler Image Sync feature. The thin controller manages ImageSync lifecycle while provider controllers (harvester, nutanix) handle actual image download/upload. TenantCluster reconciler creates ImageSync automatically when a schematicID is specified, waits for Ready, then injects the resolved provider image reference.

## Test plan
- [ ] `go vet ./internal/...` passes
- [ ] ImageSync controller handles creation, finalizer, phase transitions, deletion
- [ ] TenantCluster reconciler creates ImageSync when schematicID is set
- [ ] Existing clusters without schematicID are unaffected