### PR TITLE
refactor: cache ProviderConfig per reconcile cycle

### DIFF
--- a/internal/controller/tenantcluster/reconcile_infrastructure.go
+++ b/internal/controller/tenantcluster/reconcile_infrastructure.go
@@ -25,7 +25,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 
-func (r *Reconciler) reconcileInfrastructure(ctx context.Context, tc *butlerv1alpha1.TenantCluster, butlerConfig *butlerv1alpha1.ButlerConfig) (ctrl.Result, error) {
+func (r *Reconciler) reconcileInfrastructure(ctx context.Context, tc *butlerv1alpha1.TenantCluster, butlerConfig *butlerv1alpha1.ButlerConfig, providerConfig *butlerv1alpha1.ProviderConfig) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
 
 	// Already ready, nothing to do
@@ -35,11 +35,14 @@ func (r *Reconciler) reconcileInfrastructure(ctx context.Context, tc *butlerv1al
 
 	logger.Info("reconciling infrastructure", "tenantNamespace", tc.Status.TenantNamespace)
 
-	providerConfig, err := r.getProviderConfig(ctx, tc)
-	if err != nil {
-		r.setCondition(tc, butlerv1alpha1.TenantClusterConditionInfrastructureReady,
-			metav1.ConditionFalse, ReasonProviderConfigNotFound, err.Error())
-		return ctrl.Result{}, err
+	if providerConfig == nil {
+		var err error
+		providerConfig, err = r.getProviderConfig(ctx, tc)
+		if err != nil {
+			r.setCondition(tc, butlerv1alpha1.TenantClusterConditionInfrastructureReady,
+				metav1.ConditionFalse, ReasonProviderConfigNotFound, err.Error())
+			return ctrl.Result{}, err
+		}
 	}
 
 	// Validate provider scope access

--- a/internal/controller/tenantcluster/reconcile_ipam.go
+++ b/internal/controller/tenantcluster/reconcile_ipam.go
@@ -149,16 +149,20 @@ func (r *Reconciler) reconcileIPAllocation(ctx context.Context, tc *butlerv1alph
 }
 
 // reconcileElasticIPAM handles dynamic LB IP allocation growth and shrink for Ready clusters.
-func (r *Reconciler) reconcileElasticIPAM(ctx context.Context, tc *butlerv1alpha1.TenantCluster, butlerConfig *butlerv1alpha1.ButlerConfig) error {
+func (r *Reconciler) reconcileElasticIPAM(ctx context.Context, tc *butlerv1alpha1.TenantCluster, butlerConfig *butlerv1alpha1.ButlerConfig, providerConfig *butlerv1alpha1.ProviderConfig) error {
 	if tc.Status.Phase != butlerv1alpha1.TenantClusterPhaseReady {
 		return nil
 	}
 
 	logger := log.FromContext(ctx)
 
-	pc, err := r.getProviderConfig(ctx, tc)
-	if err != nil {
-		return nil // Can't get provider, skip silently
+	pc := providerConfig
+	if pc == nil {
+		var err error
+		pc, err = r.getProviderConfig(ctx, tc)
+		if err != nil {
+			return nil
+		}
 	}
 
 	if !r.isElasticIPAM(pc) {

--- a/internal/controller/tenantcluster/tenantcluster_controller.go
+++ b/internal/controller/tenantcluster/tenantcluster_controller.go
@@ -203,7 +203,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		}
 	}
 
-	result, err := r.reconcileInfrastructure(ctx, tc, butlerConfig)
+	result, err := r.reconcileInfrastructure(ctx, tc, butlerConfig, providerConfig)
 	if err != nil {
 		logger.Error(err, "failed to reconcile infrastructure")
 		return r.setFailedStatus(ctx, tc, ReasonCAPIResourceError, err.Error())
@@ -248,7 +248,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		degraded = append(degraded, "machine template sync failed ("+truncateError(err)+")")
 	}
 
-	if err := r.reconcileElasticIPAM(ctx, tc, butlerConfig); err != nil {
+	if err := r.reconcileElasticIPAM(ctx, tc, butlerConfig, providerConfig); err != nil {
 		logger.Error(err, "elastic IPAM reconciliation failed")
 		degraded = append(degraded, "elastic IPAM failed ("+truncateError(err)+")")
 	}


### PR DESCRIPTION
## Summary

ProviderConfig was fetched 3 times per reconcile cycle: once in Reconcile() for image sync, once in reconcileInfrastructure() for CAPI builds, and once in reconcileElasticIPAM() for LB pool management.

Fetch once in Reconcile() and pass to sub-reconcilers. Both reconcileInfrastructure and reconcileElasticIPAM fall back to fetching if the caller passes nil.

**Owner references (P2-3) dropped from this PR.** Testing on butler-beta confirmed that CAPI actively manages owner references on its resources (Cluster owns InfraCluster, MachineDeployment, etc.) and overwrites any cross-group owner refs set by Butler. The TenantCluster owner refs are replaced within seconds of creation. The deletion ordering fix in v0.11.0 (delete CAPI Cluster before namespace) is the correct cleanup mechanism.

## Test plan

- [x] `go vet` clean
- [x] Integration tests: 13/14 pass (same pre-existing flaky deletion test)
- [x] butler-beta: deployed, all 15 clusters ReconcileSucceeded, zero errors
- [x] butler-beta: verified CAPI overwrites owner refs (owner ref approach abandoned)