### PR TITLE
fix: defer MachineDeployment creation for Talos until bootstrap secret exists

### DIFF
--- a/internal/capi/builder.go
+++ b/internal/capi/builder.go
@@ -1134,8 +1134,12 @@ func (b *Builder) buildMachineDeployment(name string, machineTemplate, bootstrap
 			},
 		}
 	} else {
-		// Talos: use dataSecretName — CAPI reads the Secret directly,
-		// waiting (requeueing) until the Secret is created by reconcileTalosBootstrap
+		// Talos: use dataSecretName — CAPX reads the Secret directly.
+		// IMPORTANT: The Secret MUST exist before the MachineDeployment is created.
+		// CAPX (Nutanix) treats a missing Secret as a terminal CreateError on the
+		// NutanixMachine, which is NOT retryable. The reconciler defers
+		// MachineDeployment creation for Talos clusters until after the bootstrap
+		// secret is created by reconcileTalosBootstrap.
 		bootstrap = map[string]interface{}{
 			"dataSecretName": fmt.Sprintf("%s-talos-bootstrap", name),
 		}
@@ -1305,5 +1309,20 @@ func (rs *ResourceSet) AllResources() []*unstructured.Unstructured {
 		rs.ControlPlane,            // Then control plane
 		rs.MachineDeployment,       // Then machine deployment
 		rs.Cluster,                 // Finally the top-level cluster (references others)
+	}
+}
+
+// ResourcesWithoutMachineDeployment returns all resources except the MachineDeployment.
+// Used for Talos clusters where the MachineDeployment must be deferred until the
+// bootstrap secret exists — CAPX treats a missing dataSecretName target as a terminal
+// CreateError on the NutanixMachine, which is not retryable.
+func (rs *ResourceSet) ResourcesWithoutMachineDeployment() []*unstructured.Unstructured {
+	return []*unstructured.Unstructured{
+		rs.CredentialSecret,
+		rs.InfrastructureCluster,
+		rs.BootstrapConfigTemplate,
+		rs.MachineTemplate,
+		rs.ControlPlane,
+		rs.Cluster,
 	}
 }

--- a/internal/capi/builder_test.go
+++ b/internal/capi/builder_test.go
@@ -457,6 +457,189 @@ func TestAllResources(t *testing.T) {
 	}
 }
 
