### PR TITLE
chore: bump butler-api to v0.10.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/butlerdotdev/butler-controller
 go 1.24.6
 
 require (
-	github.com/butlerdotdev/butler-api v0.9.5-0.20260421165241-305dc45811fb
+	github.com/butlerdotdev/butler-api v0.10.0
 	github.com/onsi/ginkgo/v2 v2.22.0
 	github.com/onsi/gomega v1.36.1
 	github.com/prometheus/client_golang v1.22.0

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
-github.com/butlerdotdev/butler-api v0.9.5-0.20260421165241-305dc45811fb h1:VvxqEMQFfORlE1KIjwhDZ79cCkEsrq85jZ0+HyC5fw8=
-github.com/butlerdotdev/butler-api v0.9.5-0.20260421165241-305dc45811fb/go.mod h1:q/RjPFM/r2ELq4DqR78OiAxerKBvH5D4nTGsVLKbjqY=
+github.com/butlerdotdev/butler-api v0.10.0 h1:cg3uKmsLD9Ty8sjAr+g//NaTo05u0p2WK4X7OxBmwIU=
+github.com/butlerdotdev/butler-api v0.10.0/go.mod h1:q/RjPFM/r2ELq4DqR78OiAxerKBvH5D4nTGsVLKbjqY=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=


### PR DESCRIPTION
Bump butler-api from pseudo-version to the tagged v0.10.0 release containing ADR-009 team environments types (EnvironmentSpec, EnvironmentLimits, new labels/annotations). No code changes; tests continue to pass.