### PR TITLE
feat: StewardControlPlane spec drift reconciliation and MachineTemplate extensions

### DIFF
--- a/internal/capi/builder.go
+++ b/internal/capi/builder.go
@@ -825,48 +825,37 @@ func parseImageNamespace(imageName string) (string, string) {
 	return "default", imageName
 }
 
-// getMachineSpecs extracts CPU, Memory, and Disk from TenantCluster spec.
-// Returns values formatted for HarvesterMachineTemplate.
-func (b *Builder) getMachineSpecs() (cpu int64, memory string, disk string) {
-	// Defaults
+// GetMachineSpecs extracts CPU, Memory, and Disk from TenantCluster spec with defaults.
+func GetMachineSpecs(tc *butlerv1alpha1.TenantCluster) (cpu int64, memory string, disk string) {
 	cpu = DefaultWorkerCPU
 	memoryMB := DefaultWorkerMemoryMB
 	diskGB := DefaultWorkerDiskGB
 
-	// Check if MachineTemplate is specified
-	mt := b.tc.Spec.Workers.MachineTemplate
+	mt := tc.Spec.Workers.MachineTemplate
 
-	// CPU - direct int32 field
 	if mt.CPU > 0 {
 		cpu = int64(mt.CPU)
 	}
 
-	// Memory - resource.Quantity, need to convert to string for Harvester
-	// Harvester expects format like "8Gi" or "8192Mi"
 	if !mt.Memory.IsZero() {
-		// Get value in bytes and convert to Gi for cleaner output
 		memBytes := mt.Memory.Value()
 		memGi := memBytes / (1024 * 1024 * 1024)
 		if memGi > 0 {
 			memory = fmt.Sprintf("%dGi", memGi)
 		} else {
-			// Fall back to Mi if less than 1Gi
 			memMi := memBytes / (1024 * 1024)
 			memory = fmt.Sprintf("%dMi", memMi)
 		}
 	} else {
-		// Use default in Mi format
 		memory = fmt.Sprintf("%dMi", memoryMB)
 	}
 
-	// DiskSize - resource.Quantity, convert to string for Harvester volumeSize
 	if !mt.DiskSize.IsZero() {
 		diskBytes := mt.DiskSize.Value()
 		diskGiB := diskBytes / (1024 * 1024 * 1024)
 		if diskGiB > 0 {
 			disk = fmt.Sprintf("%dGi", diskGiB)
 		} else {
-			// Unlikely but handle sub-Gi disks
 			diskMi := diskBytes / (1024 * 1024)
 			disk = fmt.Sprintf("%dMi", diskMi)
 		}
@@ -875,6 +864,10 @@ func (b *Builder) getMachineSpecs() (cpu int64, memory string, disk string) {
 	}
 
 	return cpu, memory, disk
+}
+
+func (b *Builder) getMachineSpecs() (cpu int64, memory string, disk string) {
+	return GetMachineSpecs(b.tc)
 }
 
 // buildKubeadmConfigTemplate constructs the KubeadmConfigTemplate with Rocky Linux bootstrap.
@@ -1028,27 +1021,23 @@ func (b *Builder) needsIngressHostsEntry() bool {
 		mode == butlerv1alpha1.ControlPlaneExposureModeGateway
 }
 
-// resolveControlPlaneResources merges ButlerConfig defaults with TenantCluster overrides.
+// ResolveControlPlaneResources merges ButlerConfig defaults with TenantCluster overrides.
 // Returns nil if no resources are configured (BestEffort QoS).
-func (b *Builder) resolveControlPlaneResources() *butlerv1alpha1.ControlPlaneResourcesSpec {
-	// Start with platform defaults
+func ResolveControlPlaneResources(tc *butlerv1alpha1.TenantCluster, butlerConfig *butlerv1alpha1.ButlerConfig) *butlerv1alpha1.ControlPlaneResourcesSpec {
 	var result *butlerv1alpha1.ControlPlaneResourcesSpec
-	if b.butlerConfig != nil {
-		result = b.butlerConfig.GetDefaultControlPlaneResources()
+	if butlerConfig != nil {
+		result = butlerConfig.GetDefaultControlPlaneResources()
 	}
 
-	// Per-cluster overrides replace per-component
-	tcResources := b.tc.Spec.ControlPlane.Resources
+	tcResources := tc.Spec.ControlPlane.Resources
 	if tcResources == nil {
 		return result
 	}
 
-	// If no platform defaults, use TC resources directly
 	if result == nil {
 		return tcResources
 	}
 
-	// Merge: TC component overrides replace entire component from ButlerConfig
 	merged := result.DeepCopy()
 	if tcResources.APIServer != nil {
 		merged.APIServer = tcResources.APIServer
@@ -1062,10 +1051,13 @@ func (b *Builder) resolveControlPlaneResources() *butlerv1alpha1.ControlPlaneRes
 	return merged
 }
 
-// componentResourceMap converts a ComponentResources to an unstructured map
-// matching the StewardControlPlane's ControlPlaneComponent shape (which wraps
-// corev1.ResourceRequirements under a "resources" key).
-func (b *Builder) componentResourceMap(cr *butlerv1alpha1.ComponentResources) map[string]interface{} {
+func (b *Builder) resolveControlPlaneResources() *butlerv1alpha1.ControlPlaneResourcesSpec {
+	return ResolveControlPlaneResources(b.tc, b.butlerConfig)
+}
+
+// ComponentResourceMap converts a ComponentResources to an unstructured map
+// matching the StewardControlPlane's ControlPlaneComponent shape.
+func ComponentResourceMap(cr *butlerv1alpha1.ComponentResources) map[string]interface{} {
 	result := map[string]interface{}{}
 	resMap := map[string]interface{}{}
 
@@ -1099,6 +1091,10 @@ func (b *Builder) componentResourceMap(cr *butlerv1alpha1.ComponentResources) ma
 		result["resources"] = resMap
 	}
 	return result
+}
+
+func (b *Builder) componentResourceMap(cr *butlerv1alpha1.ComponentResources) map[string]interface{} {
+	return ComponentResourceMap(cr)
 }
 
 // buildMachineDeployment constructs the MachineDeployment resource.

--- a/internal/controller/tenantcluster/tenantcluster_controller.go
+++ b/internal/controller/tenantcluster/tenantcluster_controller.go
@@ -1177,13 +1177,11 @@ func (r *Reconciler) reconcileStewardControlPlane(ctx context.Context, tc *butle
 		changes = append(changes, fmt.Sprintf("version %s->%s", currentVersion, tc.Spec.KubernetesVersion))
 	}
 
-	// Replicas drift
+	// Replicas drift. Only patch if TC explicitly sets replicas (> 0).
+	// SCP defaults to 2 via kubebuilder; patching 0 -> 1 would fight the default.
 	currentReplicas, _, _ := unstructured.NestedInt64(scp.Object, "spec", "replicas")
 	desiredReplicas := int64(tc.Spec.ControlPlane.Replicas)
-	if desiredReplicas < 1 {
-		desiredReplicas = 1
-	}
-	if desiredReplicas != currentReplicas {
+	if desiredReplicas > 0 && desiredReplicas != currentReplicas {
 		specPatch["replicas"] = desiredReplicas
 		changes = append(changes, fmt.Sprintf("replicas %d->%d", currentReplicas, desiredReplicas))
 	}
@@ -1192,19 +1190,19 @@ func (r *Reconciler) reconcileStewardControlPlane(ctx context.Context, tc *butle
 	desired := capi.ResolveControlPlaneResources(tc, butlerConfig)
 	if desired != nil {
 		if desired.APIServer != nil {
-			if r.cpComponentDrifted(scp, "apiServer", desired.APIServer) {
+			if cpComponentDrifted(scp, "apiServer", desired.APIServer) {
 				specPatch["apiServer"] = capi.ComponentResourceMap(desired.APIServer)
 				changes = append(changes, "apiServer resources")
 			}
 		}
 		if desired.ControllerManager != nil {
-			if r.cpComponentDrifted(scp, "controllerManager", desired.ControllerManager) {
+			if cpComponentDrifted(scp, "controllerManager", desired.ControllerManager) {
 				specPatch["controllerManager"] = capi.ComponentResourceMap(desired.ControllerManager)
 				changes = append(changes, "controllerManager resources")
 			}
 		}
 		if desired.Scheduler != nil {
-			if r.cpComponentDrifted(scp, "scheduler", desired.Scheduler) {
+			if cpComponentDrifted(scp, "scheduler", desired.Scheduler) {
 				specPatch["scheduler"] = capi.ComponentResourceMap(desired.Scheduler)
 				changes = append(changes, "scheduler resources")
 			}
@@ -1224,9 +1222,7 @@ func (r *Reconciler) reconcileStewardControlPlane(ctx context.Context, tc *butle
 	return r.Patch(ctx, scp, client.RawPatch(types.MergePatchType, patchBytes))
 }
 
-// cpComponentDrifted returns true when the desired ComponentResources differ
-// from the values stored on the live StewardControlPlane for a given component.
-func (r *Reconciler) cpComponentDrifted(scp *unstructured.Unstructured, component string, desired *butlerv1alpha1.ComponentResources) bool {
+func cpComponentDrifted(scp *unstructured.Unstructured, component string, desired *butlerv1alpha1.ComponentResources) bool {
 	check := func(path []string, want *resource.Quantity) bool {
 		if want == nil {
 			return false
@@ -1402,29 +1398,40 @@ func (r *Reconciler) reconcileMachineTemplate(ctx context.Context, tc *butlerv1a
 	// Remove managedFields to avoid conflicts
 	newTmpl.SetManagedFields(nil)
 
+	var setErrs []error
+	setField := func(obj map[string]interface{}, val interface{}, fields ...string) {
+		if err := unstructured.SetNestedField(obj, val, fields...); err != nil {
+			setErrs = append(setErrs, err)
+		}
+	}
+
 	switch infraRefKind {
 	case "KubevirtMachineTemplate":
 		vmBase := []string{"spec", "template", "spec", "virtualMachineTemplate", "spec", "template", "spec", "domain"}
-		_ = unstructured.SetNestedField(newTmpl.Object, desiredCPU, append(vmBase, "cpu", "cores")...)
-		_ = unstructured.SetNestedField(newTmpl.Object, desiredMemory, append(vmBase, "resources", "requests", "memory")...)
-		_ = unstructured.SetNestedField(newTmpl.Object, desiredMemory, append(vmBase, "resources", "limits", "memory")...)
-		_ = unstructured.SetNestedField(newTmpl.Object, fmt.Sprintf("%d", desiredCPU), append(vmBase, "resources", "limits", "cpu")...)
+		setField(newTmpl.Object, desiredCPU, append(vmBase, "cpu", "cores")...)
+		setField(newTmpl.Object, desiredMemory, append(vmBase, "resources", "requests", "memory")...)
+		setField(newTmpl.Object, desiredMemory, append(vmBase, "resources", "limits", "memory")...)
+		setField(newTmpl.Object, fmt.Sprintf("%d", desiredCPU), append(vmBase, "resources", "limits", "cpu")...)
 
 		dvTemplates, ok, _ := unstructured.NestedSlice(newTmpl.Object,
 			"spec", "template", "spec", "virtualMachineTemplate", "spec", "dataVolumeTemplates")
 		if ok && len(dvTemplates) > 0 {
 			if dvt, ok := dvTemplates[0].(map[string]interface{}); ok {
-				_ = unstructured.SetNestedField(dvt, desiredDisk, "spec", "storage", "resources", "requests", "storage")
+				setField(dvt, desiredDisk, "spec", "storage", "resources", "requests", "storage")
 				dvTemplates[0] = dvt
-				_ = unstructured.SetNestedField(newTmpl.Object, dvTemplates,
+				setField(newTmpl.Object, dvTemplates,
 					"spec", "template", "spec", "virtualMachineTemplate", "spec", "dataVolumeTemplates")
 			}
 		}
 
 	case "NutanixMachineTemplate":
-		_ = unstructured.SetNestedField(newTmpl.Object, desiredCPU, "spec", "template", "spec", "vcpuSockets")
-		_ = unstructured.SetNestedField(newTmpl.Object, desiredMemory, "spec", "template", "spec", "memorySize")
-		_ = unstructured.SetNestedField(newTmpl.Object, desiredDisk, "spec", "template", "spec", "systemDiskSize")
+		setField(newTmpl.Object, desiredCPU, "spec", "template", "spec", "vcpuSockets")
+		setField(newTmpl.Object, desiredMemory, "spec", "template", "spec", "memorySize")
+		setField(newTmpl.Object, desiredDisk, "spec", "template", "spec", "systemDiskSize")
+	}
+
+	if len(setErrs) > 0 {
+		return fmt.Errorf("failed to set fields on new MachineTemplate: %v", setErrs[0])
 	}
 
 	// Create the new template

--- a/internal/controller/tenantcluster/tenantcluster_controller.go
+++ b/internal/controller/tenantcluster/tenantcluster_controller.go
@@ -29,6 +29,7 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -224,6 +225,11 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	if err := r.reconcileMachineDeploymentReplicas(ctx, tc, butlerConfig); err != nil {
 		logger.Error(err, "failed to reconcile MachineDeployment replicas")
 		// Don't fail the reconcile, just log - scaling is not critical path
+	}
+
+	// Sync StewardControlPlane spec (K8s version, CP replicas, CP resources)
+	if err := r.reconcileStewardControlPlane(ctx, tc, butlerConfig); err != nil {
+		logger.Error(err, "failed to reconcile StewardControlPlane")
 	}
 
 	// Detect and apply machineTemplate changes (CPU/memory/disk)
@@ -1131,6 +1137,130 @@ func (r *Reconciler) countTenantReadyNodes(ctx context.Context, tc *butlerv1alph
 	return readyCount, nil
 }
 
+// reconcileStewardControlPlane patches the StewardControlPlane when the TenantCluster
+// spec diverges from the live SCP (version, replicas, CP resources).
+func (r *Reconciler) reconcileStewardControlPlane(ctx context.Context, tc *butlerv1alpha1.TenantCluster, butlerConfig *butlerv1alpha1.ButlerConfig) error {
+	logger := log.FromContext(ctx)
+
+	if tc.Status.Phase != butlerv1alpha1.TenantClusterPhaseReady &&
+		tc.Status.Phase != butlerv1alpha1.TenantClusterPhaseInstalling {
+		return nil
+	}
+	if tc.Status.TenantNamespace == "" {
+		return nil
+	}
+
+	scp := &unstructured.Unstructured{}
+	scp.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   capi.ControlPlaneAPIGroup,
+		Version: capi.ControlPlaneAPIVersion,
+		Kind:    "StewardControlPlane",
+	})
+	if err := r.Get(ctx, types.NamespacedName{
+		Namespace: tc.Status.TenantNamespace,
+		Name:      tc.Name,
+	}, scp); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return fmt.Errorf("failed to get StewardControlPlane: %w", err)
+	}
+
+	patch := map[string]interface{}{"spec": map[string]interface{}{}}
+	specPatch := patch["spec"].(map[string]interface{})
+	var changes []string
+
+	// Version drift
+	currentVersion, _, _ := unstructured.NestedString(scp.Object, "spec", "version")
+	if tc.Spec.KubernetesVersion != "" && tc.Spec.KubernetesVersion != currentVersion {
+		specPatch["version"] = tc.Spec.KubernetesVersion
+		changes = append(changes, fmt.Sprintf("version %s->%s", currentVersion, tc.Spec.KubernetesVersion))
+	}
+
+	// Replicas drift
+	currentReplicas, _, _ := unstructured.NestedInt64(scp.Object, "spec", "replicas")
+	desiredReplicas := int64(tc.Spec.ControlPlane.Replicas)
+	if desiredReplicas < 1 {
+		desiredReplicas = 1
+	}
+	if desiredReplicas != currentReplicas {
+		specPatch["replicas"] = desiredReplicas
+		changes = append(changes, fmt.Sprintf("replicas %d->%d", currentReplicas, desiredReplicas))
+	}
+
+	// CP resource drift
+	desired := capi.ResolveControlPlaneResources(tc, butlerConfig)
+	if desired != nil {
+		if desired.APIServer != nil {
+			if r.cpComponentDrifted(scp, "apiServer", desired.APIServer) {
+				specPatch["apiServer"] = capi.ComponentResourceMap(desired.APIServer)
+				changes = append(changes, "apiServer resources")
+			}
+		}
+		if desired.ControllerManager != nil {
+			if r.cpComponentDrifted(scp, "controllerManager", desired.ControllerManager) {
+				specPatch["controllerManager"] = capi.ComponentResourceMap(desired.ControllerManager)
+				changes = append(changes, "controllerManager resources")
+			}
+		}
+		if desired.Scheduler != nil {
+			if r.cpComponentDrifted(scp, "scheduler", desired.Scheduler) {
+				specPatch["scheduler"] = capi.ComponentResourceMap(desired.Scheduler)
+				changes = append(changes, "scheduler resources")
+			}
+		}
+	}
+
+	if len(changes) == 0 {
+		return nil
+	}
+
+	patchBytes, err := json.Marshal(patch)
+	if err != nil {
+		return fmt.Errorf("failed to marshal SCP patch: %w", err)
+	}
+
+	logger.Info("updating StewardControlPlane", "cluster", tc.Name, "changes", changes)
+	return r.Patch(ctx, scp, client.RawPatch(types.MergePatchType, patchBytes))
+}
+
+// cpComponentDrifted returns true when the desired ComponentResources differ
+// from the values stored on the live StewardControlPlane for a given component.
+func (r *Reconciler) cpComponentDrifted(scp *unstructured.Unstructured, component string, desired *butlerv1alpha1.ComponentResources) bool {
+	check := func(path []string, want *resource.Quantity) bool {
+		if want == nil {
+			return false
+		}
+		cur, ok, _ := unstructured.NestedString(scp.Object, path...)
+		if !ok {
+			return true
+		}
+		curQ, err := resource.ParseQuantity(cur)
+		if err != nil {
+			return true
+		}
+		return curQ.Cmp(*want) != 0
+	}
+
+	if desired.Requests != nil {
+		if check([]string{"spec", component, "resources", "requests", "cpu"}, desired.Requests.CPU) {
+			return true
+		}
+		if check([]string{"spec", component, "resources", "requests", "memory"}, desired.Requests.Memory) {
+			return true
+		}
+	}
+	if desired.Limits != nil {
+		if check([]string{"spec", component, "resources", "limits", "cpu"}, desired.Limits.CPU) {
+			return true
+		}
+		if check([]string{"spec", component, "resources", "limits", "memory"}, desired.Limits.Memory) {
+			return true
+		}
+	}
+	return false
+}
+
 // reconcileMachineTemplate detects CPU/memory/disk changes in the TenantCluster spec
 // and performs a rolling update by creating a new immutable MachineTemplate and updating
 // the MachineDeployment's infrastructureRef to point to it.
@@ -1191,48 +1321,52 @@ func (r *Reconciler) reconcileMachineTemplate(ctx context.Context, tc *butlerv1a
 		return fmt.Errorf("failed to get current MachineTemplate: %w", err)
 	}
 
-	// Extract current specs from the template based on provider type
-	var currentCPU int64
-	var currentMemory string
+	desiredCPU, desiredMemory, desiredDisk := capi.GetMachineSpecs(tc)
 
-	if infraRefKind == "KubevirtMachineTemplate" {
+	var currentCPU int64
+	var currentMemory, currentDisk string
+
+	switch infraRefKind {
+	case "KubevirtMachineTemplate":
 		currentCPU, _, _ = unstructured.NestedInt64(currentTmpl.Object,
 			"spec", "template", "spec", "virtualMachineTemplate", "spec",
 			"template", "spec", "domain", "cpu", "cores")
 		currentMemory, _, _ = unstructured.NestedString(currentTmpl.Object,
 			"spec", "template", "spec", "virtualMachineTemplate", "spec",
 			"template", "spec", "domain", "resources", "requests", "memory")
-	} else {
-		// Nutanix or other providers — skip for now
+		dvTemplates, ok, _ := unstructured.NestedSlice(currentTmpl.Object,
+			"spec", "template", "spec", "virtualMachineTemplate", "spec",
+			"dataVolumeTemplates")
+		if ok && len(dvTemplates) > 0 {
+			if dvt, ok := dvTemplates[0].(map[string]interface{}); ok {
+				currentDisk, _, _ = unstructured.NestedString(dvt,
+					"spec", "storage", "resources", "requests", "storage")
+			}
+		}
+
+	case "NutanixMachineTemplate":
+		currentCPU, _, _ = unstructured.NestedInt64(currentTmpl.Object,
+			"spec", "template", "spec", "vcpuSockets")
+		currentMemory, _, _ = unstructured.NestedString(currentTmpl.Object,
+			"spec", "template", "spec", "memorySize")
+		currentDisk, _, _ = unstructured.NestedString(currentTmpl.Object,
+			"spec", "template", "spec", "systemDiskSize")
+
+	default:
+		logger.Info("machine template rolling update not supported for provider",
+			"kind", infraRefKind, "cluster", tc.Name)
 		return nil
 	}
 
-	// Compute desired specs from TenantCluster
-	desiredCPU := int64(tc.Spec.Workers.MachineTemplate.CPU)
-	if desiredCPU < 1 {
-		desiredCPU = 2 // default
-	}
-	desiredMemory := "4Gi" // default
-	if !tc.Spec.Workers.MachineTemplate.Memory.IsZero() {
-		memBytes := tc.Spec.Workers.MachineTemplate.Memory.Value()
-		memGi := memBytes / (1024 * 1024 * 1024)
-		if memGi > 0 {
-			desiredMemory = fmt.Sprintf("%dGi", memGi)
-		} else {
-			memMi := memBytes / (1024 * 1024)
-			desiredMemory = fmt.Sprintf("%dMi", memMi)
-		}
-	}
-
-	// Compare — if no change, nothing to do
-	if currentCPU == desiredCPU && currentMemory == desiredMemory {
+	if currentCPU == desiredCPU && currentMemory == desiredMemory && currentDisk == desiredDisk {
 		return nil
 	}
 
 	logger.Info("machine template change detected",
 		"cluster", tc.Name,
 		"currentCPU", currentCPU, "desiredCPU", desiredCPU,
-		"currentMemory", currentMemory, "desiredMemory", desiredMemory)
+		"currentMemory", currentMemory, "desiredMemory", desiredMemory,
+		"currentDisk", currentDisk, "desiredDisk", desiredDisk)
 
 	// Determine new template name — increment version suffix
 	newName := infraRefName + "-v2"
@@ -1268,31 +1402,29 @@ func (r *Reconciler) reconcileMachineTemplate(ctx context.Context, tc *butlerv1a
 	// Remove managedFields to avoid conflicts
 	newTmpl.SetManagedFields(nil)
 
-	if infraRefKind == "KubevirtMachineTemplate" {
-		// Update CPU cores
-		if err := unstructured.SetNestedField(newTmpl.Object, desiredCPU,
-			"spec", "template", "spec", "virtualMachineTemplate", "spec",
-			"template", "spec", "domain", "cpu", "cores"); err != nil {
-			return fmt.Errorf("failed to set CPU cores: %w", err)
+	switch infraRefKind {
+	case "KubevirtMachineTemplate":
+		vmBase := []string{"spec", "template", "spec", "virtualMachineTemplate", "spec", "template", "spec", "domain"}
+		_ = unstructured.SetNestedField(newTmpl.Object, desiredCPU, append(vmBase, "cpu", "cores")...)
+		_ = unstructured.SetNestedField(newTmpl.Object, desiredMemory, append(vmBase, "resources", "requests", "memory")...)
+		_ = unstructured.SetNestedField(newTmpl.Object, desiredMemory, append(vmBase, "resources", "limits", "memory")...)
+		_ = unstructured.SetNestedField(newTmpl.Object, fmt.Sprintf("%d", desiredCPU), append(vmBase, "resources", "limits", "cpu")...)
+
+		dvTemplates, ok, _ := unstructured.NestedSlice(newTmpl.Object,
+			"spec", "template", "spec", "virtualMachineTemplate", "spec", "dataVolumeTemplates")
+		if ok && len(dvTemplates) > 0 {
+			if dvt, ok := dvTemplates[0].(map[string]interface{}); ok {
+				_ = unstructured.SetNestedField(dvt, desiredDisk, "spec", "storage", "resources", "requests", "storage")
+				dvTemplates[0] = dvt
+				_ = unstructured.SetNestedField(newTmpl.Object, dvTemplates,
+					"spec", "template", "spec", "virtualMachineTemplate", "spec", "dataVolumeTemplates")
+			}
 		}
-		// Update memory requests
-		if err := unstructured.SetNestedField(newTmpl.Object, desiredMemory,
-			"spec", "template", "spec", "virtualMachineTemplate", "spec",
-			"template", "spec", "domain", "resources", "requests", "memory"); err != nil {
-			return fmt.Errorf("failed to set memory requests: %w", err)
-		}
-		// Update memory limits
-		if err := unstructured.SetNestedField(newTmpl.Object, desiredMemory,
-			"spec", "template", "spec", "virtualMachineTemplate", "spec",
-			"template", "spec", "domain", "resources", "limits", "memory"); err != nil {
-			return fmt.Errorf("failed to set memory limits: %w", err)
-		}
-		// Update CPU limits
-		if err := unstructured.SetNestedField(newTmpl.Object, fmt.Sprintf("%d", desiredCPU),
-			"spec", "template", "spec", "virtualMachineTemplate", "spec",
-			"template", "spec", "domain", "resources", "limits", "cpu"); err != nil {
-			return fmt.Errorf("failed to set CPU limits: %w", err)
-		}
+
+	case "NutanixMachineTemplate":
+		_ = unstructured.SetNestedField(newTmpl.Object, desiredCPU, "spec", "template", "spec", "vcpuSockets")
+		_ = unstructured.SetNestedField(newTmpl.Object, desiredMemory, "spec", "template", "spec", "memorySize")
+		_ = unstructured.SetNestedField(newTmpl.Object, desiredDisk, "spec", "template", "spec", "systemDiskSize")
 	}
 
 	// Create the new template

--- a/internal/controller/tenantcluster/tenantcluster_scp_test.go
+++ b/internal/controller/tenantcluster/tenantcluster_scp_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	butlerv1alpha1 "github.com/butlerdotdev/butler-api/api/v1alpha1"
+	"github.com/butlerdotdev/butler-controller/internal/capi"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -49,9 +50,7 @@ func quantityPtr(s string) *resource.Quantity {
 }
 
 func TestCpComponentDrifted(t *testing.T) {
-	r := &Reconciler{}
-
-	tests := []struct {
+		tests := []struct {
 		name      string
 		scpCPU    string
 		scpMemory string
@@ -110,12 +109,25 @@ func TestCpComponentDrifted(t *testing.T) {
 					Memory: quantityPtr(tt.wantMem),
 				},
 			}
-			got := r.cpComponentDrifted(scp, "apiServer", desired)
+			got := cpComponentDrifted(scp, "apiServer", desired)
 			if got != tt.drifted {
 				t.Errorf("cpComponentDrifted() = %v, want %v", got, tt.drifted)
 			}
 		})
 	}
+
+	t.Run("limits drift with nil requests", func(t *testing.T) {
+		scp := makeSCP("v1.31.0", 1, "", "")
+		desired := &butlerv1alpha1.ComponentResources{
+			Limits: &butlerv1alpha1.ResourceQuantities{
+				CPU:    quantityPtr("2"),
+				Memory: quantityPtr("1Gi"),
+			},
+		}
+		if !cpComponentDrifted(scp, "apiServer", desired) {
+			t.Error("expected drift when limits set but not on SCP")
+		}
+	})
 }
 
 func TestReconcileStewardControlPlane_PatchContent(t *testing.T) {
@@ -268,10 +280,7 @@ func TestReconcileStewardControlPlane_PatchContent(t *testing.T) {
 
 func int64Ptr(v int64) *int64 { return &v }
 
-// buildSCPPatch extracts the patch-building logic so it can be tested without a real client.
-// This mirrors the logic inside reconcileStewardControlPlane.
 func buildSCPPatch(tc *butlerv1alpha1.TenantCluster, scp *unstructured.Unstructured, butlerConfig *butlerv1alpha1.ButlerConfig) (map[string]interface{}, []string) {
-	r := &Reconciler{}
 	patch := map[string]interface{}{"spec": map[string]interface{}{}}
 	specPatch := patch["spec"].(map[string]interface{})
 	var changes []string
@@ -284,22 +293,24 @@ func buildSCPPatch(tc *butlerv1alpha1.TenantCluster, scp *unstructured.Unstructu
 
 	currentReplicas, _, _ := unstructured.NestedInt64(scp.Object, "spec", "replicas")
 	desiredReplicas := int64(tc.Spec.ControlPlane.Replicas)
-	if desiredReplicas < 1 {
-		desiredReplicas = 1
-	}
-	if desiredReplicas != currentReplicas {
+	if desiredReplicas > 0 && desiredReplicas != currentReplicas {
 		specPatch["replicas"] = desiredReplicas
 		changes = append(changes, "replicas")
 	}
 
-	desired := tc.Spec.ControlPlane.Resources
-	if butlerConfig != nil {
-		// Would use capi.ResolveControlPlaneResources here in production
-	}
+	desired := capi.ResolveControlPlaneResources(tc, butlerConfig)
 	if desired != nil {
-		if desired.APIServer != nil && r.cpComponentDrifted(scp, "apiServer", desired.APIServer) {
-			specPatch["apiServer"] = map[string]interface{}{"changed": true}
+		if desired.APIServer != nil && cpComponentDrifted(scp, "apiServer", desired.APIServer) {
+			specPatch["apiServer"] = capi.ComponentResourceMap(desired.APIServer)
 			changes = append(changes, "apiServer")
+		}
+		if desired.ControllerManager != nil && cpComponentDrifted(scp, "controllerManager", desired.ControllerManager) {
+			specPatch["controllerManager"] = capi.ComponentResourceMap(desired.ControllerManager)
+			changes = append(changes, "controllerManager")
+		}
+		if desired.Scheduler != nil && cpComponentDrifted(scp, "scheduler", desired.Scheduler) {
+			specPatch["scheduler"] = capi.ComponentResourceMap(desired.Scheduler)
+			changes = append(changes, "scheduler")
 		}
 	}
 

--- a/internal/controller/tenantcluster/tenantcluster_scp_test.go
+++ b/internal/controller/tenantcluster/tenantcluster_scp_test.go
@@ -1,0 +1,307 @@
+// Copyright 2026 The Butler Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package tenantcluster
+
+import (
+	"encoding/json"
+	"testing"
+
+	butlerv1alpha1 "github.com/butlerdotdev/butler-api/api/v1alpha1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func makeSCP(version string, replicas int64, apiServerCPU, apiServerMem string) *unstructured.Unstructured {
+	spec := map[string]interface{}{
+		"version":  version,
+		"replicas": replicas,
+	}
+	if apiServerCPU != "" || apiServerMem != "" {
+		resources := map[string]interface{}{}
+		requests := map[string]interface{}{}
+		if apiServerCPU != "" {
+			requests["cpu"] = apiServerCPU
+		}
+		if apiServerMem != "" {
+			requests["memory"] = apiServerMem
+		}
+		resources["requests"] = requests
+		spec["apiServer"] = map[string]interface{}{"resources": resources}
+	}
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "controlplane.cluster.x-k8s.io/v1alpha1",
+			"kind":       "StewardControlPlane",
+			"metadata": map[string]interface{}{
+				"name":      "test-cluster",
+				"namespace": "test-ns-abc123",
+			},
+			"spec": spec,
+		},
+	}
+}
+
+func quantityPtr(s string) *resource.Quantity {
+	q := resource.MustParse(s)
+	return &q
+}
+
+func TestCpComponentDrifted(t *testing.T) {
+	r := &Reconciler{}
+
+	tests := []struct {
+		name      string
+		scpCPU    string
+		scpMemory string
+		wantCPU   string
+		wantMem   string
+		drifted   bool
+	}{
+		{
+			name:      "no drift",
+			scpCPU:    "500m",
+			scpMemory: "256Mi",
+			wantCPU:   "500m",
+			wantMem:   "256Mi",
+			drifted:   false,
+		},
+		{
+			name:      "equivalent quantities no drift",
+			scpCPU:    "500m",
+			scpMemory: "256Mi",
+			wantCPU:   "0.5",
+			wantMem:   "268435456",
+			drifted:   false,
+		},
+		{
+			name:      "cpu drifted",
+			scpCPU:    "500m",
+			scpMemory: "256Mi",
+			wantCPU:   "1",
+			wantMem:   "256Mi",
+			drifted:   true,
+		},
+		{
+			name:      "memory drifted",
+			scpCPU:    "500m",
+			scpMemory: "256Mi",
+			wantCPU:   "500m",
+			wantMem:   "512Mi",
+			drifted:   true,
+		},
+		{
+			name:      "field missing on scp",
+			scpCPU:    "",
+			scpMemory: "",
+			wantCPU:   "500m",
+			wantMem:   "256Mi",
+			drifted:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scp := makeSCP("v1.31.0", 1, tt.scpCPU, tt.scpMemory)
+			desired := &butlerv1alpha1.ComponentResources{
+				Requests: &butlerv1alpha1.ResourceQuantities{
+					CPU:    quantityPtr(tt.wantCPU),
+					Memory: quantityPtr(tt.wantMem),
+				},
+			}
+			got := r.cpComponentDrifted(scp, "apiServer", desired)
+			if got != tt.drifted {
+				t.Errorf("cpComponentDrifted() = %v, want %v", got, tt.drifted)
+			}
+		})
+	}
+}
+
+func TestReconcileStewardControlPlane_PatchContent(t *testing.T) {
+	tests := []struct {
+		name           string
+		tcVersion      string
+		tcReplicas     int32
+		tcResources    *butlerv1alpha1.ControlPlaneResourcesSpec
+		scpVersion     string
+		scpReplicas    int64
+		scpCPU         string
+		scpMem         string
+		wantNoPatch    bool
+		wantVersion    string
+		wantReplicas   *int64
+		wantAPIServer  bool
+	}{
+		{
+			name:        "no drift produces no patch",
+			tcVersion:   "v1.31.0",
+			tcReplicas:  1,
+			scpVersion:  "v1.31.0",
+			scpReplicas: 1,
+			wantNoPatch: true,
+		},
+		{
+			name:        "version drift",
+			tcVersion:   "v1.32.0",
+			tcReplicas:  1,
+			scpVersion:  "v1.31.0",
+			scpReplicas: 1,
+			wantVersion: "v1.32.0",
+		},
+		{
+			name:         "replicas drift",
+			tcVersion:    "v1.31.0",
+			tcReplicas:   3,
+			scpVersion:   "v1.31.0",
+			scpReplicas:  1,
+			wantReplicas: int64Ptr(3),
+		},
+		{
+			name:       "resource drift",
+			tcVersion:  "v1.31.0",
+			tcReplicas: 1,
+			tcResources: &butlerv1alpha1.ControlPlaneResourcesSpec{
+				APIServer: &butlerv1alpha1.ComponentResources{
+					Requests: &butlerv1alpha1.ResourceQuantities{
+						CPU:    quantityPtr("2"),
+						Memory: quantityPtr("1Gi"),
+					},
+				},
+			},
+			scpVersion:    "v1.31.0",
+			scpReplicas:   1,
+			scpCPU:        "500m",
+			scpMem:        "256Mi",
+			wantAPIServer: true,
+		},
+		{
+			name:       "equivalent resources no drift",
+			tcVersion:  "v1.31.0",
+			tcReplicas: 1,
+			tcResources: &butlerv1alpha1.ControlPlaneResourcesSpec{
+				APIServer: &butlerv1alpha1.ComponentResources{
+					Requests: &butlerv1alpha1.ResourceQuantities{
+						CPU:    quantityPtr("0.5"),
+						Memory: quantityPtr("268435456"),
+					},
+				},
+			},
+			scpVersion:  "v1.31.0",
+			scpReplicas: 1,
+			scpCPU:      "500m",
+			scpMem:      "256Mi",
+			wantNoPatch: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tc := &butlerv1alpha1.TenantCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: "platform-engineering",
+				},
+				Spec: butlerv1alpha1.TenantClusterSpec{
+					KubernetesVersion: tt.tcVersion,
+					ControlPlane: butlerv1alpha1.ControlPlaneSpec{
+						Replicas:  tt.tcReplicas,
+						Resources: tt.tcResources,
+					},
+				},
+				Status: butlerv1alpha1.TenantClusterStatus{
+					Phase:           butlerv1alpha1.TenantClusterPhaseReady,
+					TenantNamespace: "test-ns-abc123",
+				},
+			}
+
+			scp := makeSCP(tt.scpVersion, tt.scpReplicas, tt.scpCPU, tt.scpMem)
+
+			patch, changes := buildSCPPatch(tc, scp, nil)
+
+			if tt.wantNoPatch {
+				if len(changes) != 0 {
+					t.Errorf("expected no changes, got %v", changes)
+				}
+				return
+			}
+			if len(changes) == 0 {
+				t.Fatal("expected changes but got none")
+			}
+
+			patchBytes, err := json.Marshal(patch)
+			if err != nil {
+				t.Fatalf("failed to marshal patch: %v", err)
+			}
+
+			var parsed map[string]interface{}
+			if err := json.Unmarshal(patchBytes, &parsed); err != nil {
+				t.Fatalf("failed to unmarshal patch: %v", err)
+			}
+
+			specPatch, _ := parsed["spec"].(map[string]interface{})
+			if specPatch == nil {
+				t.Fatal("patch missing spec")
+			}
+
+			if tt.wantVersion != "" {
+				if v, ok := specPatch["version"]; !ok || v != tt.wantVersion {
+					t.Errorf("patch version = %v, want %v", v, tt.wantVersion)
+				}
+			}
+			if tt.wantReplicas != nil {
+				v, ok := specPatch["replicas"]
+				if !ok {
+					t.Errorf("patch missing replicas")
+				} else if int64(v.(float64)) != *tt.wantReplicas {
+					t.Errorf("patch replicas = %v, want %v", v, *tt.wantReplicas)
+				}
+			}
+			if tt.wantAPIServer {
+				if _, ok := specPatch["apiServer"]; !ok {
+					t.Errorf("patch missing apiServer")
+				}
+			}
+		})
+	}
+}
+
+func int64Ptr(v int64) *int64 { return &v }
+
+// buildSCPPatch extracts the patch-building logic so it can be tested without a real client.
+// This mirrors the logic inside reconcileStewardControlPlane.
+func buildSCPPatch(tc *butlerv1alpha1.TenantCluster, scp *unstructured.Unstructured, butlerConfig *butlerv1alpha1.ButlerConfig) (map[string]interface{}, []string) {
+	r := &Reconciler{}
+	patch := map[string]interface{}{"spec": map[string]interface{}{}}
+	specPatch := patch["spec"].(map[string]interface{})
+	var changes []string
+
+	currentVersion, _, _ := unstructured.NestedString(scp.Object, "spec", "version")
+	if tc.Spec.KubernetesVersion != "" && tc.Spec.KubernetesVersion != currentVersion {
+		specPatch["version"] = tc.Spec.KubernetesVersion
+		changes = append(changes, "version")
+	}
+
+	currentReplicas, _, _ := unstructured.NestedInt64(scp.Object, "spec", "replicas")
+	desiredReplicas := int64(tc.Spec.ControlPlane.Replicas)
+	if desiredReplicas < 1 {
+		desiredReplicas = 1
+	}
+	if desiredReplicas != currentReplicas {
+		specPatch["replicas"] = desiredReplicas
+		changes = append(changes, "replicas")
+	}
+
+	desired := tc.Spec.ControlPlane.Resources
+	if butlerConfig != nil {
+		// Would use capi.ResolveControlPlaneResources here in production
+	}
+	if desired != nil {
+		if desired.APIServer != nil && r.cpComponentDrifted(scp, "apiServer", desired.APIServer) {
+			specPatch["apiServer"] = map[string]interface{}{"changed": true}
+			changes = append(changes, "apiServer")
+		}
+	}
+
+	return patch, changes
+}


### PR DESCRIPTION
## Summary

- Add `reconcileStewardControlPlane` to detect and patch version, replicas, and CP resource drift between TenantCluster spec and the live StewardControlPlane using MergePatch
- Extend `reconcileMachineTemplate` with disk size drift detection for KubevirtMachineTemplate and full NutanixMachineTemplate support (vcpuSockets, memorySize, systemDiskSize)
- Export `ResolveControlPlaneResources`, `ComponentResourceMap`, and `GetMachineSpecs` from the CAPI builder for reconciler reuse
- Resource quantities compared via `resource.MustParse().Cmp()` to handle equivalent representations

## Test plan

- [x] Unit tests: version/replicas/resource drift, quantity normalization, no-op idempotency
- [x] `go vet` clean
- [x] E2E on butler-beta: memory change triggered new KubevirtMachineTemplate and MachineDeployment update
- [ ] E2E: K8s version change propagates to SCP
- [ ] E2E: CP replicas change propagates to SCP