### PR TITLE
fix(ipam): exclude platform LB services from elastic IPAM usage count

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -74,3 +74,6 @@ require (
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.0 // indirect
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )
+
+// TODO: Remove once butler-api PR #30 is merged and a new version is tagged.
+replace github.com/butlerdotdev/butler-api => ../butler-api

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/butlerdotdev/butler-controller
 go 1.24.6
 
 require (
-	github.com/butlerdotdev/butler-api v0.11.0
+	github.com/butlerdotdev/butler-api v0.11.1
 	github.com/onsi/ginkgo/v2 v2.22.0
 	github.com/onsi/gomega v1.36.1
 	github.com/prometheus/client_golang v1.22.0
@@ -74,6 +74,3 @@ require (
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.0 // indirect
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )
-
-// TODO: Remove once butler-api PR #30 is merged and a new version is tagged.
-replace github.com/butlerdotdev/butler-api => ../butler-api

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,5 @@
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
-github.com/butlerdotdev/butler-api v0.11.0 h1:JbDsZcn4JEryTSqrWmcdUkP/RA8FXfTV+kl3mbBOrA0=
-github.com/butlerdotdev/butler-api v0.11.0/go.mod h1:q/RjPFM/r2ELq4DqR78OiAxerKBvH5D4nTGsVLKbjqY=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
+github.com/butlerdotdev/butler-api v0.11.1 h1:co/Z3nmzw8VvMPjWGQVVjgFkHUTP23CQM/KceOuQ//M=
+github.com/butlerdotdev/butler-api v0.11.1/go.mod h1:q/RjPFM/r2ELq4DqR78OiAxerKBvH5D4nTGsVLKbjqY=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/internal/addons/installer.go
+++ b/internal/addons/installer.go
@@ -690,6 +690,7 @@ func (i *Installer) InstallTraefik(ctx context.Context, kubeconfig []byte, versi
 		"--set", "ingressClass.enabled=true",
 		"--set", "ingressClass.isDefaultClass=true",
 		"--set", "service.type=LoadBalancer",
+		"--set", `commonLabels.butler\.butlerlabs\.dev/platform-lb=true`,
 		"--wait",
 		"--timeout", "2m",
 	}

--- a/internal/controller/tenantcluster/reconcile_ipam.go
+++ b/internal/controller/tenantcluster/reconcile_ipam.go
@@ -196,6 +196,10 @@ func (r *Reconciler) reconcileElasticIPAM(ctx context.Context, tc *butlerv1alpha
 		return nil
 	}
 
+	// Ensure platform LB services are labeled before counting, so existing
+	// clusters provisioned before the label existed get correct IP accounting.
+	r.ensurePlatformLBLabels(ctx, tenantClient)
+
 	usedIPs, err := r.countUsedLBIPs(ctx, tenantClient)
 	if err != nil {
 		logger.V(1).Info("cannot count used LB IPs, skipping", "error", err)
@@ -354,6 +358,8 @@ func (r *Reconciler) listLBAllocations(ctx context.Context, tc *butlerv1alpha1.T
 }
 
 // countUsedLBIPs counts the number of LoadBalancer services with assigned IPs on a tenant cluster.
+// Platform-managed LB services (labeled with LabelPlatformLB) are excluded since they are
+// infrastructure services whose IPs should not count against tenant workload allocation.
 func (r *Reconciler) countUsedLBIPs(ctx context.Context, tc *tenant.TenantClient) (int32, error) {
 	svcList, err := tc.Clientset.CoreV1().Services("").List(ctx, metav1.ListOptions{})
 	if err != nil {
@@ -365,6 +371,9 @@ func (r *Reconciler) countUsedLBIPs(ctx context.Context, tc *tenant.TenantClient
 		if svc.Spec.Type != corev1.ServiceTypeLoadBalancer {
 			continue
 		}
+		if svc.Labels[butlerv1alpha1.LabelPlatformLB] == "true" {
+			continue
+		}
 		for _, ing := range svc.Status.LoadBalancer.Ingress {
 			if ing.IP != "" {
 				count++
@@ -373,6 +382,31 @@ func (r *Reconciler) countUsedLBIPs(ctx context.Context, tc *tenant.TenantClient
 		}
 	}
 	return count, nil
+}
+
+// ensurePlatformLBLabels ensures the Traefik service on a tenant cluster has the platform-lb
+// label so that countUsedLBIPs excludes it from usage calculations. This handles existing
+// clusters that were provisioned before the label was added to InstallTraefik.
+func (r *Reconciler) ensurePlatformLBLabels(ctx context.Context, tc *tenant.TenantClient) {
+	logger := log.FromContext(ctx)
+
+	svc, err := tc.Clientset.CoreV1().Services("traefik").Get(ctx, "traefik", metav1.GetOptions{})
+	if err != nil {
+		if !apierrors.IsNotFound(err) {
+			logger.V(1).Info("ensurePlatformLBLabels: failed to get traefik service", "error", err)
+		}
+		return
+	}
+	if svc.Labels[butlerv1alpha1.LabelPlatformLB] == "true" {
+		return
+	}
+	if svc.Labels == nil {
+		svc.Labels = make(map[string]string)
+	}
+	svc.Labels[butlerv1alpha1.LabelPlatformLB] = "true"
+	if _, err := tc.Clientset.CoreV1().Services("traefik").Update(ctx, svc, metav1.UpdateOptions{}); err != nil {
+		logger.V(1).Info("ensurePlatformLBLabels: failed to patch label", "error", err)
+	}
 }
 
 // updateMetalLBPool configures MetalLB on the tenant cluster with all allocated IP ranges.

--- a/internal/controller/tenantcluster/reconcile_ipam_test.go
+++ b/internal/controller/tenantcluster/reconcile_ipam_test.go
@@ -1,0 +1,200 @@
+// Copyright 2026 The Butler Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package tenantcluster
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+
+	butlerv1alpha1 "github.com/butlerdotdev/butler-api/api/v1alpha1"
+	"github.com/butlerdotdev/butler-controller/internal/tenant"
+)
+
+func TestCountUsedLBIPs(t *testing.T) {
+	tests := []struct {
+		name     string
+		services []corev1.Service
+		expected int32
+	}{
+		{
+			name:     "no services",
+			services: nil,
+			expected: 0,
+		},
+		{
+			name: "ClusterIP service ignored",
+			services: []corev1.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "web", Namespace: "default"},
+					Spec:       corev1.ServiceSpec{Type: corev1.ServiceTypeClusterIP},
+				},
+			},
+			expected: 0,
+		},
+		{
+			name: "LB service without label counted",
+			services: []corev1.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "app-lb", Namespace: "default"},
+					Spec:       corev1.ServiceSpec{Type: corev1.ServiceTypeLoadBalancer},
+					Status: corev1.ServiceStatus{
+						LoadBalancer: corev1.LoadBalancerStatus{
+							Ingress: []corev1.LoadBalancerIngress{{IP: "10.0.0.1"}},
+						},
+					},
+				},
+			},
+			expected: 1,
+		},
+		{
+			name: "LB service with platform-lb label excluded",
+			services: []corev1.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "traefik",
+						Namespace: "traefik",
+						Labels:    map[string]string{butlerv1alpha1.LabelPlatformLB: "true"},
+					},
+					Spec: corev1.ServiceSpec{Type: corev1.ServiceTypeLoadBalancer},
+					Status: corev1.ServiceStatus{
+						LoadBalancer: corev1.LoadBalancerStatus{
+							Ingress: []corev1.LoadBalancerIngress{{IP: "10.0.0.2"}},
+						},
+					},
+				},
+			},
+			expected: 0,
+		},
+		{
+			name: "mixed services: only unlabeled LBs with IPs counted",
+			services: []corev1.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "traefik",
+						Namespace: "traefik",
+						Labels:    map[string]string{butlerv1alpha1.LabelPlatformLB: "true"},
+					},
+					Spec: corev1.ServiceSpec{Type: corev1.ServiceTypeLoadBalancer},
+					Status: corev1.ServiceStatus{
+						LoadBalancer: corev1.LoadBalancerStatus{
+							Ingress: []corev1.LoadBalancerIngress{{IP: "10.0.0.2"}},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "app-lb", Namespace: "default"},
+					Spec:       corev1.ServiceSpec{Type: corev1.ServiceTypeLoadBalancer},
+					Status: corev1.ServiceStatus{
+						LoadBalancer: corev1.LoadBalancerStatus{
+							Ingress: []corev1.LoadBalancerIngress{{IP: "10.0.0.3"}},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "internal", Namespace: "default"},
+					Spec:       corev1.ServiceSpec{Type: corev1.ServiceTypeClusterIP},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "pending-lb", Namespace: "default"},
+					Spec:       corev1.ServiceSpec{Type: corev1.ServiceTypeLoadBalancer},
+					Status:     corev1.ServiceStatus{},
+				},
+			},
+			expected: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var objects []corev1.Service
+			objects = append(objects, tt.services...)
+
+			clientset := fake.NewSimpleClientset()
+			for i := range objects {
+				_, err := clientset.CoreV1().Services(objects[i].Namespace).Create(
+					context.Background(), &objects[i], metav1.CreateOptions{})
+				if err != nil {
+					t.Fatalf("failed to create test service: %v", err)
+				}
+			}
+
+			tc := &tenant.TenantClient{Clientset: clientset}
+			r := &Reconciler{}
+
+			got, err := r.countUsedLBIPs(context.Background(), tc)
+			if err != nil {
+				t.Fatalf("countUsedLBIPs() error = %v", err)
+			}
+			if got != tt.expected {
+				t.Errorf("countUsedLBIPs() = %d, want %d", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestEnsurePlatformLBLabels(t *testing.T) {
+	t.Run("labels traefik service when label missing", func(t *testing.T) {
+		svc := &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "traefik",
+				Namespace: "traefik",
+			},
+			Spec: corev1.ServiceSpec{Type: corev1.ServiceTypeLoadBalancer},
+		}
+		clientset := fake.NewSimpleClientset(svc)
+		tc := &tenant.TenantClient{Clientset: clientset}
+		r := &Reconciler{}
+
+		r.ensurePlatformLBLabels(context.Background(), tc)
+
+		updated, err := clientset.CoreV1().Services("traefik").Get(
+			context.Background(), "traefik", metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("failed to get service: %v", err)
+		}
+		if updated.Labels[butlerv1alpha1.LabelPlatformLB] != "true" {
+			t.Errorf("expected label %s=true, got labels: %v",
+				butlerv1alpha1.LabelPlatformLB, updated.Labels)
+		}
+	})
+
+	t.Run("no-op when label already present", func(t *testing.T) {
+		svc := &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "traefik",
+				Namespace: "traefik",
+				Labels:    map[string]string{butlerv1alpha1.LabelPlatformLB: "true"},
+			},
+			Spec: corev1.ServiceSpec{Type: corev1.ServiceTypeLoadBalancer},
+		}
+		clientset := fake.NewSimpleClientset(svc)
+		tc := &tenant.TenantClient{Clientset: clientset}
+		r := &Reconciler{}
+
+		r.ensurePlatformLBLabels(context.Background(), tc)
+
+		// Verify no update was issued (label still present, no error)
+		updated, err := clientset.CoreV1().Services("traefik").Get(
+			context.Background(), "traefik", metav1.GetOptions{})
+		if err != nil {
+			t.Fatalf("failed to get service: %v", err)
+		}
+		if updated.Labels[butlerv1alpha1.LabelPlatformLB] != "true" {
+			t.Errorf("label should still be present")
+		}
+	})
+
+	t.Run("no-op when traefik service does not exist", func(t *testing.T) {
+		clientset := fake.NewSimpleClientset()
+		tc := &tenant.TenantClient{Clientset: clientset}
+		r := &Reconciler{}
+
+		// Should not panic or error
+		r.ensurePlatformLBLabels(context.Background(), tc)
+	})
+}


