### PR TITLE
refactor: rename kamaji packages and references to steward

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -79,6 +79,8 @@ func main() {
 	flag.BoolVar(&enableStewardControllers, "enable-steward-controllers", true,
 		"Enable Steward integration controllers (StewardSecret, StewardStatus). "+
 			"Disable if not using Steward for hosted control planes.")
+	flag.BoolVar(&enableStewardControllers, "enable-kamaji-controllers", true,
+		"Deprecated: use --enable-steward-controllers instead.")
 	flag.BoolVar(&enableWebhooks, "enable-webhooks", false,
 		"Enable admission webhooks for TenantCluster, NetworkPool, and ProviderConfig. "+
 			"Requires cert-manager for TLS certificate management.")

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -36,8 +36,8 @@ import (
 	"github.com/butlerdotdev/butler-controller/internal/controller/butlerconfig"
 	"github.com/butlerdotdev/butler-controller/internal/controller/imagesync"
 	"github.com/butlerdotdev/butler-controller/internal/controller/ipallocation"
-	"github.com/butlerdotdev/butler-controller/internal/controller/kamajisecret"
-	"github.com/butlerdotdev/butler-controller/internal/controller/kamajistatus"
+	"github.com/butlerdotdev/butler-controller/internal/controller/stewardsecret"
+	"github.com/butlerdotdev/butler-controller/internal/controller/stewardstatus"
 	"github.com/butlerdotdev/butler-controller/internal/controller/managementaddon"
 	"github.com/butlerdotdev/butler-controller/internal/controller/networkpool"
 	"github.com/butlerdotdev/butler-controller/internal/controller/providerconfig"
@@ -68,7 +68,7 @@ func main() {
 	var metricsAddr string
 	var probeAddr string
 	var enableLeaderElection bool
-	var enableKamajiControllers bool
+	var enableStewardControllers bool
 	var enableWebhooks bool
 
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
@@ -76,9 +76,9 @@ func main() {
 	flag.BoolVar(&enableLeaderElection, "leader-elect", true,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
-	flag.BoolVar(&enableKamajiControllers, "enable-kamaji-controllers", true,
-		"Enable Kamaji integration controllers (KamajiSecret, KamajiStatus). "+
-			"Disable if not using Kamaji for hosted control planes.")
+	flag.BoolVar(&enableStewardControllers, "enable-steward-controllers", true,
+		"Enable Steward integration controllers (StewardSecret, StewardStatus). "+
+			"Disable if not using Steward for hosted control planes.")
 	flag.BoolVar(&enableWebhooks, "enable-webhooks", false,
 		"Enable admission webhooks for TenantCluster, NetworkPool, and ProviderConfig. "+
 			"Requires cert-manager for TLS certificate management.")
@@ -241,28 +241,28 @@ func main() {
 		setupLog.Info("admission webhooks disabled")
 	}
 
-	// Kamaji integration controllers
-	if enableKamajiControllers {
-		// KamajiSecret controller. Translates kubeconfig format
-		if err = (&kamajisecret.Reconciler{
+	// Steward integration controllers
+	if enableStewardControllers {
+		// StewardSecret controller. Translates kubeconfig format
+		if err = (&stewardsecret.Reconciler{
 			Client: mgr.GetClient(),
 			Scheme: mgr.GetScheme(),
 		}).SetupWithManager(mgr); err != nil {
-			setupLog.Error(err, "unable to create controller", "controller", "KamajiSecret")
+			setupLog.Error(err, "unable to create controller", "controller", "StewardSecret")
 			os.Exit(1)
 		}
 
-		// KamajiStatus controller
-		if err = (&kamajistatus.Reconciler{
+		// StewardStatus controller
+		if err = (&stewardstatus.Reconciler{
 			Client: mgr.GetClient(),
 			Scheme: mgr.GetScheme(),
 		}).SetupWithManager(mgr); err != nil {
-			setupLog.Error(err, "unable to create controller", "controller", "KamajiStatus")
+			setupLog.Error(err, "unable to create controller", "controller", "StewardStatus")
 			os.Exit(1)
 		}
-		setupLog.Info("Kamaji integration controllers enabled")
+		setupLog.Info("Steward integration controllers enabled")
 	} else {
-		setupLog.Info("Kamaji integration controllers disabled")
+		setupLog.Info("Steward integration controllers disabled")
 	}
 
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
@@ -275,7 +275,7 @@ func main() {
 	}
 
 	setupLog.Info("starting manager",
-		"controllers", []string{"ButlerConfig", "Team", "TenantCluster", "TenantAddon", "ManagementAddon", "NetworkPool", "IPAllocation", "ImageSync", "ProviderConfig", "Workspace", "KamajiSecret", "KamajiStatus"})
+		"controllers", []string{"ButlerConfig", "Team", "TenantCluster", "TenantAddon", "ManagementAddon", "NetworkPool", "IPAllocation", "ImageSync", "ProviderConfig", "Workspace", "StewardSecret", "StewardStatus"})
 
 	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
 		setupLog.Error(err, "problem running manager")

--- a/internal/addons/installer.go
+++ b/internal/addons/installer.go
@@ -37,7 +37,7 @@ const (
 )
 
 // Installer handles addon installations on tenant clusters.
-// Tenant clusters use Kamaji hosted control planes, so Cilium must be
+// Tenant clusters use Steward hosted control planes, so Cilium must be
 // configured to reach the API server via kubernetes.default.svc.cluster.local
 // rather than localhost:7445 used on management clusters.
 type Installer struct {

--- a/internal/capi/builder.go
+++ b/internal/capi/builder.go
@@ -237,7 +237,7 @@ func (b *Builder) buildKubevirtCluster(name string) *unstructured.Unstructured {
 			"apiVersion": "v1",
 			"kind":       "Secret",
 		},
-		// Control plane service template - Kamaji handles the actual control plane
+		// Control plane service template - Steward handles the actual control plane
 		// but capk needs this for cluster readiness
 		"controlPlaneServiceTemplate": map[string]interface{}{
 			"spec": map[string]interface{}{
@@ -633,7 +633,7 @@ func (b *Builder) buildKubevirtMachineTemplate(name string) *unstructured.Unstru
 }
 
 // buildNutanixResources constructs CAPI resources for Nutanix provider.
-// Uses CAPX (cluster-api-provider-nutanix) with Kamaji hosted control planes.
+// Uses CAPX (cluster-api-provider-nutanix) with Steward hosted control planes.
 func (b *Builder) buildNutanixResources() (*ResourceSet, error) {
 	// Validate Nutanix credentials are provided
 	if b.nutanixCreds == nil {
@@ -707,7 +707,7 @@ func (b *Builder) buildNutanixCluster(name string) *unstructured.Unstructured {
 	credSecretName := fmt.Sprintf("%s-nutanix-creds", name)
 
 	spec := map[string]interface{}{
-		// Control plane endpoint - will be patched by Kamaji when LoadBalancer gets IP
+		// Control plane endpoint - will be patched by Steward when LoadBalancer gets IP
 		"controlPlaneEndpoint": map[string]interface{}{
 			"host": "",
 			"port": int64(6443),

--- a/internal/controller/stewardsecret/stewardsecret_controller.go
+++ b/internal/controller/stewardsecret/stewardsecret_controller.go
@@ -14,12 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package kamajisecret provides a controller that translates Kamaji kubeconfig secrets
+// Package stewardsecret provides a controller that translates Steward kubeconfig secrets
 // to the format expected by Cluster API.
 //
-// Problem: Kamaji creates kubeconfig secrets with key "admin.conf", but CAPI expects "value".
-// Solution: Watch Kamaji secrets and create/update corresponding CAPI-compatible secrets.
-package kamajisecret
+// Problem: Steward creates kubeconfig secrets with key "admin.conf", but CAPI expects "value".
+// Solution: Watch Steward secrets and create/update corresponding CAPI-compatible secrets.
+package stewardsecret
 
 import (
 	"context"
@@ -39,12 +39,12 @@ import (
 )
 
 const (
-	// StewardAdminKubeconfigLabel is the label that identifies Kamaji admin kubeconfig secrets.
+	// StewardAdminKubeconfigLabel is the label that identifies Steward admin kubeconfig secrets.
 	StewardAdminKubeconfigLabel = "steward.butlerlabs.dev/component"
-	KamajiAdminKubeconfigValue = "admin-kubeconfig"
+	StewardAdminKubeconfigValue = "admin-kubeconfig"
 
-	// KamajiSourceKey is the key Kamaji uses for the kubeconfig.
-	KamajiSourceKey = "admin.conf"
+	// StewardSourceKey is the key Steward uses for the kubeconfig.
+	StewardSourceKey = "admin.conf"
 
 	// CAPITargetKey is the key CAPI expects for the kubeconfig.
 	CAPITargetKey = "value"
@@ -56,7 +56,7 @@ const (
 	ButlerManagedLabel = "app.kubernetes.io/managed-by"
 )
 
-// Reconciler watches Kamaji kubeconfig secrets and creates CAPI-compatible versions.
+// Reconciler watches Steward kubeconfig secrets and creates CAPI-compatible versions.
 type Reconciler struct {
 	client.Client
 	Scheme *runtime.Scheme
@@ -64,13 +64,13 @@ type Reconciler struct {
 
 // +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;create;update;patch
 
-// Reconcile handles Kamaji secret translation.
+// Reconcile handles Steward secret translation.
 func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
 
-	// Get the Kamaji secret
-	kamajiSecret := &corev1.Secret{}
-	if err := r.Get(ctx, req.NamespacedName, kamajiSecret); err != nil {
+	// Get the Steward admin-kubeconfig secret
+	stewardSecret := &corev1.Secret{}
+	if err := r.Get(ctx, req.NamespacedName, stewardSecret); err != nil {
 		if apierrors.IsNotFound(err) {
 			// Secret was deleted, CAPI secret will be garbage collected via owner reference
 			return ctrl.Result{}, nil
@@ -78,22 +78,22 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		return ctrl.Result{}, err
 	}
 
-	// Skip if not a Kamaji admin kubeconfig secret
-	if kamajiSecret.Labels[StewardAdminKubeconfigLabel] != KamajiAdminKubeconfigValue {
+	// Skip if not a Steward admin kubeconfig secret
+	if stewardSecret.Labels[StewardAdminKubeconfigLabel] != StewardAdminKubeconfigValue {
 		return ctrl.Result{}, nil
 	}
 
-	// Extract kubeconfig from Kamaji secret
-	kubeconfigData, ok := kamajiSecret.Data[KamajiSourceKey]
+	// Extract kubeconfig from Steward secret
+	kubeconfigData, ok := stewardSecret.Data[StewardSourceKey]
 	if !ok {
-		logger.V(1).Info("Kamaji secret missing admin.conf key", "secret", req.NamespacedName)
+		logger.V(1).Info("Steward secret missing admin.conf key", "secret", req.NamespacedName)
 		return ctrl.Result{}, nil
 	}
 
 	// Derive cluster name from secret name (format: {cluster-name}-admin-kubeconfig)
-	clusterName := extractClusterName(kamajiSecret.Name)
+	clusterName := extractClusterName(stewardSecret.Name)
 	if clusterName == "" {
-		logger.Info("could not extract cluster name from secret", "secret", kamajiSecret.Name)
+		logger.Info("could not extract cluster name from secret", "secret", stewardSecret.Name)
 		return ctrl.Result{}, nil
 	}
 
@@ -120,9 +120,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 			CAPITargetKey: kubeconfigData,
 		}
 
-		// Set owner reference to the original Kamaji secret
-		// This ensures cleanup when the Kamaji secret is deleted
-		return controllerutil.SetOwnerReference(kamajiSecret, capiSecret, r.Scheme)
+		// Set owner reference to the original Steward secret
+		// This ensures cleanup when the Steward secret is deleted
+		return controllerutil.SetOwnerReference(stewardSecret, capiSecret, r.Scheme)
 	})
 
 	if err != nil {
@@ -143,7 +143,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	return ctrl.Result{}, nil
 }
 
-// extractClusterName extracts the cluster name from a Kamaji secret name.
+// extractClusterName extracts the cluster name from a Steward admin-kubeconfig secret name.
 // Format: {cluster-name}-admin-kubeconfig -> cluster-name
 func extractClusterName(secretName string) string {
 	const suffix = "-admin-kubeconfig"
@@ -155,14 +155,14 @@ func extractClusterName(secretName string) string {
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
-	// Only watch secrets with the Kamaji admin-kubeconfig label
+	// Only watch secrets with the Steward admin-kubeconfig label
 	labelPredicate := predicate.NewPredicateFuncs(func(obj client.Object) bool {
 		labels := obj.GetLabels()
-		return labels[StewardAdminKubeconfigLabel] == KamajiAdminKubeconfigValue
+		return labels[StewardAdminKubeconfigLabel] == StewardAdminKubeconfigValue
 	})
 
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&corev1.Secret{}, builder.WithPredicates(labelPredicate)).
-		Named("kamajisecret").
+		Named("stewardsecret").
 		Complete(r)
 }

--- a/internal/controller/stewardsecret/stewardsecret_controller_test.go
+++ b/internal/controller/stewardsecret/stewardsecret_controller_test.go
@@ -1,7 +1,7 @@
 // Copyright 2026 The Butler Authors.
 // SPDX-License-Identifier: Apache-2.0
 
-package kamajisecret
+package stewardsecret
 
 import "testing"
 

--- a/internal/controller/stewardstatus/stewardstatus_controller.go
+++ b/internal/controller/stewardstatus/stewardstatus_controller.go
@@ -14,16 +14,16 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package kamajistatus provides a controller that synchronizes Kamaji TenantControlPlane
+// Package stewardstatus provides a controller that synchronizes Steward TenantControlPlane
 // status to StewardControlPlane for CAPI compatibility.
 //
-// Problem: The Kamaji CAPI provider sometimes fails to properly synchronize status
-// from the Kamaji TenantControlPlane to the StewardControlPlane resource, causing
+// Problem: The capi-steward provider sometimes fails to properly synchronize status
+// from the Steward TenantControlPlane to the StewardControlPlane resource, causing
 // CAPI to not recognize the control plane as ready.
 //
 // Solution: Watch TenantControlPlane resources and patch the corresponding
 // StewardControlPlane status when the TCP is ready.
-package kamajistatus
+package stewardstatus
 
 import (
 	"context"
@@ -53,7 +53,7 @@ var (
 	}
 )
 
-// Reconciler watches Kamaji TenantControlPlane resources and syncs status to StewardControlPlane.
+// Reconciler watches Steward TenantControlPlane resources and syncs status to StewardControlPlane.
 type Reconciler struct {
 	client.Client
 	Scheme *runtime.Scheme
@@ -61,8 +61,8 @@ type Reconciler struct {
 
 // +kubebuilder:rbac:groups=steward.butlerlabs.dev,resources=tenantcontrolplanes,verbs=get;list;watch
 // +kubebuilder:rbac:groups=steward.butlerlabs.dev,resources=tenantcontrolplanes/status,verbs=get
-// +kubebuilder:rbac:groups=controlplane.cluster.x-k8s.io,resources=kamajicontrolplanes,verbs=get;list;watch;update;patch
-// +kubebuilder:rbac:groups=controlplane.cluster.x-k8s.io,resources=kamajicontrolplanes/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=controlplane.cluster.x-k8s.io,resources=stewardcontrolplanes,verbs=get;list;watch;update;patch
+// +kubebuilder:rbac:groups=controlplane.cluster.x-k8s.io,resources=stewardcontrolplanes/status,verbs=get;update;patch
 
 // Reconcile handles TenantControlPlane status synchronization.
 func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
@@ -212,6 +212,6 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 	return ctrl.NewControllerManagedBy(mgr).
 		For(tcp).
-		Named("kamajistatus").
+		Named("stewardstatus").
 		Complete(r)
 }

--- a/internal/controller/stewardstatus/stewardstatus_controller_test.go
+++ b/internal/controller/stewardstatus/stewardstatus_controller_test.go
@@ -1,7 +1,7 @@
 // Copyright 2026 The Butler Authors.
 // SPDX-License-Identifier: Apache-2.0
 
-package kamajistatus
+package stewardstatus
 
 import (
 	"testing"

--- a/internal/controller/tenantcluster/reconcile_infrastructure.go
+++ b/internal/controller/tenantcluster/reconcile_infrastructure.go
@@ -153,9 +153,9 @@ func (r *Reconciler) reconcileInfrastructure(ctx context.Context, tc *butlerv1al
 		logger.Error(err, "failed to check infrastructure status")
 	}
 
-	patched, err := r.handleKamajiHarvesterCompatibility(ctx, tc, butlerConfig)
+	patched, err := r.handleStewardHarvesterCompatibility(ctx, tc, butlerConfig)
 	if err != nil {
-		logger.Error(err, "failed to handle Kamaji compatibility")
+		logger.Error(err, "failed to handle Steward compatibility")
 	}
 	if patched {
 		logger.Info("patched StewardControlPlane status for Harvester compatibility")
@@ -301,7 +301,7 @@ func (r *Reconciler) checkInfrastructureStatus(ctx context.Context, tc *butlerv1
 	return infraReady, cpReady, workersReady, nil
 }
 
-func (r *Reconciler) handleKamajiHarvesterCompatibility(ctx context.Context, tc *butlerv1alpha1.TenantCluster, butlerConfig *butlerv1alpha1.ButlerConfig) (bool, error) {
+func (r *Reconciler) handleStewardHarvesterCompatibility(ctx context.Context, tc *butlerv1alpha1.TenantCluster, butlerConfig *butlerv1alpha1.ButlerConfig) (bool, error) {
 	logger := log.FromContext(ctx)
 
 	kcp := &unstructured.Unstructured{}
@@ -442,7 +442,7 @@ func (r *Reconciler) handleKamajiHarvesterCompatibility(ctx context.Context, tc 
 		return false, nil
 	}
 
-	logger.Info("detected Kamaji unsupported infrastructure provider error, patching StewardControlPlane status")
+	logger.Info("detected unsupported infrastructure provider error, patching StewardControlPlane status")
 
 	deploymentStatus, deployFound, _ := unstructured.NestedMap(tcp.Object, "status", "kubernetesResources", "deployment")
 	if !deployFound {

--- a/internal/controller/tenantcluster/tenantcluster_controller.go
+++ b/internal/controller/tenantcluster/tenantcluster_controller.go
@@ -83,8 +83,8 @@ type Reconciler struct {
 // +kubebuilder:rbac:groups=cluster.x-k8s.io,resources=machinedeployments,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=cluster.x-k8s.io,resources=machinedeployments/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=bootstrap.cluster.x-k8s.io,resources=kubeadmconfigtemplates,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=controlplane.cluster.x-k8s.io,resources=kamajicontrolplanes,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=controlplane.cluster.x-k8s.io,resources=kamajicontrolplanes/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=controlplane.cluster.x-k8s.io,resources=stewardcontrolplanes,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=controlplane.cluster.x-k8s.io,resources=stewardcontrolplanes/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=harvesterclusters,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=harvestermachinetemplates,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=events,verbs=create;patch


### PR DESCRIPTION
## Summary

Rename all "kamaji" references to "steward" across the codebase. Steward is Butler's community-governed fork of Kamaji; the naming was a holdover from before the fork.

**Package renames:**
- `internal/controller/kamajisecret` -> `internal/controller/stewardsecret`
- `internal/controller/kamajistatus` -> `internal/controller/stewardstatus`

**Flag rename:**
- `--enable-kamaji-controllers` -> `--enable-steward-controllers`

**Function rename:**
- `handleKamajiHarvesterCompatibility` -> `handleStewardHarvesterCompatibility`

**Constant renames:**
- `KamajiSourceKey` -> `StewardSourceKey`
- `KamajiAdminKubeconfigValue` -> `StewardAdminKubeconfigValue`

**RBAC fix:**
- `kamajicontrolplanes` -> `stewardcontrolplanes` in kubebuilder markers (the CRD was already renamed but markers were stale)

## Test plan

- [x] `go vet` clean
- [x] All renamed package tests pass (stewardsecret: 7, stewardstatus: 9)
- [ ] Deploy to butler-beta: verify both controllers start and reconcile