+func TestResourcesWithoutMachineDeployment_ExcludesMD(t *testing.T) {
+	tc := newTestTenantCluster("test-cluster", "default")
+	pc := newTestProviderConfig("harvester")
+
+	builder := NewBuilder(tc, pc, "test-cluster-12345678")
+	rs, err := builder.Build()
+	if err != nil {
+		t.Fatalf("failed to build resources: %v", err)
+	}
+
+	resources := rs.ResourcesWithoutMachineDeployment()
+
+	// Should have 6 slots (no MachineDeployment)
+	if len(resources) != 6 {
+		t.Fatalf("expected 6 resource slots, got %d", len(resources))
+	}
+
+	// Verify no MachineDeployment in the list
+	for _, r := range resources {
+		if r != nil && r.GetKind() == "MachineDeployment" {
+			t.Error("ResourcesWithoutMachineDeployment must not contain MachineDeployment")
+		}
+	}
+
+	// Verify MachineDeployment is still accessible directly on the ResourceSet
+	if rs.MachineDeployment == nil {
+		t.Error("MachineDeployment should still be present on the ResourceSet")
+	}
+	if rs.MachineDeployment.GetKind() != "MachineDeployment" {
+		t.Errorf("expected MachineDeployment kind, got %s", rs.MachineDeployment.GetKind())
+	}
+}
+
+func TestTalosNutanixBuild_HasMachineDeploymentWithDataSecretName(t *testing.T) {
+	tc := newTestTenantCluster("talos-cluster", "default")
+	tc.Spec.Workers.MachineTemplate.OS.Type = butlerv1alpha1.OSTypeTalos
+
+	pc := newTestProviderConfig("nutanix")
+	pc.Spec.Nutanix = &butlerv1alpha1.NutanixProviderConfig{
+		Endpoint:    "https://prism.example.com",
+		Port:        9440,
+		ClusterUUID: "cluster-uuid-1234",
+		SubnetUUID:  "subnet-uuid-5678",
+	}
+
+	builder := NewBuilder(tc, pc, "talos-cluster-12345678").
+		WithNutanixCredentials("admin", "password", "")
+
+	rs, err := builder.Build()
+	if err != nil {
+		t.Fatalf("failed to build resources: %v", err)
+	}
+
+	// Builder still produces MachineDeployment — it's the reconciler that defers creation
+	if rs.MachineDeployment == nil {
+		t.Fatal("expected MachineDeployment to be built")
+	}
+
+	// Talos clusters use dataSecretName, not configRef
+	md := rs.MachineDeployment
+	spec := md.Object["spec"].(map[string]interface{})
+	template := spec["template"].(map[string]interface{})
+	templateSpec := template["spec"].(map[string]interface{})
+	bootstrap := templateSpec["bootstrap"].(map[string]interface{})
+
+	if _, hasConfigRef := bootstrap["configRef"]; hasConfigRef {
+		t.Error("Talos cluster should not have bootstrap.configRef")
+	}
+
+	secretName, ok := bootstrap["dataSecretName"].(string)
+	if !ok {
+		t.Fatal("expected bootstrap.dataSecretName for Talos cluster")
+	}
+	if secretName != "talos-cluster-talos-bootstrap" {
+		t.Errorf("expected dataSecretName 'talos-cluster-talos-bootstrap', got '%s'", secretName)
+	}
+
+	// No BootstrapConfigTemplate for Talos
+	if rs.BootstrapConfigTemplate != nil {
+		t.Error("Talos cluster should not have BootstrapConfigTemplate")
+	}
+}
+
+func TestTalosNutanixBuild_ResourcesWithoutMD(t *testing.T) {
+	tc := newTestTenantCluster("talos-cluster", "default")
+	tc.Spec.Workers.MachineTemplate.OS.Type = butlerv1alpha1.OSTypeTalos
+
+	pc := newTestProviderConfig("nutanix")
+	pc.Spec.Nutanix = &butlerv1alpha1.NutanixProviderConfig{
+		Endpoint:    "https://prism.example.com",
+		Port:        9440,
+		ClusterUUID: "cluster-uuid-1234",
+		SubnetUUID:  "subnet-uuid-5678",
+	}
+
+	builder := NewBuilder(tc, pc, "talos-cluster-12345678").
+		WithNutanixCredentials("admin", "password", "")
+
+	rs, err := builder.Build()
+	if err != nil {
+		t.Fatalf("failed to build resources: %v", err)
+	}
+
+	// Phase 1 resources (without MachineDeployment)
+	phase1 := rs.ResourcesWithoutMachineDeployment()
+
+	// Count non-nil resources
+	var phase1NonNil []*unstructured.Unstructured
+	for _, r := range phase1 {
+		if r != nil {
+			phase1NonNil = append(phase1NonNil, r)
+		}
+	}
+
+	// Nutanix Talos: CredentialSecret, NutanixCluster, NutanixMachineTemplate,
+	// StewardControlPlane, Cluster (no BootstrapConfigTemplate for Talos)
+	if len(phase1NonNil) != 5 {
+		t.Errorf("expected 5 non-nil phase 1 resources for Nutanix Talos, got %d", len(phase1NonNil))
+		for _, r := range phase1NonNil {
+			t.Logf("  - %s", r.GetKind())
+		}
+	}
+
+	// MachineDeployment still on the struct for phase 2
+	if rs.MachineDeployment == nil {
+		t.Error("MachineDeployment must still be present on ResourceSet for phase 2 creation")
+	}
+}
+
+func TestNonTalosHarvesterBuild_AllResourcesUnchanged(t *testing.T) {
+	// Ensure the fix doesn't change behavior for non-Talos clusters
+	tc := newTestTenantCluster("kubeadm-cluster", "default")
+	// OS.Type defaults to empty (non-Talos)
+	pc := newTestProviderConfig("harvester")
+
+	builder := NewBuilder(tc, pc, "kubeadm-cluster-12345678")
+	rs, err := builder.Build()
+	if err != nil {
+		t.Fatalf("failed to build resources: %v", err)
+	}
+
+	all := rs.AllResources()
+	withoutMD := rs.ResourcesWithoutMachineDeployment()
+
+	// AllResources should have MachineDeployment
+	hasMD := false
+	for _, r := range all {
+		if r != nil && r.GetKind() == "MachineDeployment" {
+			hasMD = true
+			break
+		}
+	}
+	if !hasMD {
+		t.Error("AllResources for non-Talos cluster must include MachineDeployment")
+	}
+
+	// ResourcesWithoutMachineDeployment should NOT have it
+	for _, r := range withoutMD {
+		if r != nil && r.GetKind() == "MachineDeployment" {
+			t.Error("ResourcesWithoutMachineDeployment must not contain MachineDeployment")
+		}
+	}
+
+	// Non-Talos should have BootstrapConfigTemplate (kubeadm)
+	if rs.BootstrapConfigTemplate == nil {
+		t.Error("Non-Talos cluster should have BootstrapConfigTemplate")
+	}
+
+	// Non-Talos bootstrap uses configRef, not dataSecretName
+	md := rs.MachineDeployment
+	spec := md.Object["spec"].(map[string]interface{})
+	template := spec["template"].(map[string]interface{})
+	templateSpec := template["spec"].(map[string]interface{})
+	bootstrap := templateSpec["bootstrap"].(map[string]interface{})
+
+	if _, hasConfigRef := bootstrap["configRef"]; !hasConfigRef {
+		t.Error("Non-Talos cluster should have bootstrap.configRef")
+	}
+	if _, hasSecret := bootstrap["dataSecretName"]; hasSecret {
+		t.Error("Non-Talos cluster should not have bootstrap.dataSecretName")
+	}
+}
+
 func TestUnsupportedProvider(t *testing.T) {
 	tc := newTestTenantCluster("test-cluster", "default")
 	pc := newTestProviderConfig("proxmox")

--- a/internal/controller/tenantcluster/reconcile_infrastructure.go
+++ b/internal/controller/tenantcluster/reconcile_infrastructure.go
@@ -122,43 +122,23 @@ func (r *Reconciler) reconcileInfrastructure(ctx context.Context, tc *butlerv1al
 		return ctrl.Result{}, fmt.Errorf("failed to build CAPI resources: %w", err)
 	}
 
-	for _, resource := range resourceSet.AllResources() {
-		if resource == nil {
-			continue
-		}
+	// For Talos clusters, defer MachineDeployment creation until the bootstrap
+	// secret exists. CAPX treats a missing dataSecretName target as a terminal
+	// CreateError on the NutanixMachine, which is NOT retryable. The bootstrap
+	// secret requires the control plane to be ready first (it needs the CP endpoint,
+	// trustd credentials, and a bootstrap token from the tenant API server).
+	//
+	// For non-Talos clusters, create all resources in one pass — kubeadm bootstrap
+	// uses a configRef to a KubeadmConfigTemplate, which CAPI handles natively.
+	var initialResources []*unstructured.Unstructured
+	if isTalosCluster(tc) {
+		initialResources = resourceSet.ResourcesWithoutMachineDeployment()
+	} else {
+		initialResources = resourceSet.AllResources()
+	}
 
-		existing := &unstructured.Unstructured{}
-		existing.SetGroupVersionKind(resource.GroupVersionKind())
-
-		err := r.Get(ctx, types.NamespacedName{
-			Name:      resource.GetName(),
-			Namespace: resource.GetNamespace(),
-		}, existing)
-
-		if apierrors.IsNotFound(err) {
-			logger.Info("creating CAPI resource",
-				"kind", resource.GetKind(),
-				"name", resource.GetName(),
-				"namespace", resource.GetNamespace())
-
-			if err := r.Create(ctx, resource); err != nil {
-				if apierrors.IsAlreadyExists(err) {
-					logger.V(1).Info("CAPI resource created by concurrent reconcile",
-						"kind", resource.GetKind(),
-						"name", resource.GetName())
-				} else {
-					return ctrl.Result{}, fmt.Errorf("failed to create %s %s: %w",
-						resource.GetKind(), resource.GetName(), err)
-				}
-			}
-		} else if err != nil {
-			return ctrl.Result{}, fmt.Errorf("failed to get %s %s: %w",
-				resource.GetKind(), resource.GetName(), err)
-		} else {
-			logger.V(1).Info("CAPI resource already exists",
-				"kind", resource.GetKind(),
-				"name", resource.GetName())
-		}
+	if err := r.createCAPIResources(ctx, initialResources); err != nil {
+		return ctrl.Result{}, err
 	}
 
 	infraReady, controlPlaneReady, workersReady, err := r.checkInfrastructureStatus(ctx, tc)
@@ -195,16 +175,28 @@ func (r *Reconciler) reconcileInfrastructure(ctx context.Context, tc *butlerv1al
 		r.setCondition(tc, butlerv1alpha1.TenantClusterConditionControlPlaneReady,
 			metav1.ConditionTrue, ReasonControlPlaneReady, "Control plane is ready")
 
-		// For Talos clusters, create the bootstrap Secret and apply config to workers
-		// as soon as CP is ready. Bootstrap MUST happen here because CAPI Machines
-		// reference the Secret via dataSecretName and block until it exists.
+		// For Talos clusters: two-phase resource creation.
+		// Phase 1 (above) created all CAPI resources EXCEPT the MachineDeployment.
+		// Phase 2 (here): now that the CP is ready, create the bootstrap secret,
+		// then create the MachineDeployment so CAPX can find the secret immediately.
+		//
 		// Config must be applied BEFORE addon installation — workers need to leave
 		// maintenance mode and join the cluster before Cilium and other addons can
 		// schedule pods on them.
 		if isTalosCluster(tc) {
 			if err := r.reconcileTalosBootstrap(ctx, tc, butlerConfig, providerConfig); err != nil {
 				logger.Error(err, "failed to reconcile Talos bootstrap")
+				return ctrl.Result{RequeueAfter: 15 * time.Second}, nil
 			}
+
+			// Bootstrap secret exists — now safe to create the MachineDeployment.
+			// CAPX will find the dataSecretName target and proceed normally.
+			if resourceSet.MachineDeployment != nil {
+				if err := r.createCAPIResources(ctx, []*unstructured.Unstructured{resourceSet.MachineDeployment}); err != nil {
+					return ctrl.Result{}, err
+				}
+			}
+
 			allApplied, err := r.reconcileTalosApplyConfig(ctx, tc)
 			if err != nil {
 				logger.Error(err, "failed to apply Talos config to workers")
@@ -674,4 +666,51 @@ func (r *Reconciler) reconcileImageSync(ctx context.Context, tc *butlerv1alpha1.
 	tc.Status.ImageSyncRef = &butlerv1alpha1.LocalObjectReference{Name: is.Name}
 
 	return "", fmt.Errorf("ImageSync %s created, waiting for completion", imageSyncName)
+}
+
+// createCAPIResources creates or verifies existence of the given CAPI resources.
+// Idempotent: skips resources that already exist.
+func (r *Reconciler) createCAPIResources(ctx context.Context, resources []*unstructured.Unstructured) error {
+	logger := log.FromContext(ctx)
+
+	for _, resource := range resources {
+		if resource == nil {
+			continue
+		}
+
+		existing := &unstructured.Unstructured{}
+		existing.SetGroupVersionKind(resource.GroupVersionKind())
+
+		err := r.Get(ctx, types.NamespacedName{
+			Name:      resource.GetName(),
+			Namespace: resource.GetNamespace(),
+		}, existing)
+
+		if apierrors.IsNotFound(err) {
+			logger.Info("creating CAPI resource",
+				"kind", resource.GetKind(),
+				"name", resource.GetName(),
+				"namespace", resource.GetNamespace())
+
+			if err := r.Create(ctx, resource); err != nil {
+				if apierrors.IsAlreadyExists(err) {
+					logger.V(1).Info("CAPI resource created by concurrent reconcile",
+						"kind", resource.GetKind(),
+						"name", resource.GetName())
+				} else {
+					return fmt.Errorf("failed to create %s %s: %w",
+						resource.GetKind(), resource.GetName(), err)
+				}
+			}
+		} else if err != nil {
+			return fmt.Errorf("failed to get %s %s: %w",
+				resource.GetKind(), resource.GetName(), err)
+		} else {
+			logger.V(1).Info("CAPI resource already exists",
+				"kind", resource.GetKind(),
+				"name", resource.GetName())
+		}
+	}
+
+	return nil
 }


### PR DESCRIPTION
## Summary

- CAPX treats a missing `dataSecretName` target as a terminal `CreateError` on `NutanixMachine`, which is not retryable. The reconciler was creating all CAPI resources (including `MachineDeployment`) in one pass, but the Talos bootstrap secret requires the control plane to be ready first. This caused all worker machines to enter a permanent `Failed` state on every Talos tenant cluster provisioned on Nutanix.
- Splits resource creation into two phases for Talos clusters: Phase 1 creates everything except `MachineDeployment`. Phase 2 (after CP is ready) creates the bootstrap secret, then the `MachineDeployment`.
- Non-Talos clusters (kubeadm) are unaffected -- they continue to create all resources in one pass since kubeadm uses `configRef` which CAPI handles natively.
- Fixes misleading comment in `builder.go` that claimed CAPI would requeue when the bootstrap secret is missing (CAPX treats it as terminal).

## Additional behavioral changes

- **Bootstrap error handling**: `reconcileTalosBootstrap` failure previously logged the error and continued into `reconcileTalosApplyConfig`, which would also fail (no secret means no workers joining). Now it returns early with a 15s requeue. Strictly an improvement -- avoids unnecessary work after a known failure -- but a behavioral change beyond the stated MD-deferral scope.
- **Parallel list pattern**: `ResourceSet` now has two hand-maintained enumeration methods (`AllResources` and `ResourcesWithoutMachineDeployment`). With 7 fields they are easy to keep in sync. Consolidation to a filter-based approach deferred to a follow-up issue if the struct grows.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] 4 new unit tests covering two-phase flow, Talos+Nutanix dataSecretName, phase-1 resource count, and non-Talos unchanged behavior
- [x] All 28 `internal/capi` tests pass (4 new + 24 existing, zero regressions)
- [ ] Deploy to Company 1 management cluster
- [ ] Delete 3 stuck dev tenant clusters and recreate via console
- [ ] Verify tenant clusters provision end-to-end without Failed machines