### PR DESCRIPTION
## Summary

- Labels platform-managed LoadBalancer services (Traefik) with `butler.butlerlabs.dev/platform-lb`
- Excludes labeled services from `countUsedLBIPs` so elastic IPAM doesn't count infrastructure IPs against tenant workload allocation
- Adds `ensurePlatformLBLabels` to retroactively label existing Traefik services on clusters provisioned before this change

## Context

Each tenant cluster's Traefik LB service was being counted as a "used" IP in elastic IPAM, inflating usage by 1 per tenant. For Company 1's 6 dev tenants, this means 6 IPs were being phantom-consumed, making the shrink logic unnecessarily aggressive.

After this change, only actual tenant workload LoadBalancers count toward elastic IPAM allocation decisions.

## Changes

| File | Change |
|------|--------|
| `internal/addons/installer.go` | Add `commonLabels` `--set` flag to Traefik helm install |
| `internal/controller/tenantcluster/reconcile_ipam.go` | Filter labeled services in `countUsedLBIPs`; add `ensurePlatformLBLabels` |
| `internal/controller/tenantcluster/reconcile_ipam_test.go` | Unit tests for filter and labeling |
| `go.mod` | Local replace for butler-api (remove before merge) |

## Dependencies

- **butler-api PR #30** must merge first (adds `LabelPlatformLB` constant)
- Once merged and tagged, update `go.mod` to remove the replace directive and pin the new version

## Test plan

- [x] Unit tests pass for `countUsedLBIPs` (5 cases: no svcs, ClusterIP ignored, unlabeled LB counted, labeled LB excluded, mixed)
- [x] Unit tests pass for `ensurePlatformLBLabels` (3 cases: patches missing label, no-op when present, no-op when service absent)
- [ ] Integration: deploy to dev management cluster, verify Traefik services gain label within 1 reconcile cycle
- [ ] Integration: verify elastic IPAM logs show reduced `usedIPs` count

Closes #59