### PR TITLE
test: add unit tests for kamajisecret and kamajistatus controllers

### DIFF
--- a/internal/controller/kamajisecret/kamajisecret_controller_test.go
+++ b/internal/controller/kamajisecret/kamajisecret_controller_test.go
@@ -1,0 +1,31 @@
+// Copyright 2026 The Butler Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package kamajisecret
+
+import "testing"
+
+func TestExtractClusterName(t *testing.T) {
+	tests := []struct {
+		name       string
+		secretName string
+		expected   string
+	}{
+		{"standard format", "my-cluster-admin-kubeconfig", "my-cluster"},
+		{"dashes in name", "prod-us-east-1-admin-kubeconfig", "prod-us-east-1"},
+		{"short name", "a-admin-kubeconfig", "a"},
+		{"no suffix match", "my-cluster-kubeconfig", ""},
+		{"just the suffix", "-admin-kubeconfig", ""},
+		{"empty string", "", ""},
+		{"partial suffix", "my-cluster-admin-kubeconfigx", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractClusterName(tt.secretName)
+			if got != tt.expected {
+				t.Errorf("extractClusterName(%q) = %q, want %q", tt.secretName, got, tt.expected)
+			}
+		})
+	}
+}

--- a/internal/controller/kamajistatus/kamajistatus_controller_test.go
+++ b/internal/controller/kamajistatus/kamajistatus_controller_test.go
@@ -1,0 +1,142 @@
+// Copyright 2026 The Butler Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package kamajistatus
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func TestIsTCPReady(t *testing.T) {
+	r := &Reconciler{}
+
+	tests := []struct {
+		name        string
+		tcp         map[string]interface{}
+		wantReady   bool
+		wantVersion string
+	}{
+		{
+			"ready with version",
+			map[string]interface{}{
+				"status": map[string]interface{}{
+					"kubernetes": map[string]interface{}{
+						"status":  "Ready",
+						"version": map[string]interface{}{"version": "v1.31.0"},
+					},
+				},
+			},
+			true, "v1.31.0",
+		},
+		{
+			"not ready",
+			map[string]interface{}{
+				"status": map[string]interface{}{
+					"kubernetes": map[string]interface{}{
+						"status": "Provisioning",
+					},
+				},
+			},
+			false, "",
+		},
+		{
+			"no status",
+			map[string]interface{}{},
+			false, "",
+		},
+		{
+			"no kubernetes status",
+			map[string]interface{}{
+				"status": map[string]interface{}{},
+			},
+			false, "",
+		},
+		{
+			"ready without version info",
+			map[string]interface{}{
+				"status": map[string]interface{}{
+					"kubernetes": map[string]interface{}{
+						"status": "Ready",
+					},
+				},
+			},
+			true, "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tcp := &unstructured.Unstructured{Object: tt.tcp}
+			gotReady, gotVersion, err := r.isTCPReady(tcp)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if gotReady != tt.wantReady {
+				t.Errorf("ready = %v, want %v", gotReady, tt.wantReady)
+			}
+			if gotVersion != tt.wantVersion {
+				t.Errorf("version = %q, want %q", gotVersion, tt.wantVersion)
+			}
+		})
+	}
+}
+
+func TestIsSCPReady(t *testing.T) {
+	r := &Reconciler{}
+
+	tests := []struct {
+		name      string
+		kcp       map[string]interface{}
+		wantReady bool
+	}{
+		{
+			"ready",
+			map[string]interface{}{
+				"status": map[string]interface{}{
+					"readyReplicas": int64(1),
+					"ready":         true,
+				},
+			},
+			true,
+		},
+		{
+			"not ready - zero replicas",
+			map[string]interface{}{
+				"status": map[string]interface{}{
+					"readyReplicas": int64(0),
+					"ready":         false,
+				},
+			},
+			false,
+		},
+		{
+			"not ready - missing ready field",
+			map[string]interface{}{
+				"status": map[string]interface{}{
+					"readyReplicas": int64(1),
+				},
+			},
+			false,
+		},
+		{
+			"no status",
+			map[string]interface{}{},
+			false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			kcp := &unstructured.Unstructured{Object: tt.kcp}
+			gotReady, err := r.isSCPReady(kcp)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if gotReady != tt.wantReady {
+				t.Errorf("ready = %v, want %v", gotReady, tt.wantReady)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Add unit tests for two previously untested controllers:

- **kamajisecret**: 7 table-driven tests for `extractClusterName` (cluster name extraction from Secret naming convention)
- **kamajistatus**: 9 table-driven tests for `isTCPReady` and `isSCPReady` (TenantControlPlane and StewardControlPlane readiness checks)

These test pure functions that don't require envtest — no Kubernetes API calls, just struct parsing and string manipulation.

Note: these packages are named `kamajisecret`/`kamajistatus` (legacy naming from before the Kamaji → Steward fork). Package rename to `stewardsecret`/`stewardstatus` is tracked as a separate follow-up.

Remaining untested controllers (ipallocation, tenantaddon, managementaddon, workspace, imagesync) require envtest suites for meaningful coverage.

## Test plan

- [x] `go vet` clean
- [x] All 16 new tests pass
- No butler-beta deploy needed — test-only changes