### PR TITLE
feat(addons): make Traefik installation optional via IngressSpec.Enabled

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/butlerdotdev/butler-controller
 go 1.24.6
 
 require (
-	github.com/butlerdotdev/butler-api v0.11.1
+	github.com/butlerdotdev/butler-api v0.12.0
 	github.com/onsi/ginkgo/v2 v2.22.0
 	github.com/onsi/gomega v1.36.1
 	github.com/prometheus/client_golang v1.22.0

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
-github.com/butlerdotdev/butler-api v0.11.1 h1:co/Z3nmzw8VvMPjWGQVVjgFkHUTP23CQM/KceOuQ//M=
-github.com/butlerdotdev/butler-api v0.11.1/go.mod h1:q/RjPFM/r2ELq4DqR78OiAxerKBvH5D4nTGsVLKbjqY=
+github.com/butlerdotdev/butler-api v0.12.0 h1:vVdFo0gonfebZkc1/5hlxnTGEbyD4WG45ZGpfPtuGX8=
+github.com/butlerdotdev/butler-api v0.12.0/go.mod h1:q/RjPFM/r2ELq4DqR78OiAxerKBvH5D4nTGsVLKbjqY=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/internal/controller/tenantcluster/reconcile_addons.go
+++ b/internal/controller/tenantcluster/reconcile_addons.go
@@ -158,18 +158,22 @@ func (r *Reconciler) reconcileAddons(ctx context.Context, tc *butlerv1alpha1.Ten
 		})
 	}
 
-	// 5. Traefik - Ingress
-	traefikVersion := addons.DefaultTraefikVersion
-	if tc.Spec.Addons.Ingress != nil && tc.Spec.Addons.Ingress.Version != "" {
-		traefikVersion = tc.Spec.Addons.Ingress.Version
-	}
-	logger.Info("installing Traefik", "version", traefikVersion)
-	if err := r.Installer.InstallTraefik(ctx, kubeconfigData, traefikVersion); err != nil {
-		logger.Error(err, "failed to install Traefik")
+	// 5. Traefik - Ingress (optional)
+	if tc.Spec.Addons.Ingress.IsIngressEnabled() {
+		traefikVersion := addons.DefaultTraefikVersion
+		if tc.Spec.Addons.Ingress != nil && tc.Spec.Addons.Ingress.Version != "" {
+			traefikVersion = tc.Spec.Addons.Ingress.Version
+		}
+		logger.Info("installing Traefik", "version", traefikVersion)
+		if err := r.Installer.InstallTraefik(ctx, kubeconfigData, traefikVersion); err != nil {
+			logger.Error(err, "failed to install Traefik")
+		} else {
+			addonStatuses = append(addonStatuses, butlerv1alpha1.AddonStatus{
+				Name: "traefik", Version: traefikVersion, Status: "Healthy", ManagedBy: "butler",
+			})
+		}
 	} else {
-		addonStatuses = append(addonStatuses, butlerv1alpha1.AddonStatus{
-			Name: "traefik", Version: traefikVersion, Status: "Healthy", ManagedBy: "butler",
-		})
+		logger.Info("skipping Traefik installation (disabled by spec)")
 	}
 
 	// Update observed state


### PR DESCRIPTION
## Summary

- Wraps Traefik install in `reconcileAddons` with `IsIngressEnabled()` conditional
- When `spec.addons.ingress.enabled: false`, the controller skips Traefik installation entirely
- Existing clusters unaffected (field defaults to true when nil/omitted)

## Context

Tenants that don't need an ingress controller (headless workloads, batch jobs, API-only services) currently get Traefik installed unconditionally, consuming 1 LB IP per cluster. With elastic IPAM, that phantom IP counts against allocation headroom.

This change lets operators opt out per-tenant by setting `spec.addons.ingress.enabled: false` on the TenantCluster resource.

## Important notes

- **Disabling does not uninstall**: Setting `enabled: false` on an existing cluster prevents re-installation but does not run `helm uninstall`. Traefik uninstall is a separate follow-up feature (addons are currently monotonic/install-only).
- **Version relaxed to optional**: Companion butler-api PR relaxes Version from Required to optional. Controller already defaults to `DefaultTraefikVersion` when empty.

## Dependencies

- **butler-api PR #31** must merge first (adds `Enabled *bool` field + `IsIngressEnabled()` helper)
- **butler-controller PR #62** should merge first (platform LB filtering — this PR is based on that branch)
- `go.mod` has a local replace directive that must be removed before merge

## Test plan

- [x] `go build ./...` passes
- [x] All existing unit tests pass
- [ ] Integration: create TenantCluster with `spec.addons.ingress.enabled: false`, verify Traefik is not installed
- [ ] Integration: create TenantCluster with field omitted, verify Traefik installs normally (default behavior)
- [ ] Integration: verify round-trip — read back a TenantCluster with `enabled: false`, confirm it persists

Closes #60