### PR TITLE
feat: NTP time server support for Talos worker nodes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/butlerdotdev/butler-controller
 go 1.24.6
 
 require (
-	github.com/butlerdotdev/butler-api v0.10.0
+	github.com/butlerdotdev/butler-api v0.11.0
 	github.com/onsi/ginkgo/v2 v2.22.0
 	github.com/onsi/gomega v1.36.1
 	github.com/prometheus/client_golang v1.22.0
@@ -74,5 +74,3 @@ require (
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.0 // indirect
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )
-
-replace github.com/butlerdotdev/butler-api => ../butler-api

--- a/go.mod
+++ b/go.mod
@@ -74,3 +74,5 @@ require (
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.0 // indirect
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )
+
+replace github.com/butlerdotdev/butler-api => ../butler-api

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
+github.com/butlerdotdev/butler-api v0.11.0 h1:JbDsZcn4JEryTSqrWmcdUkP/RA8FXfTV+kl3mbBOrA0=
+github.com/butlerdotdev/butler-api v0.11.0/go.mod h1:q/RjPFM/r2ELq4DqR78OiAxerKBvH5D4nTGsVLKbjqY=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,5 @@
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
-github.com/butlerdotdev/butler-api v0.10.0 h1:cg3uKmsLD9Ty8sjAr+g//NaTo05u0p2WK4X7OxBmwIU=
-github.com/butlerdotdev/butler-api v0.10.0/go.mod h1:q/RjPFM/r2ELq4DqR78OiAxerKBvH5D4nTGsVLKbjqY=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/internal/capi/builder.go
+++ b/internal/capi/builder.go
@@ -77,6 +77,7 @@ type Builder struct {
 type NutanixCredentials struct {
 	Username string
 	Password string
+	CABundle string // PEM-encoded CA chain for Prism Central TLS verification
 }
 
 // NewBuilder creates a new CAPI resource builder.
@@ -90,10 +91,11 @@ func NewBuilder(tc *butlerv1alpha1.TenantCluster, pc *butlerv1alpha1.ProviderCon
 
 // WithNutanixCredentials sets the Nutanix credentials for CAPX secret generation.
 // Must be called before Build() when using Nutanix provider.
-func (b *Builder) WithNutanixCredentials(username, password string) *Builder {
+func (b *Builder) WithNutanixCredentials(username, password, caBundle string) *Builder {
 	b.nutanixCreds = &NutanixCredentials{
 		Username: username,
 		Password: password,
+		CABundle: caBundle,
 	}
 	return b
 }
@@ -723,6 +725,15 @@ func (b *Builder) buildNutanixCluster(name string) *unstructured.Unstructured {
 				"namespace": b.namespace,
 			},
 		},
+	}
+
+	// Add CA trust bundle for internal PKI (e.g. corporate CAs)
+	if b.nutanixCreds != nil && b.nutanixCreds.CABundle != "" {
+		prismCentral := spec["prismCentral"].(map[string]interface{})
+		prismCentral["additionalTrustBundle"] = map[string]interface{}{
+			"kind": "String",
+			"data": b.nutanixCreds.CABundle,
+		}
 	}
 
 	nxCluster.Object["spec"] = spec

--- a/internal/controller/stewardsecret/stewardsecret_controller.go
+++ b/internal/controller/stewardsecret/stewardsecret_controller.go
@@ -107,6 +107,12 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	}
 
 	op, err := controllerutil.CreateOrUpdate(ctx, r.Client, capiSecret, func() error {
+		// CAPI expects kubeconfig secrets to have this type.
+		// Must be set on create; Secret type is immutable after creation.
+		if capiSecret.CreationTimestamp.IsZero() {
+			capiSecret.Type = corev1.SecretType("cluster.x-k8s.io/secret")
+		}
+
 		// Set labels
 		if capiSecret.Labels == nil {
 			capiSecret.Labels = make(map[string]string)

--- a/internal/controller/tenantcluster/helpers.go
+++ b/internal/controller/tenantcluster/helpers.go
@@ -22,6 +22,33 @@ import (
 	"github.com/butlerdotdev/butler-controller/internal/tenant"
 )
 
+// getNutanixCredentials reads username, password, and optional CA bundle from
+// the ProviderConfig's referenced credentials Secret.
+func (r *Reconciler) getNutanixCredentials(ctx context.Context, pc *butlerv1alpha1.ProviderConfig) (*struct{ Username, Password, CABundle string }, error) {
+	ns := pc.Spec.CredentialsRef.Namespace
+	if ns == "" {
+		ns = "butler-system"
+	}
+
+	secret := &corev1.Secret{}
+	if err := r.Get(ctx, types.NamespacedName{
+		Name:      pc.Spec.CredentialsRef.Name,
+		Namespace: ns,
+	}, secret); err != nil {
+		return nil, fmt.Errorf("failed to get credentials secret %s/%s: %w", ns, pc.Spec.CredentialsRef.Name, err)
+	}
+
+	username := string(secret.Data["username"])
+	password := string(secret.Data["password"])
+	if username == "" || password == "" {
+		return nil, fmt.Errorf("credentials secret %s/%s missing username or password key", ns, pc.Spec.CredentialsRef.Name)
+	}
+
+	caBundle := string(secret.Data["ca.pem"])
+
+	return &struct{ Username, Password, CABundle string }{Username: username, Password: password, CABundle: caBundle}, nil
+}
+
 func (r *Reconciler) getButlerConfig(ctx context.Context) (*butlerv1alpha1.ButlerConfig, error) {
 	config := &butlerv1alpha1.ButlerConfig{}
 	if err := r.Get(ctx, types.NamespacedName{Name: ButlerConfigSingletonName}, config); err != nil {

--- a/internal/controller/tenantcluster/reconcile_infrastructure.go
+++ b/internal/controller/tenantcluster/reconcile_infrastructure.go
@@ -66,6 +66,19 @@ func (r *Reconciler) reconcileInfrastructure(ctx context.Context, tc *butlerv1al
 	builder := capi.NewBuilder(tc, providerConfig, tc.Status.TenantNamespace).
 		WithButlerConfig(butlerConfig)
 
+	// Nutanix requires credentials from the ProviderConfig's referenced Secret.
+	// CAPX needs username/password to create a per-cluster credential Secret in
+	// the tenant namespace (JSON array with basic_auth type).
+	if providerConfig.Spec.Provider == butlerv1alpha1.ProviderTypeNutanix {
+		creds, err := r.getNutanixCredentials(ctx, providerConfig)
+		if err != nil {
+			r.setCondition(tc, butlerv1alpha1.TenantClusterConditionInfrastructureReady,
+				metav1.ConditionFalse, ReasonProviderConfigNotFound, fmt.Sprintf("failed to load Nutanix credentials: %v", err))
+			return ctrl.Result{}, err
+		}
+		builder.WithNutanixCredentials(creds.Username, creds.Password, creds.CABundle)
+	}
+
 	// For Ingress/Gateway modes, get the Ingress controller IP for worker /etc/hosts
 	// CRITICAL: If Ingress/Gateway mode is enabled but the Ingress controller doesn't have
 	// an external IP yet, we MUST wait. Otherwise, KubeadmConfigTemplate will be created
@@ -189,7 +202,7 @@ func (r *Reconciler) reconcileInfrastructure(ctx context.Context, tc *butlerv1al
 		// maintenance mode and join the cluster before Cilium and other addons can
 		// schedule pods on them.
 		if isTalosCluster(tc) {
-			if err := r.reconcileTalosBootstrap(ctx, tc, butlerConfig); err != nil {
+			if err := r.reconcileTalosBootstrap(ctx, tc, butlerConfig, providerConfig); err != nil {
 				logger.Error(err, "failed to reconcile Talos bootstrap")
 			}
 			allApplied, err := r.reconcileTalosApplyConfig(ctx, tc)

--- a/internal/controller/tenantcluster/reconcile_talos.go
+++ b/internal/controller/tenantcluster/reconcile_talos.go
@@ -203,6 +203,21 @@ func isTalosCluster(tc *butlerv1alpha1.TenantCluster) bool {
 	return talos.IsTalosCluster(tc)
 }
 
+// resolveTimeServers returns the NTP servers to use for Talos worker config.
+// Fallback chain: TenantCluster → ProviderConfig.Network → ButlerConfig → pool.ntp.org.
+func resolveTimeServers(tc *butlerv1alpha1.TenantCluster, providerConfig *butlerv1alpha1.ProviderConfig, butlerConfig *butlerv1alpha1.ButlerConfig) []string {
+	if len(tc.Spec.TimeServers) > 0 {
+		return tc.Spec.TimeServers
+	}
+	if providerConfig != nil && providerConfig.Spec.Network != nil && len(providerConfig.Spec.Network.TimeServers) > 0 {
+		return providerConfig.Spec.Network.TimeServers
+	}
+	if servers := butlerConfig.GetDefaultTimeServers(); len(servers) > 0 {
+		return servers
+	}
+	return []string{"pool.ntp.org"}
+}
+
 // reconcileTalosBootstrap generates the Talos machine config and creates the bootstrap
 // Secret that CAPI's dataSecretName mechanism reads. This is called after the TCP is
 // ready and the control plane is accessible.
@@ -212,7 +227,7 @@ func isTalosCluster(tc *butlerv1alpha1.TenantCluster) bool {
 //   - cluster.token: kubeadm bootstrap token for kubelet TLS bootstrapping
 //   - machine.ca.crt: OS CA cert for trusting steward-trustd
 //   - cluster.ca.crt: K8s cluster CA for trusting the API server
-func (r *Reconciler) reconcileTalosBootstrap(ctx context.Context, tc *butlerv1alpha1.TenantCluster, butlerConfig *butlerv1alpha1.ButlerConfig) error {
+func (r *Reconciler) reconcileTalosBootstrap(ctx context.Context, tc *butlerv1alpha1.TenantCluster, butlerConfig *butlerv1alpha1.ButlerConfig, providerConfig *butlerv1alpha1.ProviderConfig) error {
 	logger := log.FromContext(ctx)
 
 	secretName := fmt.Sprintf("%s-talos-bootstrap", tc.Name)
@@ -357,7 +372,13 @@ func (r *Reconciler) reconcileTalosBootstrap(ctx context.Context, tc *butlerv1al
 	}
 
 	// Get Talos-specific config
+	// Default install disk varies by provider:
+	//   - KubeVirt/Harvester: /dev/vda (virtio)
+	//   - Nutanix/Proxmox:    /dev/sda (SCSI)
 	installDisk := "/dev/vda"
+	if providerConfig != nil && providerConfig.Spec.Provider != butlerv1alpha1.ProviderTypeHarvester {
+		installDisk = "/dev/sda"
+	}
 	var installerImage string
 	if tc.Spec.Workers.MachineTemplate.OS.Talos != nil {
 		if tc.Spec.Workers.MachineTemplate.OS.Talos.InstallDisk != "" {
@@ -365,6 +386,8 @@ func (r *Reconciler) reconcileTalosBootstrap(ctx context.Context, tc *butlerv1al
 		}
 		installerImage = tc.Spec.Workers.MachineTemplate.OS.Talos.InstallerImage
 	}
+
+	timeServers := resolveTimeServers(tc, providerConfig, butlerConfig)
 
 	// Generate Talos machine config
 	input := talos.MachineConfigInput{
@@ -378,6 +401,7 @@ func (r *Reconciler) reconcileTalosBootstrap(ctx context.Context, tc *butlerv1al
 		ServiceCIDR:          serviceCIDR,
 		InstallDisk:          installDisk,
 		InstallerImage:       installerImage,
+		TimeServers:          timeServers,
 	}
 
 	machineConfigData, err := talos.GenerateWorkerConfig(input)

--- a/internal/controller/tenantcluster/tenantcluster_controller.go
+++ b/internal/controller/tenantcluster/tenantcluster_controller.go
@@ -276,7 +276,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	}
 
 	if isTalosCluster(tc) {
-		if err := r.reconcileTalosBootstrap(ctx, tc, butlerConfig); err != nil {
+		if err := r.reconcileTalosBootstrap(ctx, tc, butlerConfig, providerConfig); err != nil {
 			logger.Error(err, "failed to reconcile Talos bootstrap")
 			degraded = append(degraded, "talos bootstrap failed ("+truncateError(err)+")")
 		}

--- a/internal/talos/machineconfig.go
+++ b/internal/talos/machineconfig.go
@@ -65,6 +65,10 @@ type MachineConfigInput struct {
 
 	// InstallerImage is the Talos installer image reference.
 	InstallerImage string
+
+	// TimeServers are NTP servers for time synchronization.
+	// Talos blocks kubelet startup until time is synced.
+	TimeServers []string
 }
 
 // GenerateWorkerConfig generates a Talos v1alpha1 worker machine config YAML.
@@ -143,6 +147,12 @@ func buildConfig(input MachineConfigInput, clusterDNS string) map[string]interfa
 		install["image"] = input.InstallerImage
 	}
 	machine["install"] = install
+
+	if len(input.TimeServers) > 0 {
+		machine["time"] = map[string]interface{}{
+			"servers": input.TimeServers,
+		}
+	}
 
 	cluster := map[string]interface{}{
 		"controlPlane": map[string]interface{}{

--- a/internal/talos/machineconfig_test.go
+++ b/internal/talos/machineconfig_test.go
@@ -228,6 +228,59 @@ func TestEndpointFromTCPStatus(t *testing.T) {
 	}
 }
 
+func TestGenerateWorkerConfig_TimeServers(t *testing.T) {
+	t.Run("with time servers", func(t *testing.T) {
+		input := validInput()
+		input.TimeServers = []string{"ntp01.example.com", "ntp02.example.com"}
+
+		data, err := GenerateWorkerConfig(input)
+		if err != nil {
+			t.Fatalf("GenerateWorkerConfig() error = %v", err)
+		}
+
+		var config map[string]interface{}
+		if err := yaml.Unmarshal(data, &config); err != nil {
+			t.Fatalf("failed to unmarshal: %v", err)
+		}
+
+		machine := config["machine"].(map[string]interface{})
+		timeSection, ok := machine["time"].(map[string]interface{})
+		if !ok {
+			t.Fatal("machine.time section missing when TimeServers provided")
+		}
+		servers, ok := timeSection["servers"].([]interface{})
+		if !ok {
+			t.Fatal("machine.time.servers missing or wrong type")
+		}
+		if len(servers) != 2 {
+			t.Fatalf("expected 2 time servers, got %d", len(servers))
+		}
+		if servers[0] != "ntp01.example.com" || servers[1] != "ntp02.example.com" {
+			t.Errorf("time servers = %v, want [ntp01.example.com ntp02.example.com]", servers)
+		}
+	})
+
+	t.Run("without time servers", func(t *testing.T) {
+		input := validInput()
+		// TimeServers is empty by default
+
+		data, err := GenerateWorkerConfig(input)
+		if err != nil {
+			t.Fatalf("GenerateWorkerConfig() error = %v", err)
+		}
+
+		var config map[string]interface{}
+		if err := yaml.Unmarshal(data, &config); err != nil {
+			t.Fatalf("failed to unmarshal: %v", err)
+		}
+
+		machine := config["machine"].(map[string]interface{})
+		if _, ok := machine["time"]; ok {
+			t.Error("machine.time should not be set when TimeServers is empty")
+		}
+	})
+}
+
 func TestGenerateWorkerConfig_NoInstallerImage(t *testing.T) {
 	input := validInput()
 	input.InstallerImage = ""


### PR DESCRIPTION
## Summary

- Implements `resolveTimeServers()` fallback chain: TenantCluster > ProviderConfig > ButlerConfig > pool.ntp.org
- Generates `machine.time.servers` section in Talos worker machine config
- Adds `TimeServers` field to `MachineConfigInput`
- Fix: Nutanix CA trust bundle and provider-aware install disk (`/dev/sda` vs `/dev/vda`)
- Fix: set CAPI secret type on steward-synced kubeconfig secrets

## Context

Talos Linux refuses to start kubelet until NTP time sync succeeds. On networks where the default (`time.cloudflare.com` UDP 123) is blocked, workers stay in maintenance mode indefinitely. This change allows operators to configure NTP servers at three levels, with the controller resolving the chain at bootstrap time.

## Test plan

- [x] Unit tests: `TestGenerateWorkerConfig_TimeServers` (with/without time servers)
- [x] Fallback chain validated live: ProviderConfig fallback, TenantCluster override, pool.ntp.org ultimate fallback
- [x] End-to-end: fresh Nutanix VM booted, received NTP config, synced time, kubelet started, node registered Ready, all addons installed
- [x] `go build ./...` clean

Depends on butlerdotdev/butler-api#29