### PR TITLE
fix: set Talos node hostname to CAPI Machine name for CAPK matching

### DIFF
--- a/internal/controller/tenantcluster/tenantcluster_controller.go
+++ b/internal/controller/tenantcluster/tenantcluster_controller.go
@@ -2503,8 +2503,9 @@ func (r *Reconciler) reconcileTalosApplyConfig(ctx context.Context, tc *butlerv1
 		}
 
 		pendingCount++
+		hostnamePatch := fmt.Sprintf(`{"machine":{"network":{"hostname":%q}}}`, machine.Name)
 		logger.Info("applying Talos config to Machine", "machine", machine.Name, "ip", machine.IP)
-		if err := talosClient.ApplyConfig(ctx, machine.IP, machineConfig); err != nil {
+		if err := talosClient.ApplyConfig(ctx, machine.IP, machineConfig, hostnamePatch); err != nil {
 			// "certificate required" means the node left maintenance mode and already has config.
 			// Treat as success and annotate.
 			if strings.Contains(err.Error(), "certificate required") {

--- a/internal/talos/client.go
+++ b/internal/talos/client.go
@@ -38,7 +38,8 @@ func NewClient() *Client {
 
 // ApplyConfig applies a Talos machine config to a node using talosctl.
 // The --insecure flag is always used because these are fresh VMs in maintenance mode.
-func (c *Client) ApplyConfig(ctx context.Context, nodeIP string, configData []byte) error {
+// Optional configPatches are passed as --config-patch arguments for per-node overrides.
+func (c *Client) ApplyConfig(ctx context.Context, nodeIP string, configData []byte, configPatches ...string) error {
 	logger := log.FromContext(ctx)
 
 	configFile, err := os.CreateTemp("", "talos-config-*.yaml")
@@ -58,6 +59,9 @@ func (c *Client) ApplyConfig(ctx context.Context, nodeIP string, configData []by
 		"--nodes", nodeIP,
 		"--file", configFile.Name(),
 		"--insecure",
+	}
+	for _, patch := range configPatches {
+		args = append(args, "--config-patch", patch)
 	}
 
 	logger.V(1).Info("applying Talos config", "node", nodeIP)


### PR DESCRIPTION
## Summary

CAPK matches Machines to Nodes by `Node.Name == Machine.Name`. Talos defaults to IP-based node names (`talos-{ip}`), causing CAPK to never find the matching node. This blocks KubevirtMachine finalizer removal during deletion, stalling rolling updates indefinitely.

Pass a per-machine `--config-patch` to `talosctl apply-config` that sets `machine.network.hostname` to the CAPI Machine name. Nodes will be named `{cluster}-workers-{hash}-{suffix}` instead of `talos-{ip}`.

Combined with the providerID fix in v0.10.1, this completes the rolling update lifecycle on Harvester: CAPI can match Machine-to-Node (providerID), and CAPK can match Machine-to-Node (hostname) for finalizer cleanup.

## Changes

- `internal/talos/client.go`: Add variadic `configPatches` parameter to `ApplyConfig` (backward compatible)
- `internal/controller/tenantcluster/tenantcluster_controller.go`: Pass hostname patch in `reconcileTalosApplyConfig`

## Test plan

- [x] `go vet` clean
- [x] Existing callers of `ApplyConfig` (without patches) still compile
- [ ] E2E: trigger rolling update on e2e-talos, verify new node joins with machine name as hostname
- [ ] E2E: verify CAPK populates nodeRef and removes finalizer on old machine deletion