### PR TITLE
fix: WorkersReady condition and worker count accuracy

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/butlerdotdev/butler-controller
 go 1.24.6
 
 require (
-	github.com/butlerdotdev/butler-api v0.9.1
+	github.com/butlerdotdev/butler-api v0.9.2
 	github.com/onsi/ginkgo/v2 v2.22.0
 	github.com/onsi/gomega v1.36.1
 	github.com/prometheus/client_golang v1.22.0

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
-github.com/butlerdotdev/butler-api v0.9.1 h1:7K9Sffg0XaRSDx9QUDw0v3PRomfRpjr1RE3kxJEmz00=
-github.com/butlerdotdev/butler-api v0.9.1/go.mod h1:q/RjPFM/r2ELq4DqR78OiAxerKBvH5D4nTGsVLKbjqY=
+github.com/butlerdotdev/butler-api v0.9.2 h1:Rx7RU1/5dW17z2Nz7PjquCtzqsmDZ2R4smBUz0bbLEU=
+github.com/butlerdotdev/butler-api v0.9.2/go.mod h1:q/RjPFM/r2ELq4DqR78OiAxerKBvH5D4nTGsVLKbjqY=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/internal/controller/tenantcluster/tenantcluster_controller.go
+++ b/internal/controller/tenantcluster/tenantcluster_controller.go
@@ -221,7 +221,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 
 	// Sync MachineDeployment replicas for Ready clusters
 	// This handles scaling operations after initial provisioning
-	if err := r.reconcileMachineDeploymentReplicas(ctx, tc); err != nil {
+	if err := r.reconcileMachineDeploymentReplicas(ctx, tc, butlerConfig); err != nil {
 		logger.Error(err, "failed to reconcile MachineDeployment replicas")
 		// Don't fail the reconcile, just log - scaling is not critical path
 	}
@@ -978,8 +978,8 @@ func (r *Reconciler) checkInfrastructureStatus(ctx context.Context, tc *butlerv1
 // reconcileMachineDeploymentReplicas syncs worker count from TenantCluster spec to MachineDeployment.
 // This is called on every reconcile to ensure spec.workers.replicas changes are propagated
 // to the underlying CAPI MachineDeployment, enabling cluster scaling operations.
-// It also updates the TenantCluster status with current worker counts.
-func (r *Reconciler) reconcileMachineDeploymentReplicas(ctx context.Context, tc *butlerv1alpha1.TenantCluster) error {
+// It also updates the TenantCluster status with current worker counts and the WorkersReady condition.
+func (r *Reconciler) reconcileMachineDeploymentReplicas(ctx context.Context, tc *butlerv1alpha1.TenantCluster, butlerConfig *butlerv1alpha1.ButlerConfig) error {
 	logger := log.FromContext(ctx)
 
 	// Only sync when cluster is Ready or Installing
@@ -1025,8 +1025,40 @@ func (r *Reconciler) reconcileMachineDeploymentReplicas(ctx context.Context, tc 
 
 	// Update TenantCluster status with worker counts from MachineDeployment
 	readyReplicas, _, _ := unstructured.NestedInt64(md.Object, "status", "readyReplicas")
+
+	// CAPI MachineDeployment readyReplicas can be 0 even when workers are actually running,
+	// because CAPI can't match Machine→Node without spec.providerID (e.g. Talos, Flatcar on KubeVirt).
+	// When the cluster is already Ready, fall back to querying the tenant API server directly.
+	// To avoid unnecessary API calls at scale, skip the query when the previous reconcile already
+	// found all workers ready (status matches desired). Only re-query on first check or during scaling.
+	if readyReplicas == 0 && tc.Status.Phase == butlerv1alpha1.TenantClusterPhaseReady {
+		previousReady := tc.Status.WorkerNodesReady
+		if previousReady > 0 && previousReady == int32(desiredReplicas) {
+			// Workers fully converged last time — reuse cached count
+			readyReplicas = int64(previousReady)
+		} else {
+			// First check, scaling in progress, or workers not yet converged — query tenant API
+			if nodeCount, err := r.countTenantReadyNodes(ctx, tc, butlerConfig); err == nil && nodeCount > 0 {
+				readyReplicas = int64(nodeCount)
+				logger.V(1).Info("using tenant node count as CAPI readyReplicas fallback",
+					"nodeCount", nodeCount)
+			}
+		}
+	}
+
 	tc.Status.WorkerNodesReady = int32(readyReplicas)
 	tc.Status.WorkerNodesDesired = int32(desiredReplicas)
+
+	// Update WorkersReady condition based on current worker counts
+	if tc.Status.WorkerNodesReady >= tc.Status.WorkerNodesDesired && tc.Status.WorkerNodesDesired > 0 {
+		r.setCondition(tc, butlerv1alpha1.TenantClusterConditionWorkersReady,
+			metav1.ConditionTrue, ReasonWorkersReady,
+			fmt.Sprintf("All %d workers ready", tc.Status.WorkerNodesReady))
+	} else {
+		r.setCondition(tc, butlerv1alpha1.TenantClusterConditionWorkersReady,
+			metav1.ConditionFalse, ReasonWorkersProvisioning,
+			fmt.Sprintf("Workers provisioning: %d/%d ready", tc.Status.WorkerNodesReady, tc.Status.WorkerNodesDesired))
+	}
 
 	// Check if MachineDeployment spec needs to be scaled
 	if currentSpecReplicas == desiredReplicas {
@@ -1051,6 +1083,52 @@ func (r *Reconciler) reconcileMachineDeploymentReplicas(ctx context.Context, tc 
 		"replicas", desiredReplicas)
 
 	return nil
+}
+
+// countTenantReadyNodes queries the tenant cluster's API server to count Ready worker nodes.
+// This is a fallback for when CAPI readyReplicas is unreliable (e.g. no providerID on nodes).
+// Returns 0 without error if the tenant cluster is unreachable (non-fatal).
+func (r *Reconciler) countTenantReadyNodes(ctx context.Context, tc *butlerv1alpha1.TenantCluster, butlerConfig *butlerv1alpha1.ButlerConfig) (int32, error) {
+	kubeconfigData, err := r.getTenantKubeconfig(ctx, tc, butlerConfig)
+	if err != nil {
+		return 0, nil // non-fatal: kubeconfig not available yet
+	}
+
+	restConfig, err := clientcmd.RESTConfigFromKubeConfig(kubeconfigData)
+	if err != nil {
+		return 0, nil
+	}
+	// Short timeout to avoid blocking reconcile if tenant API is slow
+	restConfig.Timeout = 10 * time.Second
+
+	clientset, err := kubernetes.NewForConfig(restConfig)
+	if err != nil {
+		return 0, nil
+	}
+
+	nodes, err := clientset.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return 0, nil // non-fatal: tenant cluster may be unreachable
+	}
+
+	var readyCount int32
+	for _, node := range nodes.Items {
+		// Skip control plane nodes (only count workers)
+		if _, isMaster := node.Labels["node-role.kubernetes.io/master"]; isMaster {
+			continue
+		}
+		if _, isCP := node.Labels["node-role.kubernetes.io/control-plane"]; isCP {
+			continue
+		}
+		for _, cond := range node.Status.Conditions {
+			if cond.Type == corev1.NodeReady && cond.Status == corev1.ConditionTrue {
+				readyCount++
+				break
+			}
+		}
+	}
+
+	return readyCount, nil
 }
 
 // reconcileMachineTemplate detects CPU/memory/disk changes in the TenantCluster spec


### PR DESCRIPTION
## Summary

- Add tenant API server fallback when CAPI `readyReplicas` is 0 on Ready clusters (CAPI can't match Machine→Node without `spec.providerID` on Talos/Flatcar/KubeVirt)
- Cache the result to avoid per-reconcile API calls — only queries on first check or during scaling
- Set `WorkersReady` condition in `reconcileMachineDeploymentReplicas` so it transitions to `True` when all workers are ready (previously only set during initial provisioning and never re-evaluated)

Depends on butlerdotdev/butler-api#25 (omitempty removal).

## Test plan

- [x] `go vet ./internal/...` passes
- [x] Validated on butler-beta with deployed controller scaled to 0
- [x] All 15 Ready clusters show correct `workerNodesReady`/`workerNodesDesired`
- [x] WorkersReady condition transitions to `True/WorkersReady` on converged clusters
- [x] e2e-flatcar (1/2 mid-scale) correctly shows `False/WorkersProvisioning`
- [x] Installing clusters show `workerNodesReady: 0` (omitempty fix)
- [x] 6 tenant API calls on first cycle, 0 after (caching confirmed)
- [x] 0 TenantCluster conflict errors