### PR TITLE
Controller hardening: concurrency safety, client caching, finalizer robustness

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -45,6 +45,7 @@ import (
 	"github.com/butlerdotdev/butler-controller/internal/controller/tenantaddon"
 	"github.com/butlerdotdev/butler-controller/internal/controller/tenantcluster"
 	"github.com/butlerdotdev/butler-controller/internal/controller/workspace"
+	"github.com/butlerdotdev/butler-controller/internal/tenant"
 	"github.com/butlerdotdev/butler-controller/internal/webhook"
 )
 
@@ -137,11 +138,14 @@ func main() {
 		os.Exit(1)
 	}
 
+	tenantClientManager := tenant.NewClientManager(mgr.GetClient())
+
 	// TenantCluster controller. Orchestrates CAPI resources
 	if err = (&tenantcluster.Reconciler{
-		Client:    mgr.GetClient(),
-		Scheme:    mgr.GetScheme(),
-		Installer: addons.NewInstaller(),
+		Client:        mgr.GetClient(),
+		Scheme:        mgr.GetScheme(),
+		Installer:     addons.NewInstaller(),
+		ClientManager: tenantClientManager,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "TenantCluster")
 		os.Exit(1)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -72,7 +72,7 @@ func main() {
 
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
-	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
+	flag.BoolVar(&enableLeaderElection, "leader-elect", true,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
 	flag.BoolVar(&enableKamajiControllers, "enable-kamaji-controllers", true,

--- a/internal/addons/installer.go
+++ b/internal/addons/installer.go
@@ -117,21 +117,24 @@ func (i *Installer) recoverPendingRelease(ctx context.Context, kubeconfigPath, r
 	output, err := i.runHelmOutput(ctx, kubeconfigPath,
 		"status", releaseName, "--namespace", namespace, "--output", "json")
 	if err != nil {
-		return // release doesn't exist yet, nothing to recover
+		return
 	}
 
-	if !strings.Contains(output, "pending-install") && !strings.Contains(output, "pending-upgrade") {
-		return // release is not stuck
+	status := extractHelmStatus(output)
+	if status != "pending-install" && status != "pending-upgrade" {
+		return
 	}
 
-	if strings.Contains(output, "pending-install") {
+	if status == "pending-install" {
 		logger.Info("recovering stuck pending-install release", "release", releaseName)
 		if err := i.runHelm(ctx, kubeconfigPath, "uninstall", releaseName, "--namespace", namespace); err != nil {
-			logger.Error(err, "failed to uninstall pending release, deleting secrets directly", "release", releaseName)
-			_ = i.runKubectl(ctx, kubeconfigPath,
+			logger.Error(err, "helm uninstall failed, deleting release secrets", "release", releaseName)
+			if err := i.runKubectl(ctx, kubeconfigPath,
 				"delete", "secrets",
 				"-n", namespace,
-				"-l", fmt.Sprintf("owner=helm,name=%s", releaseName))
+				"-l", fmt.Sprintf("owner=helm,name=%s", releaseName)); err != nil {
+				logger.Error(err, "failed to delete release secrets", "release", releaseName)
+			}
 		}
 	} else {
 		logger.Info("recovering stuck pending-upgrade release", "release", releaseName)
@@ -139,6 +142,22 @@ func (i *Installer) recoverPendingRelease(ctx context.Context, kubeconfigPath, r
 			logger.Error(err, "rollback failed", "release", releaseName)
 		}
 	}
+}
+
+func extractHelmStatus(jsonOutput string) string {
+	// Parse {"info":{"status":"pending-install"}} from helm status --output json.
+	// Avoids substring matching on the full JSON which could false-positive on
+	// chart values or resource names containing "pending-install".
+	idx := strings.Index(jsonOutput, `"status":"`)
+	if idx == -1 {
+		return ""
+	}
+	start := idx + len(`"status":"`)
+	end := strings.Index(jsonOutput[start:], `"`)
+	if end == -1 {
+		return ""
+	}
+	return jsonOutput[start : start+end]
 }
 
 func (i *Installer) runKubectl(ctx context.Context, kubeconfigPath string, args ...string) error {

--- a/internal/addons/installer.go
+++ b/internal/addons/installer.go
@@ -81,6 +81,11 @@ func (i *Installer) writeKubeconfig(kubeconfig []byte) (string, func(), error) {
 }
 
 func (i *Installer) runHelm(ctx context.Context, kubeconfigPath string, args ...string) error {
+	_, err := i.runHelmOutput(ctx, kubeconfigPath, args...)
+	return err
+}
+
+func (i *Installer) runHelmOutput(ctx context.Context, kubeconfigPath string, args ...string) (string, error) {
 	var fullArgs []string
 
 	if len(args) > 0 && args[0] == "repo" {
@@ -92,9 +97,48 @@ func (i *Installer) runHelm(ctx context.Context, kubeconfigPath string, args ...
 	cmd := exec.CommandContext(ctx, i.helmPath, fullArgs...)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("helm failed: %w, output: %s", err, string(output))
+		return string(output), fmt.Errorf("helm failed: %w, output: %s", err, string(output))
 	}
-	return nil
+	return string(output), nil
+}
+
+// recoverPendingRelease detects Helm releases stuck in pending-install or
+// pending-upgrade state and recovers them. A pending release blocks all
+// subsequent helm upgrade --install calls. This happens when a previous
+// helm invocation was interrupted (controller restart, timeout) or when
+// two reconcile cycles race through addon installation.
+//
+// Recovery strategy:
+//   - pending-install (no prior deployed revision): delete the release via helm uninstall
+//   - pending-upgrade (has a prior deployed revision): rollback to the last deployed revision
+func (i *Installer) recoverPendingRelease(ctx context.Context, kubeconfigPath, releaseName, namespace string) {
+	logger := log.FromContext(ctx)
+
+	output, err := i.runHelmOutput(ctx, kubeconfigPath,
+		"status", releaseName, "--namespace", namespace, "--output", "json")
+	if err != nil {
+		return // release doesn't exist yet, nothing to recover
+	}
+
+	if !strings.Contains(output, "pending-install") && !strings.Contains(output, "pending-upgrade") {
+		return // release is not stuck
+	}
+
+	if strings.Contains(output, "pending-install") {
+		logger.Info("recovering stuck pending-install release", "release", releaseName)
+		if err := i.runHelm(ctx, kubeconfigPath, "uninstall", releaseName, "--namespace", namespace); err != nil {
+			logger.Error(err, "failed to uninstall pending release, deleting secrets directly", "release", releaseName)
+			_ = i.runKubectl(ctx, kubeconfigPath,
+				"delete", "secrets",
+				"-n", namespace,
+				"-l", fmt.Sprintf("owner=helm,name=%s", releaseName))
+		}
+	} else {
+		logger.Info("recovering stuck pending-upgrade release", "release", releaseName)
+		if err := i.runHelm(ctx, kubeconfigPath, "rollback", releaseName, "--namespace", namespace); err != nil {
+			logger.Error(err, "rollback failed", "release", releaseName)
+		}
+	}
 }
 
 func (i *Installer) runKubectl(ctx context.Context, kubeconfigPath string, args ...string) error {
@@ -215,6 +259,8 @@ func (i *Installer) InstallCilium(ctx context.Context, kubeconfig []byte, cfg Ci
 		}
 	} else {
 		// LoadBalancer mode: Standard helm install with --wait
+		i.recoverPendingRelease(ctx, kubeconfigPath, "cilium", "kube-system")
+
 		args := append([]string{"upgrade", "--install", "cilium", "cilium/cilium"}, baseArgs...)
 		args = append(args, "--wait", "--timeout", "10m")
 
@@ -385,6 +431,8 @@ func (i *Installer) InstallCertManager(ctx context.Context, kubeconfig []byte, v
 		logger.V(1).Info("helm repo update failed", "error", err)
 	}
 
+	i.recoverPendingRelease(ctx, kubeconfigPath, "cert-manager", "cert-manager")
+
 	args := []string{
 		"upgrade", "--install", "cert-manager", "jetstack/cert-manager",
 		"--namespace", "cert-manager",
@@ -428,6 +476,8 @@ func (i *Installer) InstallLonghorn(ctx context.Context, kubeconfig []byte, vers
 	if err := i.runHelm(ctx, kubeconfigPath, "repo", "update"); err != nil {
 		logger.V(1).Info("helm repo update failed", "error", err)
 	}
+
+	i.recoverPendingRelease(ctx, kubeconfigPath, "longhorn", "longhorn-system")
 
 	args := []string{
 		"upgrade", "--install", "longhorn", "longhorn/longhorn",
@@ -473,6 +523,8 @@ func (i *Installer) InstallMetalLB(ctx context.Context, kubeconfig []byte, versi
 	if err := i.runHelm(ctx, kubeconfigPath, "repo", "update"); err != nil {
 		logger.V(1).Info("helm repo update failed", "error", err)
 	}
+
+	i.recoverPendingRelease(ctx, kubeconfigPath, "metallb", "metallb-system")
 
 	args := []string{
 		"upgrade", "--install", "metallb", "metallb/metallb",
@@ -610,6 +662,8 @@ func (i *Installer) InstallTraefik(ctx context.Context, kubeconfig []byte, versi
 		logger.V(1).Info("helm repo update failed", "error", err)
 	}
 
+	i.recoverPendingRelease(ctx, kubeconfigPath, "traefik", "traefik")
+
 	args := []string{
 		"upgrade", "--install", "traefik", "traefik/traefik",
 		"--namespace", "traefik",
@@ -660,6 +714,8 @@ func (i *Installer) InstallChart(ctx context.Context, kubeconfig []byte, opts Ch
 	if err := i.runHelm(ctx, kubeconfigPath, "repo", "update"); err != nil {
 		logger.V(1).Info("helm repo update failed", "error", err)
 	}
+
+	i.recoverPendingRelease(ctx, kubeconfigPath, opts.ReleaseName, opts.Namespace)
 
 	// Build args
 	timeout := opts.Timeout

--- a/internal/capi/builder_test.go
+++ b/internal/capi/builder_test.go
@@ -21,6 +21,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
 
 	butlerv1alpha1 "github.com/butlerdotdev/butler-api/api/v1alpha1"
@@ -121,15 +122,14 @@ func TestBuildCluster(t *testing.T) {
 	}
 
 	infraRef := spec["infrastructureRef"].(map[string]interface{})
-	if infraRef["kind"] != "HarvesterCluster" {
-		t.Errorf("expected infrastructureRef.kind 'HarvesterCluster', got '%s'", infraRef["kind"])
+	if infraRef["kind"] != "KubevirtCluster" {
+		t.Errorf("expected infrastructureRef.kind 'KubevirtCluster', got '%s'", infraRef["kind"])
 	}
 }
 
-func TestBuildHarvesterCluster(t *testing.T) {
+func TestBuildKubevirtCluster(t *testing.T) {
 	tc := newTestTenantCluster("test-cluster", "default")
 	pc := newTestProviderConfig("harvester")
-	pc.Spec.Harvester.Namespace = "default"
 	pc.Spec.CredentialsRef.Name = "harvester-creds"
 	pc.Spec.CredentialsRef.Namespace = "butler-system"
 
@@ -139,36 +139,23 @@ func TestBuildHarvesterCluster(t *testing.T) {
 		t.Fatalf("failed to build resources: %v", err)
 	}
 
-	hc := rs.InfrastructureCluster
+	kc := rs.InfrastructureCluster
 
-	// Check GVK
-	if hc.GetAPIVersion() != "infrastructure.cluster.x-k8s.io/v1alpha1" {
-		t.Errorf("expected apiVersion 'infrastructure.cluster.x-k8s.io/v1alpha1', got '%s'", hc.GetAPIVersion())
+	if kc.GetAPIVersion() != "infrastructure.cluster.x-k8s.io/v1alpha1" {
+		t.Errorf("expected apiVersion 'infrastructure.cluster.x-k8s.io/v1alpha1', got '%s'", kc.GetAPIVersion())
 	}
-	if hc.GetKind() != "HarvesterCluster" {
-		t.Errorf("expected kind 'HarvesterCluster', got '%s'", hc.GetKind())
-	}
-
-	// Check spec
-	spec := hc.Object["spec"].(map[string]interface{})
-	if spec["targetNamespace"] != "default" {
-		t.Errorf("expected targetNamespace 'default', got '%v'", spec["targetNamespace"])
+	if kc.GetKind() != "KubevirtCluster" {
+		t.Errorf("expected kind 'KubevirtCluster', got '%s'", kc.GetKind())
 	}
 
-	// Check loadBalancerConfig (required by HarvesterCluster CRD)
-	lbConfig, ok := spec["loadBalancerConfig"].(map[string]interface{})
-	if !ok {
-		t.Error("expected loadBalancerConfig to be present")
-	} else if lbConfig["ipamType"] != "dhcp" {
-		t.Errorf("expected loadBalancerConfig.ipamType 'dhcp', got '%v'", lbConfig["ipamType"])
-	}
+	spec := kc.Object["spec"].(map[string]interface{})
 
-	identitySecret := spec["identitySecret"].(map[string]interface{})
-	if identitySecret["name"] != "harvester-creds" {
-		t.Errorf("expected identitySecret.name 'harvester-creds', got '%v'", identitySecret["name"])
+	secretRef := spec["infraClusterSecretRef"].(map[string]interface{})
+	if secretRef["name"] != "harvester-creds" {
+		t.Errorf("expected infraClusterSecretRef.name 'harvester-creds', got '%v'", secretRef["name"])
 	}
-	if identitySecret["namespace"] != "butler-system" {
-		t.Errorf("expected identitySecret.namespace 'butler-system', got '%v'", identitySecret["namespace"])
+	if secretRef["namespace"] != "butler-system" {
+		t.Errorf("expected infraClusterSecretRef.namespace 'butler-system', got '%v'", secretRef["namespace"])
 	}
 }
 
@@ -253,8 +240,8 @@ func TestBuildMachineDeployment(t *testing.T) {
 	}
 
 	infraRef := templateSpec["infrastructureRef"].(map[string]interface{})
-	if infraRef["kind"] != "HarvesterMachineTemplate" {
-		t.Errorf("expected infrastructureRef.kind 'HarvesterMachineTemplate', got '%v'", infraRef["kind"])
+	if infraRef["kind"] != "KubevirtMachineTemplate" {
+		t.Errorf("expected infrastructureRef.kind 'KubevirtMachineTemplate', got '%v'", infraRef["kind"])
 	}
 }
 
@@ -334,9 +321,8 @@ func TestBuildKubeadmConfigTemplate(t *testing.T) {
 	}
 }
 
-func TestBuildHarvesterMachineTemplate(t *testing.T) {
+func TestBuildKubevirtMachineTemplate(t *testing.T) {
 	tc := newTestTenantCluster("test-cluster", "default")
-	// Note: Workers.Resources doesn't exist in butler-api, using defaults (4 CPU, 8Gi)
 	pc := newTestProviderConfig("harvester")
 	pc.Spec.Harvester.NetworkName = "default/vlan40-workloads"
 	pc.Spec.Harvester.ImageName = "default/rocky-9-generic-cloud"
@@ -348,61 +334,31 @@ func TestBuildHarvesterMachineTemplate(t *testing.T) {
 		t.Fatalf("failed to build resources: %v", err)
 	}
 
-	hmt := rs.MachineTemplate
+	kvmt := rs.MachineTemplate
 
-	// Check GVK
-	if hmt.GetAPIVersion() != "infrastructure.cluster.x-k8s.io/v1alpha1" {
-		t.Errorf("expected apiVersion 'infrastructure.cluster.x-k8s.io/v1alpha1', got '%s'", hmt.GetAPIVersion())
+	if kvmt.GetAPIVersion() != "infrastructure.cluster.x-k8s.io/v1alpha1" {
+		t.Errorf("expected apiVersion 'infrastructure.cluster.x-k8s.io/v1alpha1', got '%s'", kvmt.GetAPIVersion())
 	}
-	if hmt.GetKind() != "HarvesterMachineTemplate" {
-		t.Errorf("expected kind 'HarvesterMachineTemplate', got '%s'", hmt.GetKind())
+	if kvmt.GetKind() != "KubevirtMachineTemplate" {
+		t.Errorf("expected kind 'KubevirtMachineTemplate', got '%s'", kvmt.GetKind())
 	}
-
-	// Check name
-	if hmt.GetName() != "test-cluster-worker" {
-		t.Errorf("expected name 'test-cluster-worker', got '%s'", hmt.GetName())
+	if kvmt.GetName() != "test-cluster-worker" {
+		t.Errorf("expected name 'test-cluster-worker', got '%s'", kvmt.GetName())
 	}
 
-	// Check spec - using defaults (4 CPU, 8Gi memory)
-	spec := hmt.Object["spec"].(map[string]interface{})
+	// KubevirtMachineTemplate has virtualMachineTemplate nested under spec.template.spec
+	spec := kvmt.Object["spec"].(map[string]interface{})
 	template := spec["template"].(map[string]interface{})
 	templateSpec := template["spec"].(map[string]interface{})
 
-	if templateSpec["cpu"].(int64) != 4 {
-		t.Errorf("expected cpu 4 (default), got '%v'", templateSpec["cpu"])
-	}
-	if templateSpec["memory"] != "8192Mi" {
-		t.Errorf("expected memory '8192Mi' (default), got '%v'", templateSpec["memory"])
-	}
-	if templateSpec["sshUser"] != "rocky" {
-		t.Errorf("expected sshUser 'rocky', got '%v'", templateSpec["sshUser"])
-	}
-	// sshKeyPair is required by HarvesterMachineTemplate CRD
-	if templateSpec["sshKeyPair"] != "default" {
-		t.Errorf("expected sshKeyPair 'default', got '%v'", templateSpec["sshKeyPair"])
+	vmTemplate, ok := templateSpec["virtualMachineTemplate"].(map[string]interface{})
+	if !ok {
+		t.Fatal("expected virtualMachineTemplate in spec")
 	}
 
-	// Check networks - should be a list of strings
-	networks := templateSpec["networks"].([]interface{})
-	if len(networks) != 1 {
-		t.Fatalf("expected 1 network, got %d", len(networks))
-	}
-	networkName := networks[0].(string)
-	if networkName != "default/vlan40-workloads" {
-		t.Errorf("expected network 'default/vlan40-workloads', got '%v'", networkName)
-	}
-
-	// Check volumes - should have volumeType
-	volumes := templateSpec["volumes"].([]interface{})
-	if len(volumes) != 1 {
-		t.Fatalf("expected 1 volume, got %d", len(volumes))
-	}
-	volume := volumes[0].(map[string]interface{})
-	if volume["volumeType"] != "image" {
-		t.Errorf("expected volumeType 'image', got '%v'", volume["volumeType"])
-	}
-	if volume["imageName"] != "default/rocky-9-generic-cloud" {
-		t.Errorf("expected imageName 'default/rocky-9-generic-cloud', got '%v'", volume["imageName"])
+	vmSpec := vmTemplate["spec"].(map[string]interface{})
+	if vmSpec["runStrategy"] != "Always" {
+		t.Errorf("expected runStrategy 'Always', got '%v'", vmSpec["runStrategy"])
 	}
 }
 
@@ -468,31 +424,42 @@ func TestAllResources(t *testing.T) {
 
 	resources := rs.AllResources()
 
-	// Should have 6 resources in the correct order
-	if len(resources) != 6 {
-		t.Errorf("expected 6 resources, got %d", len(resources))
+	// AllResources returns 7 slots (includes CredentialSecret which is nil for Harvester)
+	if len(resources) != 7 {
+		t.Fatalf("expected 7 resource slots, got %d", len(resources))
 	}
 
-	// Verify order is correct for creation
-	expectedOrder := []string{
-		"HarvesterCluster",
+	// Count non-nil resources (Harvester has no CredentialSecret)
+	var nonNil []*unstructured.Unstructured
+	for _, r := range resources {
+		if r != nil {
+			nonNil = append(nonNil, r)
+		}
+	}
+	if len(nonNil) != 6 {
+		t.Errorf("expected 6 non-nil resources, got %d", len(nonNil))
+	}
+
+	// Verify non-nil resource kinds (order: InfraCluster, Bootstrap, MachineTemplate, CP, MD, Cluster)
+	expectedKinds := []string{
+		"KubevirtCluster",
 		"KubeadmConfigTemplate",
-		"HarvesterMachineTemplate",
+		"KubevirtMachineTemplate",
 		"StewardControlPlane",
 		"MachineDeployment",
 		"Cluster",
 	}
 
-	for i, r := range resources {
-		if r.GetKind() != expectedOrder[i] {
-			t.Errorf("resource %d should be %s, got %s", i, expectedOrder[i], r.GetKind())
+	for i, r := range nonNil {
+		if r.GetKind() != expectedKinds[i] {
+			t.Errorf("resource %d should be %s, got %s", i, expectedKinds[i], r.GetKind())
 		}
 	}
 }
 
 func TestUnsupportedProvider(t *testing.T) {
 	tc := newTestTenantCluster("test-cluster", "default")
-	pc := newTestProviderConfig("nutanix")
+	pc := newTestProviderConfig("proxmox")
 
 	builder := NewBuilder(tc, pc, "test-cluster-12345678")
 	_, err := builder.Build()

--- a/internal/controller/ipallocation/ipallocation_controller.go
+++ b/internal/controller/ipallocation/ipallocation_controller.go
@@ -115,8 +115,26 @@ func (r *Reconciler) handleDeletion(ctx context.Context, alloc *butlerv1alpha1.I
 	logger.Info("releasing IPAllocation", "name", alloc.Name,
 		"start", alloc.Status.StartAddress, "end", alloc.Status.EndAddress)
 
-	controllerutil.RemoveFinalizer(alloc, butlerv1alpha1.FinalizerIPAllocation)
-	return ctrl.Result{}, r.Update(ctx, alloc)
+	latest := &butlerv1alpha1.IPAllocation{}
+	if err := r.Get(ctx, client.ObjectKeyFromObject(alloc), latest); err != nil {
+		if apierrors.IsNotFound(err) {
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, err
+	}
+	if controllerutil.ContainsFinalizer(latest, butlerv1alpha1.FinalizerIPAllocation) {
+		controllerutil.RemoveFinalizer(latest, butlerv1alpha1.FinalizerIPAllocation)
+		if err := r.Update(ctx, latest); err != nil {
+			if apierrors.IsNotFound(err) {
+				return ctrl.Result{}, nil
+			}
+			if apierrors.IsConflict(err) {
+				return ctrl.Result{Requeue: true}, nil
+			}
+			return ctrl.Result{}, err
+		}
+	}
+	return ctrl.Result{}, nil
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/internal/controller/networkpool/networkpool_controller.go
+++ b/internal/controller/networkpool/networkpool_controller.go
@@ -166,8 +166,26 @@ func (r *Reconciler) handleDeletion(ctx context.Context, pool *butlerv1alpha1.Ne
 		return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
 	}
 
-	controllerutil.RemoveFinalizer(pool, butlerv1alpha1.FinalizerNetworkPool)
-	return ctrl.Result{}, r.Update(ctx, pool)
+	latest := &butlerv1alpha1.NetworkPool{}
+	if err := r.Get(ctx, client.ObjectKeyFromObject(pool), latest); err != nil {
+		if apierrors.IsNotFound(err) {
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, err
+	}
+	if controllerutil.ContainsFinalizer(latest, butlerv1alpha1.FinalizerNetworkPool) {
+		controllerutil.RemoveFinalizer(latest, butlerv1alpha1.FinalizerNetworkPool)
+		if err := r.Update(ctx, latest); err != nil {
+			if apierrors.IsNotFound(err) {
+				return ctrl.Result{}, nil
+			}
+			if apierrors.IsConflict(err) {
+				return ctrl.Result{Requeue: true}, nil
+			}
+			return ctrl.Result{}, err
+		}
+	}
+	return ctrl.Result{}, nil
 }
 
 func (r *Reconciler) validatePool(pool *butlerv1alpha1.NetworkPool) []string {

--- a/internal/controller/networkpool/suite_test.go
+++ b/internal/controller/networkpool/suite_test.go
@@ -86,8 +86,9 @@ var _ = BeforeSuite(func() {
 
 	// Register the NetworkPool controller (sole allocator for IPAllocations)
 	err = (&Reconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
+		Client:   mgr.GetClient(),
+		Scheme:   mgr.GetScheme(),
+		Recorder: mgr.GetEventRecorderFor("networkpool-controller"),
 	}).SetupWithManager(mgr)
 	Expect(err).NotTo(HaveOccurred())
 

--- a/internal/controller/providerconfig/providerconfig_controller.go
+++ b/internal/controller/providerconfig/providerconfig_controller.go
@@ -159,8 +159,26 @@ func (r *Reconciler) handleDeletion(ctx context.Context, pc *butlerv1alpha1.Prov
 		return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
 	}
 
-	controllerutil.RemoveFinalizer(pc, butlerv1alpha1.FinalizerProviderConfig)
-	return ctrl.Result{}, r.Update(ctx, pc)
+	latest := &butlerv1alpha1.ProviderConfig{}
+	if err := r.Get(ctx, client.ObjectKeyFromObject(pc), latest); err != nil {
+		if apierrors.IsNotFound(err) {
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, err
+	}
+	if controllerutil.ContainsFinalizer(latest, butlerv1alpha1.FinalizerProviderConfig) {
+		controllerutil.RemoveFinalizer(latest, butlerv1alpha1.FinalizerProviderConfig)
+		if err := r.Update(ctx, latest); err != nil {
+			if apierrors.IsNotFound(err) {
+				return ctrl.Result{}, nil
+			}
+			if apierrors.IsConflict(err) {
+				return ctrl.Result{Requeue: true}, nil
+			}
+			return ctrl.Result{}, err
+		}
+	}
+	return ctrl.Result{}, nil
 }
 
 func (r *Reconciler) validateCredentials(ctx context.Context, pc *butlerv1alpha1.ProviderConfig) bool {

--- a/internal/controller/providerconfig/suite_test.go
+++ b/internal/controller/providerconfig/suite_test.go
@@ -85,8 +85,9 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 
 	err = (&Reconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
+		Client:   mgr.GetClient(),
+		Scheme:   mgr.GetScheme(),
+		Recorder: mgr.GetEventRecorderFor("providerconfig-controller"),
 	}).SetupWithManager(mgr)
 	Expect(err).NotTo(HaveOccurred())
 

--- a/internal/controller/team/team_controller.go
+++ b/internal/controller/team/team_controller.go
@@ -200,9 +200,24 @@ func (r *Reconciler) reconcileDelete(ctx context.Context, team *butlerv1alpha1.T
 
 	// Namespace is gone, remove finalizer
 	logger.Info("removing finalizer", "name", team.Name)
-	controllerutil.RemoveFinalizer(team, butlerv1alpha1.FinalizerTeam)
-	if err := r.Update(ctx, team); err != nil {
+	latest := &butlerv1alpha1.Team{}
+	if err := r.Get(ctx, client.ObjectKeyFromObject(team), latest); err != nil {
+		if apierrors.IsNotFound(err) {
+			return ctrl.Result{}, nil
+		}
 		return ctrl.Result{}, err
+	}
+	if controllerutil.ContainsFinalizer(latest, butlerv1alpha1.FinalizerTeam) {
+		controllerutil.RemoveFinalizer(latest, butlerv1alpha1.FinalizerTeam)
+		if err := r.Update(ctx, latest); err != nil {
+			if apierrors.IsNotFound(err) {
+				return ctrl.Result{}, nil
+			}
+			if apierrors.IsConflict(err) {
+				return ctrl.Result{Requeue: true}, nil
+			}
+			return ctrl.Result{}, err
+		}
 	}
 
 	logger.Info("Team deletion complete", "name", team.Name)

--- a/internal/controller/tenantcluster/tenantcluster_controller.go
+++ b/internal/controller/tenantcluster/tenantcluster_controller.go
@@ -2783,7 +2783,7 @@ func (r *Reconciler) reconcileTalosBootstrap(ctx context.Context, tc *butlerv1al
 	}
 
 	// Get tenant client to create bootstrap token in tenant API server
-	tc2, err := r.getTenantClient(ctx, tc)
+	tenantClient, err := r.getTenantClient(ctx, tc)
 	if err != nil {
 		logger.Info("tenant client not available yet, waiting", "error", err)
 		return nil
@@ -2792,7 +2792,7 @@ func (r *Reconciler) reconcileTalosBootstrap(ctx context.Context, tc *butlerv1al
 	// Reuse existing bootstrap token if one was created by a previous attempt,
 	// otherwise generate a new one. This ensures idempotency when the reconciler
 	// succeeds in creating the token but fails before creating the bootstrap Secret.
-	bootstrapToken, err := talos.FindExistingBootstrapToken(ctx, tc2.Clientset)
+	bootstrapToken, err := talos.FindExistingBootstrapToken(ctx, tenantClient.Clientset)
 	if err != nil {
 		return fmt.Errorf("failed to check for existing bootstrap token: %w", err)
 	}
@@ -2805,7 +2805,7 @@ func (r *Reconciler) reconcileTalosBootstrap(ctx context.Context, tc *butlerv1al
 			return fmt.Errorf("failed to generate bootstrap token: %w", err)
 		}
 
-		if err := talos.CreateBootstrapTokenSecret(ctx, tc2.Clientset, bootstrapToken); err != nil {
+		if err := talos.CreateBootstrapTokenSecret(ctx, tenantClient.Clientset, bootstrapToken); err != nil {
 			return fmt.Errorf("failed to create bootstrap token in tenant: %w", err)
 		}
 

--- a/internal/controller/tenantcluster/tenantcluster_controller.go
+++ b/internal/controller/tenantcluster/tenantcluster_controller.go
@@ -36,7 +36,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/tools/clientcmd"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -47,6 +46,7 @@ import (
 	"github.com/butlerdotdev/butler-controller/internal/addons"
 	"github.com/butlerdotdev/butler-controller/internal/capi"
 	"github.com/butlerdotdev/butler-controller/internal/talos"
+	"github.com/butlerdotdev/butler-controller/internal/tenant"
 )
 
 const (
@@ -70,8 +70,9 @@ const (
 
 type Reconciler struct {
 	client.Client
-	Scheme    *runtime.Scheme
-	Installer *addons.Installer
+	Scheme        *runtime.Scheme
+	Installer     *addons.Installer
+	ClientManager *tenant.ClientManager
 }
 
 // +kubebuilder:rbac:groups=butler.butlerlabs.dev,resources=tenantclusters,verbs=get;list;watch;create;update;patch;delete
@@ -848,6 +849,15 @@ func (r *Reconciler) getTenantKubeconfig(ctx context.Context, tc *butlerv1alpha1
 	return kubeconfigData, nil
 }
 
+// getTenantClient returns a cached Kubernetes client for the tenant cluster.
+// Falls back to ad-hoc client creation if the ClientManager is not configured.
+func (r *Reconciler) getTenantClient(ctx context.Context, tc *butlerv1alpha1.TenantCluster) (*tenant.TenantClient, error) {
+	if r.ClientManager != nil && tc.Status.TenantNamespace != "" {
+		return r.ClientManager.GetClient(ctx, tc.Status.TenantNamespace, tc.Name)
+	}
+	return nil, fmt.Errorf("tenant client not available: no ClientManager or tenant namespace")
+}
+
 // getExternalKubeconfig returns the kubeconfig with the external hostname (admin.conf).
 // This is used for Cilium configuration in Ingress/Gateway mode to ensure proper SNI is sent.
 func (r *Reconciler) getExternalKubeconfig(ctx context.Context, tc *butlerv1alpha1.TenantCluster) ([]byte, error) {
@@ -1102,24 +1112,12 @@ func (r *Reconciler) reconcileMachineDeploymentReplicas(ctx context.Context, tc 
 // This is a fallback for when CAPI readyReplicas is unreliable (e.g. no providerID on nodes).
 // Returns 0 without error if the tenant cluster is unreachable (non-fatal).
 func (r *Reconciler) countTenantReadyNodes(ctx context.Context, tc *butlerv1alpha1.TenantCluster, butlerConfig *butlerv1alpha1.ButlerConfig) (int32, error) {
-	kubeconfigData, err := r.getTenantKubeconfig(ctx, tc, butlerConfig)
+	tenantClient, err := r.getTenantClient(ctx, tc)
 	if err != nil {
 		return 0, nil // non-fatal: kubeconfig not available yet
 	}
 
-	restConfig, err := clientcmd.RESTConfigFromKubeConfig(kubeconfigData)
-	if err != nil {
-		return 0, nil
-	}
-	// Short timeout to avoid blocking reconcile if tenant API is slow
-	restConfig.Timeout = 10 * time.Second
-
-	clientset, err := kubernetes.NewForConfig(restConfig)
-	if err != nil {
-		return 0, nil
-	}
-
-	nodes, err := clientset.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+	nodes, err := tenantClient.Clientset.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return 0, nil // non-fatal: tenant cluster may be unreachable
 	}
@@ -1234,21 +1232,12 @@ func (r *Reconciler) reconcileNodeProviderIDs(ctx context.Context, tc *butlerv1a
 		return nil
 	}
 
-	kubeconfigData, err := r.getTenantKubeconfig(ctx, tc, butlerConfig)
+	tenantClient, err := r.getTenantClient(ctx, tc)
 	if err != nil {
-		return fmt.Errorf("failed to get tenant kubeconfig: %w", err)
-	}
-	restConfig, err := clientcmd.RESTConfigFromKubeConfig(kubeconfigData)
-	if err != nil {
-		return fmt.Errorf("failed to parse tenant kubeconfig: %w", err)
-	}
-	restConfig.Timeout = 10 * time.Second
-	clientset, err := kubernetes.NewForConfig(restConfig)
-	if err != nil {
-		return fmt.Errorf("failed to create tenant clientset: %w", err)
+		return fmt.Errorf("failed to get tenant client: %w", err)
 	}
 
-	nodes, err := clientset.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+	nodes, err := tenantClient.Clientset.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return fmt.Errorf("failed to list tenant nodes: %w", err)
 	}
@@ -1276,7 +1265,7 @@ func (r *Reconciler) reconcileNodeProviderIDs(ctx context.Context, tc *butlerv1a
 		}
 
 		patch := []byte(fmt.Sprintf(`{"spec":{"providerID":%q}}`, providerID))
-		if _, err := clientset.CoreV1().Nodes().Patch(ctx, node.Name, types.StrategicMergePatchType, patch, metav1.PatchOptions{}); err != nil {
+		if _, err := tenantClient.Clientset.CoreV1().Nodes().Patch(ctx, node.Name, types.StrategicMergePatchType, patch, metav1.PatchOptions{}); err != nil {
 			logger.Info("failed to set providerID on tenant node", "node", node.Name, "providerID", providerID, "error", err)
 			continue
 		}
@@ -2036,6 +2025,11 @@ func (r *Reconciler) handleDeletion(ctx context.Context, tc *butlerv1alpha1.Tena
 		}
 	}
 
+	// Evict cached tenant client before cleanup
+	if r.ClientManager != nil && tc.Status.TenantNamespace != "" {
+		r.ClientManager.RemoveClient(tc.Status.TenantNamespace, tc.Name)
+	}
+
 	// Clean up IPAllocations before deleting namespace
 	r.cleanupIPAllocations(ctx, tc)
 
@@ -2788,28 +2782,17 @@ func (r *Reconciler) reconcileTalosBootstrap(ctx context.Context, tc *butlerv1al
 		logger.Info("using Gateway endpoint for Talos control plane endpoint", "endpoint", controlPlaneEndpoint)
 	}
 
-	// Get tenant admin kubeconfig to create bootstrap token in tenant API server
-	kubeconfigData, err := r.getTenantKubeconfig(ctx, tc, butlerConfig)
+	// Get tenant client to create bootstrap token in tenant API server
+	tc2, err := r.getTenantClient(ctx, tc)
 	if err != nil {
-		logger.Info("tenant kubeconfig not available yet, waiting", "error", err)
+		logger.Info("tenant client not available yet, waiting", "error", err)
 		return nil
-	}
-
-	// Create kubernetes client from kubeconfig
-	restConfig, err := clientcmd.RESTConfigFromKubeConfig(kubeconfigData)
-	if err != nil {
-		return fmt.Errorf("failed to create REST config from kubeconfig: %w", err)
-	}
-
-	tenantClient, err := kubernetes.NewForConfig(restConfig)
-	if err != nil {
-		return fmt.Errorf("failed to create tenant kubernetes client: %w", err)
 	}
 
 	// Reuse existing bootstrap token if one was created by a previous attempt,
 	// otherwise generate a new one. This ensures idempotency when the reconciler
 	// succeeds in creating the token but fails before creating the bootstrap Secret.
-	bootstrapToken, err := talos.FindExistingBootstrapToken(ctx, tenantClient)
+	bootstrapToken, err := talos.FindExistingBootstrapToken(ctx, tc2.Clientset)
 	if err != nil {
 		return fmt.Errorf("failed to check for existing bootstrap token: %w", err)
 	}
@@ -2822,7 +2805,7 @@ func (r *Reconciler) reconcileTalosBootstrap(ctx context.Context, tc *butlerv1al
 			return fmt.Errorf("failed to generate bootstrap token: %w", err)
 		}
 
-		if err := talos.CreateBootstrapTokenSecret(ctx, tenantClient, bootstrapToken); err != nil {
+		if err := talos.CreateBootstrapTokenSecret(ctx, tc2.Clientset, bootstrapToken); err != nil {
 			return fmt.Errorf("failed to create bootstrap token in tenant: %w", err)
 		}
 
@@ -3251,17 +3234,7 @@ func (r *Reconciler) listLBAllocations(ctx context.Context, tc *butlerv1alpha1.T
 }
 
 // countUsedLBIPs counts the number of LoadBalancer services with assigned IPs on a tenant cluster.
-func (r *Reconciler) countUsedLBIPs(ctx context.Context, kubeconfig []byte) (int32, error) {
-	restConfig, err := clientcmd.RESTConfigFromKubeConfig(kubeconfig)
-	if err != nil {
-		return 0, fmt.Errorf("failed to build REST config: %w", err)
-	}
-
-	clientset, err := kubernetes.NewForConfig(restConfig)
-	if err != nil {
-		return 0, fmt.Errorf("failed to create clientset: %w", err)
-	}
-
+func (r *Reconciler) countUsedLBIPs(ctx context.Context, clientset kubernetes.Interface) (int32, error) {
 	svcList, err := clientset.CoreV1().Services("").List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return 0, fmt.Errorf("failed to list services: %w", err)
@@ -3320,13 +3293,13 @@ func (r *Reconciler) reconcileElasticIPAM(ctx context.Context, tc *butlerv1alpha
 	}
 
 	// Count used IPs from tenant cluster
-	kubeconfig, err := r.getTenantKubeconfig(ctx, tc, butlerConfig)
+	tenantClient, err := r.getTenantClient(ctx, tc)
 	if err != nil {
-		logger.V(1).Info("cannot get tenant kubeconfig for elastic IPAM, skipping", "error", err)
+		logger.V(1).Info("cannot get tenant client for elastic IPAM, skipping", "error", err)
 		return nil
 	}
 
-	usedIPs, err := r.countUsedLBIPs(ctx, kubeconfig)
+	usedIPs, err := r.countUsedLBIPs(ctx, tenantClient.Clientset)
 	if err != nil {
 		logger.V(1).Info("cannot count used LB IPs, skipping", "error", err)
 		return nil

--- a/internal/controller/tenantcluster/tenantcluster_controller.go
+++ b/internal/controller/tenantcluster/tenantcluster_controller.go
@@ -35,7 +35,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/kubernetes"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -3234,8 +3233,8 @@ func (r *Reconciler) listLBAllocations(ctx context.Context, tc *butlerv1alpha1.T
 }
 
 // countUsedLBIPs counts the number of LoadBalancer services with assigned IPs on a tenant cluster.
-func (r *Reconciler) countUsedLBIPs(ctx context.Context, clientset kubernetes.Interface) (int32, error) {
-	svcList, err := clientset.CoreV1().Services("").List(ctx, metav1.ListOptions{})
+func (r *Reconciler) countUsedLBIPs(ctx context.Context, tc *tenant.TenantClient) (int32, error) {
+	svcList, err := tc.Clientset.CoreV1().Services("").List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return 0, fmt.Errorf("failed to list services: %w", err)
 	}
@@ -3299,7 +3298,7 @@ func (r *Reconciler) reconcileElasticIPAM(ctx context.Context, tc *butlerv1alpha
 		return nil
 	}
 
-	usedIPs, err := r.countUsedLBIPs(ctx, tenantClient.Clientset)
+	usedIPs, err := r.countUsedLBIPs(ctx, tenantClient)
 	if err != nil {
 		logger.V(1).Info("cannot count used LB IPs, skipping", "error", err)
 		return nil

--- a/internal/controller/tenantcluster/tenantcluster_controller.go
+++ b/internal/controller/tenantcluster/tenantcluster_controller.go
@@ -2555,14 +2555,8 @@ func (r *Reconciler) annotateMachine(ctx context.Context, machineName, namespace
 		return err
 	}
 
-	annotations := machine.GetAnnotations()
-	if annotations == nil {
-		annotations = map[string]string{}
-	}
-	annotations["butler.butlerlabs.dev/talos-config-applied"] = "true"
-	machine.SetAnnotations(annotations)
-
-	return r.Update(ctx, machine)
+	patch := []byte(`{"metadata":{"annotations":{"butler.butlerlabs.dev/talos-config-applied":"true"}}}`)
+	return r.Patch(ctx, machine, client.RawPatch(types.MergePatchType, patch))
 }
 
 // reconcileTalosconfig creates a talosconfig Secret for CLI access to worker nodes.

--- a/internal/controller/tenantcluster/tenantcluster_controller.go
+++ b/internal/controller/tenantcluster/tenantcluster_controller.go
@@ -1711,12 +1711,12 @@ func (r *Reconciler) handleKamajiHarvesterCompatibility(ctx context.Context, tc 
 			if currentHost != endpointHost || currentPort != endpointPort {
 				logger.Info("patching Cluster controlPlaneEndpoint", "currentHost", currentHost, "newHost", endpointHost, "currentPort", currentPort, "newPort", endpointPort)
 
-				if err := unstructured.SetNestedField(cluster.Object, endpointHost, "spec", "controlPlaneEndpoint", "host"); err != nil {
-					logger.Error(err, "failed to set controlPlaneEndpoint.host")
-				} else if err := unstructured.SetNestedField(cluster.Object, endpointPort, "spec", "controlPlaneEndpoint", "port"); err != nil {
-					logger.Error(err, "failed to set controlPlaneEndpoint.port")
-				} else if err := r.Update(ctx, cluster); err != nil {
-					logger.Error(err, "failed to update Cluster controlPlaneEndpoint")
+				patch := []byte(fmt.Sprintf(
+					`{"spec":{"controlPlaneEndpoint":{"host":%q,"port":%d}}}`,
+					endpointHost, endpointPort,
+				))
+				if err := r.Patch(ctx, cluster, client.RawPatch(types.MergePatchType, patch)); err != nil {
+					logger.Error(err, "failed to patch Cluster controlPlaneEndpoint")
 				} else {
 					logger.Info("successfully patched Cluster controlPlaneEndpoint", "host", endpointHost, "port", endpointPort)
 					return true, nil

--- a/internal/controller/tenantcluster/tenantcluster_controller.go
+++ b/internal/controller/tenantcluster/tenantcluster_controller.go
@@ -2039,6 +2039,34 @@ func (r *Reconciler) handleDeletion(ctx context.Context, tc *butlerv1alpha1.Tena
 	r.cleanupIPAllocations(ctx, tc)
 
 	if tc.Status.TenantNamespace != "" {
+		// Delete the CAPI Cluster first so the CAPI controller can remove its
+		// finalizer while dependent resources (KubevirtCluster, StewardControlPlane)
+		// still exist. Deleting the namespace first cascade-deletes those resources,
+		// leaving the CAPI Cluster with a finalizer that can never be removed.
+		capiCluster := &unstructured.Unstructured{}
+		capiCluster.SetGroupVersionKind(schema.GroupVersionKind{
+			Group:   capi.ClusterAPIGroup,
+			Version: capi.ClusterAPIVersion,
+			Kind:    "Cluster",
+		})
+		if err := r.Get(ctx, types.NamespacedName{
+			Name:      tc.Name,
+			Namespace: tc.Status.TenantNamespace,
+		}, capiCluster); err == nil {
+			if capiCluster.GetDeletionTimestamp().IsZero() {
+				logger.Info("deleting CAPI Cluster before namespace", "cluster", tc.Name)
+				if err := r.Delete(ctx, capiCluster); err != nil && !apierrors.IsNotFound(err) {
+					return ctrl.Result{}, err
+				}
+			}
+			// CAPI Cluster still exists (finalizer pending), wait for CAPI controller to clean up
+			logger.V(1).Info("waiting for CAPI Cluster deletion", "cluster", tc.Name)
+			return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
+		} else if !apierrors.IsNotFound(err) {
+			return ctrl.Result{}, err
+		}
+
+		// CAPI Cluster is gone, safe to delete the namespace
 		ns := &corev1.Namespace{}
 		err := r.Get(ctx, types.NamespacedName{Name: tc.Status.TenantNamespace}, ns)
 		if err == nil {

--- a/internal/controller/tenantcluster/tenantcluster_controller.go
+++ b/internal/controller/tenantcluster/tenantcluster_controller.go
@@ -2054,9 +2054,25 @@ func (r *Reconciler) handleDeletion(ctx context.Context, tc *butlerv1alpha1.Tena
 		logger.Info("tenant namespace deleted", "namespace", tc.Status.TenantNamespace)
 	}
 
-	controllerutil.RemoveFinalizer(tc, butlerv1alpha1.FinalizerTenantCluster)
-	if err := r.Update(ctx, tc); err != nil {
+	latest := &butlerv1alpha1.TenantCluster{}
+	if err := r.Get(ctx, client.ObjectKeyFromObject(tc), latest); err != nil {
+		if apierrors.IsNotFound(err) {
+			return ctrl.Result{}, nil
+		}
 		return ctrl.Result{}, err
+	}
+
+	if controllerutil.ContainsFinalizer(latest, butlerv1alpha1.FinalizerTenantCluster) {
+		controllerutil.RemoveFinalizer(latest, butlerv1alpha1.FinalizerTenantCluster)
+		if err := r.Update(ctx, latest); err != nil {
+			if apierrors.IsNotFound(err) {
+				return ctrl.Result{}, nil
+			}
+			if apierrors.IsConflict(err) {
+				return ctrl.Result{Requeue: true}, nil
+			}
+			return ctrl.Result{}, err
+		}
 	}
 
 	logger.Info("TenantCluster deletion complete", "name", tc.Name)

--- a/internal/controller/tenantcluster/tenantcluster_controller.go
+++ b/internal/controller/tenantcluster/tenantcluster_controller.go
@@ -857,10 +857,13 @@ func (r *Reconciler) getTenantKubeconfig(ctx context.Context, tc *butlerv1alpha1
 // getTenantClient returns a cached Kubernetes client for the tenant cluster.
 // Falls back to ad-hoc client creation if the ClientManager is not configured.
 func (r *Reconciler) getTenantClient(ctx context.Context, tc *butlerv1alpha1.TenantCluster) (*tenant.TenantClient, error) {
-	if r.ClientManager != nil && tc.Status.TenantNamespace != "" {
-		return r.ClientManager.GetClient(ctx, tc.Status.TenantNamespace, tc.Name)
+	if r.ClientManager == nil {
+		return nil, fmt.Errorf("tenant ClientManager not configured")
 	}
-	return nil, fmt.Errorf("tenant client not available: no ClientManager or tenant namespace")
+	if tc.Status.TenantNamespace == "" {
+		return nil, fmt.Errorf("tenant namespace not yet assigned")
+	}
+	return r.ClientManager.GetClient(ctx, tc.Status.TenantNamespace, tc.Name)
 }
 
 // getExternalKubeconfig returns the kubeconfig with the external hostname (admin.conf).

--- a/internal/controller/tenantcluster/tenantcluster_controller.go
+++ b/internal/controller/tenantcluster/tenantcluster_controller.go
@@ -376,8 +376,14 @@ func (r *Reconciler) reconcileInfrastructure(ctx context.Context, tc *butlerv1al
 				"namespace", resource.GetNamespace())
 
 			if err := r.Create(ctx, resource); err != nil {
-				return ctrl.Result{}, fmt.Errorf("failed to create %s %s: %w",
-					resource.GetKind(), resource.GetName(), err)
+				if apierrors.IsAlreadyExists(err) {
+					logger.V(1).Info("CAPI resource created by concurrent reconcile",
+						"kind", resource.GetKind(),
+						"name", resource.GetName())
+				} else {
+					return ctrl.Result{}, fmt.Errorf("failed to create %s %s: %w",
+						resource.GetKind(), resource.GetName(), err)
+				}
 			}
 		} else if err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to get %s %s: %w",

--- a/internal/controller/workspace/workspace_controller.go
+++ b/internal/controller/workspace/workspace_controller.go
@@ -587,9 +587,7 @@ func (r *Reconciler) handleDeletion(ctx context.Context, ws *butlerv1alpha1.Work
 		Namespace: ws.Namespace,
 	}, tc); err != nil {
 		if errors.IsNotFound(err) {
-			// Cluster gone, nothing to clean up on tenant side
-			controllerutil.RemoveFinalizer(ws, butlerv1alpha1.FinalizerWorkspace)
-			return ctrl.Result{}, r.Update(ctx, ws)
+			return r.removeFinalizer(ctx, ws)
 		}
 		return ctrl.Result{}, err
 	}
@@ -605,15 +603,13 @@ func (r *Reconciler) handleDeletion(ctx context.Context, ws *butlerv1alpha1.Work
 	kubeconfigData, err := r.getTenantKubeconfig(ctx, tc, butlerConfig)
 	if err != nil {
 		logger.Error(err, "failed to get tenant kubeconfig for cleanup, removing finalizer anyway")
-		controllerutil.RemoveFinalizer(ws, butlerv1alpha1.FinalizerWorkspace)
-		return ctrl.Result{}, r.Update(ctx, ws)
+		return r.removeFinalizer(ctx, ws)
 	}
 
 	tenantClient, err := r.buildTenantClient(kubeconfigData)
 	if err != nil {
 		logger.Error(err, "failed to build tenant client for cleanup, removing finalizer anyway")
-		controllerutil.RemoveFinalizer(ws, butlerv1alpha1.FinalizerWorkspace)
-		return ctrl.Result{}, r.Update(ctx, ws)
+		return r.removeFinalizer(ctx, ws)
 	}
 
 	// Delete service
@@ -651,12 +647,30 @@ func (r *Reconciler) handleDeletion(ctx context.Context, ws *butlerv1alpha1.Work
 		}
 	}
 
-	controllerutil.RemoveFinalizer(ws, butlerv1alpha1.FinalizerWorkspace)
-	if err := r.Update(ctx, ws); err != nil {
+	return r.removeFinalizer(ctx, ws)
+}
+
+// removeFinalizer re-fetches the Workspace, removes the finalizer, and handles conflicts.
+func (r *Reconciler) removeFinalizer(ctx context.Context, ws *butlerv1alpha1.Workspace) (ctrl.Result, error) {
+	latest := &butlerv1alpha1.Workspace{}
+	if err := r.Get(ctx, client.ObjectKeyFromObject(ws), latest); err != nil {
+		if errors.IsNotFound(err) {
+			return ctrl.Result{}, nil
+		}
 		return ctrl.Result{}, err
 	}
-
-	logger.Info("workspace cleanup complete")
+	if controllerutil.ContainsFinalizer(latest, butlerv1alpha1.FinalizerWorkspace) {
+		controllerutil.RemoveFinalizer(latest, butlerv1alpha1.FinalizerWorkspace)
+		if err := r.Update(ctx, latest); err != nil {
+			if errors.IsNotFound(err) {
+				return ctrl.Result{}, nil
+			}
+			if errors.IsConflict(err) {
+				return ctrl.Result{Requeue: true}, nil
+			}
+			return ctrl.Result{}, err
+		}
+	}
 	return ctrl.Result{}, nil
 }
 

--- a/internal/tenant/client.go
+++ b/internal/tenant/client.go
@@ -1,58 +1,36 @@
-/*
-Copyright 2026 The Butler Authors.
+// Copyright 2026 The Butler Authors.
+// SPDX-License-Identifier: Apache-2.0
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
-// Package tenant provides utilities for managing connections to tenant clusters.
 package tenant
 
 import (
 	"context"
+	"fmt"
 	"sync"
+	"time"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// ClientManager manages Kubernetes clients for tenant clusters.
-//
-// Since Kamaji hosts tenant control planes in the management cluster,
-// we can connect to tenant APIs locally. This manager caches clients
-// to avoid recreating them on every reconciliation.
-//
-// Key features:
-// - Caches clients by tenant cluster name
-// - Automatically refreshes clients when kubeconfig changes
-// - Cleans up clients when tenant clusters are deleted
-// - Thread-safe for concurrent reconciliation
+// ClientManager manages cached Kubernetes clients for tenant clusters.
+// Tenant control planes are hosted in the management cluster via Steward,
+// so connections use the internal ClusterIP service endpoint (admin.svc).
+// Clients are cached by tenant namespace/name to avoid creating new HTTP/2
+// connections on every reconcile cycle.
 type ClientManager struct {
 	mu      sync.RWMutex
 	clients map[string]*TenantClient
 	mgr     client.Client
 }
 
-// TenantClient wraps connections to a tenant cluster.
+// TenantClient wraps a cached connection to a tenant cluster.
 type TenantClient struct {
-	// RESTConfig is the REST config for the tenant cluster.
 	RESTConfig *rest.Config
-
-	// Clientset is the Kubernetes clientset.
-	Clientset kubernetes.Interface
-
-	// Client is the controller-runtime client.
-	Client client.Client
+	Clientset  kubernetes.Interface
 }
 
 // NewClientManager creates a new ClientManager.
@@ -63,50 +41,72 @@ func NewClientManager(mgr client.Client) *ClientManager {
 	}
 }
 
-// GetClient returns a client for the specified tenant cluster.
-// If a client doesn't exist or the kubeconfig has changed, a new one is created.
-func (m *ClientManager) GetClient(ctx context.Context, namespace, name string) (*TenantClient, error) {
-	key := namespace + "/" + name
+// GetClient returns a cached client for the specified tenant cluster.
+// On cache miss, it fetches the admin kubeconfig Secret from the tenant
+// namespace, preferring the internal service endpoint (admin.svc) over
+// the external endpoint (admin.conf).
+func (m *ClientManager) GetClient(ctx context.Context, namespace, clusterName string) (*TenantClient, error) {
+	key := namespace + "/" + clusterName
 
-	// Check cache first
 	m.mu.RLock()
-	if client, ok := m.clients[key]; ok {
+	if c, ok := m.clients[key]; ok {
 		m.mu.RUnlock()
-		return client, nil
+		return c, nil
 	}
 	m.mu.RUnlock()
 
-	// Create new client
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	// Double-check after acquiring write lock
-	if client, ok := m.clients[key]; ok {
-		return client, nil
+	if c, ok := m.clients[key]; ok {
+		return c, nil
 	}
 
-	// TODO: Implement client creation
-	// 1. Get kubeconfig secret for tenant cluster
-	// 2. Parse kubeconfig
-	// 3. Create REST config
-	// 4. Create clientset and controller-runtime client
-	// 5. Cache and return
+	secretName := clusterName + "-admin-kubeconfig"
+	secret := &corev1.Secret{}
+	if err := m.mgr.Get(ctx, client.ObjectKey{Name: secretName, Namespace: namespace}, secret); err != nil {
+		return nil, fmt.Errorf("fetching kubeconfig secret %s/%s: %w", namespace, secretName, err)
+	}
 
-	return nil, nil
+	var kubeconfigData []byte
+	for _, key := range []string{"admin.svc", "admin.conf"} {
+		if data, ok := secret.Data[key]; ok && len(data) > 0 {
+			kubeconfigData = data
+			break
+		}
+	}
+	if len(kubeconfigData) == 0 {
+		return nil, fmt.Errorf("kubeconfig secret %s/%s has no admin.svc or admin.conf key", namespace, secretName)
+	}
+
+	restConfig, err := clientcmd.RESTConfigFromKubeConfig(kubeconfigData)
+	if err != nil {
+		return nil, fmt.Errorf("parsing kubeconfig for %s/%s: %w", namespace, clusterName, err)
+	}
+	restConfig.Timeout = 10 * time.Second
+
+	clientset, err := kubernetes.NewForConfig(restConfig)
+	if err != nil {
+		return nil, fmt.Errorf("creating clientset for %s/%s: %w", namespace, clusterName, err)
+	}
+
+	tc := &TenantClient{
+		RESTConfig: restConfig,
+		Clientset:  clientset,
+	}
+	m.clients[namespace+"/"+clusterName] = tc
+	return tc, nil
 }
 
-// RemoveClient removes a cached client.
-// Called when a tenant cluster is deleted.
-func (m *ClientManager) RemoveClient(namespace, name string) {
-	key := namespace + "/" + name
+// RemoveClient removes a cached client. Called when a tenant cluster is deleted.
+func (m *ClientManager) RemoveClient(namespace, clusterName string) {
 	m.mu.Lock()
-	delete(m.clients, key)
+	delete(m.clients, namespace+"/"+clusterName)
 	m.mu.Unlock()
 }
 
-// RefreshClient forces a client refresh.
-// Called when a kubeconfig secret changes.
-func (m *ClientManager) RefreshClient(ctx context.Context, namespace, name string) (*TenantClient, error) {
-	m.RemoveClient(namespace, name)
-	return m.GetClient(ctx, namespace, name)
+// RefreshClient forces a client refresh. Called when a kubeconfig Secret changes.
+func (m *ClientManager) RefreshClient(ctx context.Context, namespace, clusterName string) (*TenantClient, error) {
+	m.RemoveClient(namespace, clusterName)
+	return m.GetClient(ctx, namespace, clusterName)
 }

--- a/internal/tenant/client.go
+++ b/internal/tenant/client.go
@@ -16,15 +16,23 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+const defaultTTL = 5 * time.Minute
+
+type cachedEntry struct {
+	client    *TenantClient
+	createdAt time.Time
+}
+
 // ClientManager manages cached Kubernetes clients for tenant clusters.
 // Tenant control planes are hosted in the management cluster via Steward,
 // so connections use the internal ClusterIP service endpoint (admin.svc).
-// Clients are cached by tenant namespace/name to avoid creating new HTTP/2
-// connections on every reconcile cycle.
+// Clients are cached by tenant namespace/name with a TTL to handle
+// kubeconfig rotation (cert renewal, key rotation).
 type ClientManager struct {
 	mu      sync.RWMutex
-	clients map[string]*TenantClient
+	clients map[string]*cachedEntry
 	mgr     client.Client
+	ttl     time.Duration
 }
 
 // TenantClient wraps a cached connection to a tenant cluster.
@@ -33,35 +41,47 @@ type TenantClient struct {
 	Clientset  kubernetes.Interface
 }
 
-// NewClientManager creates a new ClientManager.
+// NewClientManager creates a new ClientManager with the default TTL.
 func NewClientManager(mgr client.Client) *ClientManager {
 	return &ClientManager{
-		clients: make(map[string]*TenantClient),
+		clients: make(map[string]*cachedEntry),
 		mgr:     mgr,
+		ttl:     defaultTTL,
 	}
 }
 
 // GetClient returns a cached client for the specified tenant cluster.
-// On cache miss, it fetches the admin kubeconfig Secret from the tenant
-// namespace, preferring the internal service endpoint (admin.svc) over
-// the external endpoint (admin.conf).
+// On cache miss or TTL expiry, it fetches the admin kubeconfig Secret
+// from the tenant namespace, preferring the internal service endpoint
+// (admin.svc) over the external endpoint (admin.conf).
 func (m *ClientManager) GetClient(ctx context.Context, namespace, clusterName string) (*TenantClient, error) {
 	key := namespace + "/" + clusterName
+	now := time.Now()
 
 	m.mu.RLock()
-	if c, ok := m.clients[key]; ok {
+	if entry, ok := m.clients[key]; ok && now.Sub(entry.createdAt) < m.ttl {
 		m.mu.RUnlock()
-		return c, nil
+		return entry.client, nil
 	}
 	m.mu.RUnlock()
 
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	if c, ok := m.clients[key]; ok {
-		return c, nil
+	if entry, ok := m.clients[key]; ok && now.Sub(entry.createdAt) < m.ttl {
+		return entry.client, nil
 	}
 
+	tc, err := m.buildClient(ctx, namespace, clusterName)
+	if err != nil {
+		return nil, err
+	}
+
+	m.clients[key] = &cachedEntry{client: tc, createdAt: now}
+	return tc, nil
+}
+
+func (m *ClientManager) buildClient(ctx context.Context, namespace, clusterName string) (*TenantClient, error) {
 	secretName := clusterName + "-admin-kubeconfig"
 	secret := &corev1.Secret{}
 	if err := m.mgr.Get(ctx, client.ObjectKey{Name: secretName, Namespace: namespace}, secret); err != nil {
@@ -69,8 +89,8 @@ func (m *ClientManager) GetClient(ctx context.Context, namespace, clusterName st
 	}
 
 	var kubeconfigData []byte
-	for _, key := range []string{"admin.svc", "admin.conf"} {
-		if data, ok := secret.Data[key]; ok && len(data) > 0 {
+	for _, k := range []string{"admin.svc", "admin.conf"} {
+		if data, ok := secret.Data[k]; ok && len(data) > 0 {
 			kubeconfigData = data
 			break
 		}
@@ -90,12 +110,10 @@ func (m *ClientManager) GetClient(ctx context.Context, namespace, clusterName st
 		return nil, fmt.Errorf("creating clientset for %s/%s: %w", namespace, clusterName, err)
 	}
 
-	tc := &TenantClient{
+	return &TenantClient{
 		RESTConfig: restConfig,
 		Clientset:  clientset,
-	}
-	m.clients[namespace+"/"+clusterName] = tc
-	return tc, nil
+	}, nil
 }
 
 // RemoveClient removes a cached client. Called when a tenant cluster is deleted.

--- a/internal/tenant/client_test.go
+++ b/internal/tenant/client_test.go
@@ -1,0 +1,230 @@
+// Copyright 2026 The Butler Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package tenant
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+	clientfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func kubeconfig() []byte {
+	return []byte(`apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    server: https://127.0.0.1:6443
+    insecure-skip-tls-verify: true
+  name: test
+contexts:
+- context:
+    cluster: test
+    user: test
+  name: test
+current-context: test
+users:
+- name: test
+  user:
+    token: fake-token
+`)
+}
+
+func newFakeManager(secrets ...*corev1.Secret) *ClientManager {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+
+	builder := clientfake.NewClientBuilder().WithScheme(scheme)
+	for _, s := range secrets {
+		builder = builder.WithObjects(s)
+	}
+
+	cm := NewClientManager(builder.Build())
+	cm.ttl = 1 * time.Second
+	return cm
+}
+
+func secretWithKey(ns, name, key string) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+		Data:       map[string][]byte{key: kubeconfig()},
+	}
+}
+
+func TestGetClient_CacheHit(t *testing.T) {
+	cm := newFakeManager(secretWithKey("ns-a", "cluster1-admin-kubeconfig", "admin.svc"))
+
+	ctx := context.Background()
+	c1, err := cm.GetClient(ctx, "ns-a", "cluster1")
+	if err != nil {
+		t.Fatalf("first GetClient: %v", err)
+	}
+
+	c2, err := cm.GetClient(ctx, "ns-a", "cluster1")
+	if err != nil {
+		t.Fatalf("second GetClient: %v", err)
+	}
+
+	if c1 != c2 {
+		t.Error("expected same pointer on cache hit")
+	}
+}
+
+func TestGetClient_TTLExpiry(t *testing.T) {
+	cm := newFakeManager(secretWithKey("ns-a", "cluster1-admin-kubeconfig", "admin.svc"))
+	cm.ttl = 10 * time.Millisecond
+
+	ctx := context.Background()
+	c1, err := cm.GetClient(ctx, "ns-a", "cluster1")
+	if err != nil {
+		t.Fatalf("first GetClient: %v", err)
+	}
+
+	time.Sleep(20 * time.Millisecond)
+
+	c2, err := cm.GetClient(ctx, "ns-a", "cluster1")
+	if err != nil {
+		t.Fatalf("second GetClient after TTL: %v", err)
+	}
+
+	if c1 == c2 {
+		t.Error("expected different pointer after TTL expiry")
+	}
+}
+
+func TestGetClient_MissingSecret(t *testing.T) {
+	cm := newFakeManager()
+
+	_, err := cm.GetClient(context.Background(), "ns-a", "cluster1")
+	if err == nil {
+		t.Fatal("expected error for missing secret")
+	}
+}
+
+func TestGetClient_EmptySecret(t *testing.T) {
+	s := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "cluster1-admin-kubeconfig", Namespace: "ns-a"},
+		Data:       map[string][]byte{},
+	}
+	cm := newFakeManager(s)
+
+	_, err := cm.GetClient(context.Background(), "ns-a", "cluster1")
+	if err == nil {
+		t.Fatal("expected error for empty secret")
+	}
+}
+
+func TestGetClient_PrefersAdminSvc(t *testing.T) {
+	s := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "cluster1-admin-kubeconfig", Namespace: "ns-a"},
+		Data: map[string][]byte{
+			"admin.svc":  kubeconfig(),
+			"admin.conf": kubeconfig(),
+		},
+	}
+	cm := newFakeManager(s)
+
+	c, err := cm.GetClient(context.Background(), "ns-a", "cluster1")
+	if err != nil {
+		t.Fatalf("GetClient: %v", err)
+	}
+	if c.RESTConfig.Host != "https://127.0.0.1:6443" {
+		t.Errorf("unexpected host: %s", c.RESTConfig.Host)
+	}
+}
+
+func TestGetClient_FallsBackToAdminConf(t *testing.T) {
+	cm := newFakeManager(secretWithKey("ns-a", "cluster1-admin-kubeconfig", "admin.conf"))
+
+	c, err := cm.GetClient(context.Background(), "ns-a", "cluster1")
+	if err != nil {
+		t.Fatalf("GetClient: %v", err)
+	}
+	if c == nil {
+		t.Fatal("expected non-nil client")
+	}
+}
+
+func TestRemoveClient(t *testing.T) {
+	cm := newFakeManager(secretWithKey("ns-a", "cluster1-admin-kubeconfig", "admin.svc"))
+
+	ctx := context.Background()
+	c1, _ := cm.GetClient(ctx, "ns-a", "cluster1")
+	cm.RemoveClient("ns-a", "cluster1")
+	c2, _ := cm.GetClient(ctx, "ns-a", "cluster1")
+
+	if c1 == c2 {
+		t.Error("expected different pointer after RemoveClient")
+	}
+}
+
+func TestRefreshClient(t *testing.T) {
+	cm := newFakeManager(secretWithKey("ns-a", "cluster1-admin-kubeconfig", "admin.svc"))
+
+	ctx := context.Background()
+	c1, _ := cm.GetClient(ctx, "ns-a", "cluster1")
+	c2, err := cm.RefreshClient(ctx, "ns-a", "cluster1")
+	if err != nil {
+		t.Fatalf("RefreshClient: %v", err)
+	}
+
+	if c1 == c2 {
+		t.Error("expected different pointer after RefreshClient")
+	}
+}
+
+func TestGetClient_ConcurrentAccess(t *testing.T) {
+	cm := newFakeManager(secretWithKey("ns-a", "cluster1-admin-kubeconfig", "admin.svc"))
+	ctx := context.Background()
+
+	var wg sync.WaitGroup
+	results := make([]*TenantClient, 10)
+	errs := make([]error, 10)
+
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			results[idx], errs[idx] = cm.GetClient(ctx, "ns-a", "cluster1")
+		}(i)
+	}
+	wg.Wait()
+
+	for i, err := range errs {
+		if err != nil {
+			t.Fatalf("goroutine %d: %v", i, err)
+		}
+	}
+
+	// All should get the same cached client (within TTL)
+	for i := 1; i < 10; i++ {
+		if results[i] != results[0] {
+			t.Errorf("goroutine %d got different client than goroutine 0", i)
+		}
+	}
+}
+
+func TestGetClient_IsolatedNamespaces(t *testing.T) {
+	cm := newFakeManager(
+		secretWithKey("ns-a", "cluster1-admin-kubeconfig", "admin.svc"),
+		secretWithKey("ns-b", "cluster1-admin-kubeconfig", "admin.svc"),
+	)
+	ctx := context.Background()
+
+	ca, _ := cm.GetClient(ctx, "ns-a", "cluster1")
+	cb, _ := cm.GetClient(ctx, "ns-b", "cluster1")
+
+	if ca == cb {
+		t.Error("expected different clients for different namespaces")
+	}
+}
+
+// Verify the fake clientset import compiles (used in test helpers only).
+var _ = fake.NewSimpleClientset

--- a/internal/tenant/client_test.go
+++ b/internal/tenant/client_test.go
@@ -12,7 +12,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/kubernetes/fake"
 	clientfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
@@ -122,11 +121,47 @@ func TestGetClient_EmptySecret(t *testing.T) {
 }
 
 func TestGetClient_PrefersAdminSvc(t *testing.T) {
+	svcKubeconfig := []byte(`apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    server: https://internal-svc:6443
+    insecure-skip-tls-verify: true
+  name: test
+contexts:
+- context:
+    cluster: test
+    user: test
+  name: test
+current-context: test
+users:
+- name: test
+  user:
+    token: fake-token
+`)
+	confKubeconfig := []byte(`apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    server: https://external-lb:6443
+    insecure-skip-tls-verify: true
+  name: test
+contexts:
+- context:
+    cluster: test
+    user: test
+  name: test
+current-context: test
+users:
+- name: test
+  user:
+    token: fake-token
+`)
 	s := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{Name: "cluster1-admin-kubeconfig", Namespace: "ns-a"},
 		Data: map[string][]byte{
-			"admin.svc":  kubeconfig(),
-			"admin.conf": kubeconfig(),
+			"admin.svc":  svcKubeconfig,
+			"admin.conf": confKubeconfig,
 		},
 	}
 	cm := newFakeManager(s)
@@ -135,8 +170,8 @@ func TestGetClient_PrefersAdminSvc(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetClient: %v", err)
 	}
-	if c.RESTConfig.Host != "https://127.0.0.1:6443" {
-		t.Errorf("unexpected host: %s", c.RESTConfig.Host)
+	if c.RESTConfig.Host != "https://internal-svc:6443" {
+		t.Errorf("expected admin.svc host, got %s", c.RESTConfig.Host)
 	}
 }
 
@@ -225,6 +260,3 @@ func TestGetClient_IsolatedNamespaces(t *testing.T) {
 		t.Error("expected different clients for different namespaces")
 	}
 }
-
-// Verify the fake clientset import compiles (used in test helpers only).
-var _ = fake.NewSimpleClientset


### PR DESCRIPTION
## Summary

Pre-GA hardening pass across all 12 controllers plus addon installer. No business logic changes except deletion ordering fix and Helm recovery (both fixing pre-existing bugs that prevented clean cluster lifecycle).

**Concurrency & safety:**
- Enable leader election by default (sole protection for NetworkPool IPAM integrity)
- Re-fetch + conflict handling before finalizer removal in 6 controllers
- Replace full object Updates with MergePatch on CAPI Cluster and Machine resources
- Handle AlreadyExists race on CAPI resource creation (MaxConcurrentReconciles > 1)

**Client caching:**
- Implement tenant ClientManager cache with 5-min TTL, replacing 4 ad-hoc client creation sites
- 10 unit tests covering cache hit/miss, TTL expiry, concurrent access, namespace isolation

**Deletion reliability:**
- Delete CAPI Cluster before namespace to allow CAPI controller to remove its finalizer while dependent resources still exist
- Recover stuck pending-install/pending-upgrade Helm releases before every addon install (6 paths)

**Test fixes:**
- Fix builder tests (HarvesterCluster -> KubevirtCluster migration)
- Fix missing EventRecorder in NetworkPool and ProviderConfig test suites

## E2E results on butler-beta

- Create: Pending -> Provisioning -> Installing -> Ready in ~4 min
- Steady state: 15 existing clusters all Ready, correct worker counts via ClientManager
- Deletion ordering: "deleting CAPI Cluster before namespace" -> CAPI finalizer removed -> namespace deleted -> "TenantCluster deletion complete"
- Helm recovery: "recovering stuck pending-upgrade release" for Cilium, "recovering stuck pending-install release" for vector-agent
- Deletion blocked by intermittent API server -> ClusterIP networking issue on butler-beta (affects all webhooks, not butler-controller specific)

## Known issues (not introduced by this PR)

- **API server webhook connectivity**: butler-beta API server intermittently cannot reach ClusterIP services, causing CAPI validation webhook timeouts during Cluster DELETE operations. Affects Longhorn conversion webhooks too. Likely Cilium/networking issue on control plane nodes. Needs separate investigation.
- **Transient Failed phase on creation**: AlreadyExists race between concurrent reconciles causes brief Failed phase before self-recovery. Pre-existing on v0.10.2.
- **NetworkPool/ProviderConfig integration tests**: Pre-existing flaky tests (timing-based), not introduced by this PR.

## Test plan

- [x] `go vet ./internal/... ./cmd/...` clean
- [x] Unit tests: ipam, talos, capi (19 tests), tenant (10 tests)
- [x] Integration tests: TenantCluster (26 tests), Team, ButlerConfig
- [x] CI build + multi-arch image
- [x] butler-beta: leader lease acquired, 15 clusters steady-state
- [x] butler-beta: full create -> Ready lifecycle
- [x] butler-beta: Helm recovery from stuck pending releases
- [x] butler-beta: CAPI Cluster deletion ordering (clean when webhook reachable)