### PR TITLE
fix(ipam): include platform LBs in available capacity calculation

### DIFF
--- a/internal/controller/tenantcluster/reconcile_ipam.go
+++ b/internal/controller/tenantcluster/reconcile_ipam.go
@@ -200,18 +200,19 @@ func (r *Reconciler) reconcileElasticIPAM(ctx context.Context, tc *butlerv1alpha
 	// clusters provisioned before the label existed get correct IP accounting.
 	r.ensurePlatformLBLabels(ctx, tenantClient)
 
-	usedIPs, err := r.countUsedLBIPs(ctx, tenantClient)
+	platformCount, tenantCount, err := r.countLBIPs(ctx, tenantClient)
 	if err != nil {
-		logger.V(1).Info("cannot count used LB IPs, skipping", "error", err)
+		logger.V(1).Info("cannot count LB IPs, skipping", "error", err)
 		return nil
 	}
 
-	availableIPs := totalAllocated - usedIPs
+	availableIPs := totalAllocated - platformCount - tenantCount
 	growthIncrement := r.getGrowthIncrement(pc)
 
 	logger.V(1).Info("elastic IPAM status",
-		"totalAllocated", totalAllocated, "usedIPs", usedIPs,
-		"availableIPs", availableIPs, "growthIncrement", growthIncrement)
+		"totalAllocated", totalAllocated, "platformLBs", platformCount,
+		"tenantLBs", tenantCount, "availableIPs", availableIPs,
+		"growthIncrement", growthIncrement)
 
 	// Grow: if fewer than 1 IP is available
 	if availableIPs < 1 {
@@ -357,36 +358,42 @@ func (r *Reconciler) listLBAllocations(ctx context.Context, tc *butlerv1alpha1.T
 	return allocList.Items, nil
 }
 
-// countUsedLBIPs counts the number of LoadBalancer services with assigned IPs on a tenant cluster.
-// Platform-managed LB services (labeled with LabelPlatformLB) are excluded since they are
-// infrastructure services whose IPs should not count against tenant workload allocation.
-func (r *Reconciler) countUsedLBIPs(ctx context.Context, tc *tenant.TenantClient) (int32, error) {
+// countLBIPs counts LoadBalancer services with assigned IPs on a tenant cluster,
+// returning separate counts for platform-managed LBs and tenant workload LBs.
+// Platform LBs (labeled with LabelPlatformLB) consume pool capacity but should not
+// be treated as tenant workload demand for growth/shrink decisions.
+func (r *Reconciler) countLBIPs(ctx context.Context, tc *tenant.TenantClient) (platformCount, tenantCount int32, err error) {
 	svcList, err := tc.Clientset.CoreV1().Services("").List(ctx, metav1.ListOptions{})
 	if err != nil {
-		return 0, fmt.Errorf("failed to list services: %w", err)
+		return 0, 0, fmt.Errorf("failed to list services: %w", err)
 	}
 
-	var count int32
 	for _, svc := range svcList.Items {
 		if svc.Spec.Type != corev1.ServiceTypeLoadBalancer {
 			continue
 		}
-		if svc.Labels[butlerv1alpha1.LabelPlatformLB] == "true" {
-			continue
-		}
+		hasIP := false
 		for _, ing := range svc.Status.LoadBalancer.Ingress {
 			if ing.IP != "" {
-				count++
+				hasIP = true
 				break
 			}
 		}
+		if !hasIP {
+			continue
+		}
+		if svc.Labels[butlerv1alpha1.LabelPlatformLB] == "true" {
+			platformCount++
+		} else {
+			tenantCount++
+		}
 	}
-	return count, nil
+	return platformCount, tenantCount, nil
 }
 
 // ensurePlatformLBLabels ensures the Traefik service on a tenant cluster has the platform-lb
-// label so that countUsedLBIPs excludes it from usage calculations. This handles existing
-// clusters that were provisioned before the label was added to InstallTraefik.
+// label so that countLBIPs can distinguish platform LBs from tenant workload LBs. This handles
+// existing clusters that were provisioned before the label was added to InstallTraefik.
 func (r *Reconciler) ensurePlatformLBLabels(ctx context.Context, tc *tenant.TenantClient) {
 	logger := log.FromContext(ctx)
 

--- a/internal/controller/tenantcluster/reconcile_ipam_test.go
+++ b/internal/controller/tenantcluster/reconcile_ipam_test.go
@@ -15,16 +15,18 @@ import (
 	"github.com/butlerdotdev/butler-controller/internal/tenant"
 )
 
-func TestCountUsedLBIPs(t *testing.T) {
+func TestCountLBIPs(t *testing.T) {
 	tests := []struct {
-		name     string
-		services []corev1.Service
-		expected int32
+		name             string
+		services         []corev1.Service
+		wantPlatform     int32
+		wantTenant       int32
 	}{
 		{
-			name:     "no services",
-			services: nil,
-			expected: 0,
+			name:         "no services",
+			services:     nil,
+			wantPlatform: 0,
+			wantTenant:   0,
 		},
 		{
 			name: "ClusterIP service ignored",
@@ -34,10 +36,11 @@ func TestCountUsedLBIPs(t *testing.T) {
 					Spec:       corev1.ServiceSpec{Type: corev1.ServiceTypeClusterIP},
 				},
 			},
-			expected: 0,
+			wantPlatform: 0,
+			wantTenant:   0,
 		},
 		{
-			name: "LB service without label counted",
+			name: "unlabeled LB counts as tenant",
 			services: []corev1.Service{
 				{
 					ObjectMeta: metav1.ObjectMeta{Name: "app-lb", Namespace: "default"},
@@ -49,10 +52,11 @@ func TestCountUsedLBIPs(t *testing.T) {
 					},
 				},
 			},
-			expected: 1,
+			wantPlatform: 0,
+			wantTenant:   1,
 		},
 		{
-			name: "LB service with platform-lb label excluded",
+			name: "platform-labeled LB counts as platform",
 			services: []corev1.Service{
 				{
 					ObjectMeta: metav1.ObjectMeta{
@@ -68,10 +72,23 @@ func TestCountUsedLBIPs(t *testing.T) {
 					},
 				},
 			},
-			expected: 0,
+			wantPlatform: 1,
+			wantTenant:   0,
 		},
 		{
-			name: "mixed services: only unlabeled LBs with IPs counted",
+			name: "LB without assigned IP not counted",
+			services: []corev1.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "pending-lb", Namespace: "default"},
+					Spec:       corev1.ServiceSpec{Type: corev1.ServiceTypeLoadBalancer},
+					Status:     corev1.ServiceStatus{},
+				},
+			},
+			wantPlatform: 0,
+			wantTenant:   0,
+		},
+		{
+			name: "mixed: platform and tenant LBs counted separately",
 			services: []corev1.Service{
 				{
 					ObjectMeta: metav1.ObjectMeta{
@@ -105,19 +122,80 @@ func TestCountUsedLBIPs(t *testing.T) {
 					Status:     corev1.ServiceStatus{},
 				},
 			},
-			expected: 1,
+			wantPlatform: 1,
+			wantTenant:   1,
+		},
+		{
+			// Scenario: allocated=1, Traefik is the only LB. Old code reported
+			// availableIPs=1 (filtered Traefik entirely), so growth never fired.
+			// New code: platform=1, tenant=0, available = 1 - 1 - 0 = 0, growth fires.
+			name: "platform LB consumes all allocation capacity",
+			services: []corev1.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "traefik",
+						Namespace: "traefik",
+						Labels:    map[string]string{butlerv1alpha1.LabelPlatformLB: "true"},
+					},
+					Spec: corev1.ServiceSpec{Type: corev1.ServiceTypeLoadBalancer},
+					Status: corev1.ServiceStatus{
+						LoadBalancer: corev1.LoadBalancerStatus{
+							Ingress: []corev1.LoadBalancerIngress{{IP: "10.0.0.1"}},
+						},
+					},
+				},
+			},
+			wantPlatform: 1,
+			wantTenant:   0,
+		},
+		{
+			// Scenario: allocated=3, Traefik + 2 tenant LBs.
+			// available = 3 - 1 - 2 = 0, growth fires correctly.
+			name: "platform plus multiple tenant LBs fills allocation",
+			services: []corev1.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "traefik",
+						Namespace: "traefik",
+						Labels:    map[string]string{butlerv1alpha1.LabelPlatformLB: "true"},
+					},
+					Spec: corev1.ServiceSpec{Type: corev1.ServiceTypeLoadBalancer},
+					Status: corev1.ServiceStatus{
+						LoadBalancer: corev1.LoadBalancerStatus{
+							Ingress: []corev1.LoadBalancerIngress{{IP: "10.0.0.1"}},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "svc-a", Namespace: "default"},
+					Spec:       corev1.ServiceSpec{Type: corev1.ServiceTypeLoadBalancer},
+					Status: corev1.ServiceStatus{
+						LoadBalancer: corev1.LoadBalancerStatus{
+							Ingress: []corev1.LoadBalancerIngress{{IP: "10.0.0.2"}},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "svc-b", Namespace: "default"},
+					Spec:       corev1.ServiceSpec{Type: corev1.ServiceTypeLoadBalancer},
+					Status: corev1.ServiceStatus{
+						LoadBalancer: corev1.LoadBalancerStatus{
+							Ingress: []corev1.LoadBalancerIngress{{IP: "10.0.0.3"}},
+						},
+					},
+				},
+			},
+			wantPlatform: 1,
+			wantTenant:   2,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			var objects []corev1.Service
-			objects = append(objects, tt.services...)
-
 			clientset := fake.NewSimpleClientset()
-			for i := range objects {
-				_, err := clientset.CoreV1().Services(objects[i].Namespace).Create(
-					context.Background(), &objects[i], metav1.CreateOptions{})
+			for i := range tt.services {
+				_, err := clientset.CoreV1().Services(tt.services[i].Namespace).Create(
+					context.Background(), &tt.services[i], metav1.CreateOptions{})
 				if err != nil {
 					t.Fatalf("failed to create test service: %v", err)
 				}
@@ -126,12 +204,140 @@ func TestCountUsedLBIPs(t *testing.T) {
 			tc := &tenant.TenantClient{Clientset: clientset}
 			r := &Reconciler{}
 
-			got, err := r.countUsedLBIPs(context.Background(), tc)
+			gotPlatform, gotTenant, err := r.countLBIPs(context.Background(), tc)
 			if err != nil {
-				t.Fatalf("countUsedLBIPs() error = %v", err)
+				t.Fatalf("countLBIPs() error = %v", err)
 			}
-			if got != tt.expected {
-				t.Errorf("countUsedLBIPs() = %d, want %d", got, tt.expected)
+			if gotPlatform != tt.wantPlatform {
+				t.Errorf("countLBIPs() platformCount = %d, want %d", gotPlatform, tt.wantPlatform)
+			}
+			if gotTenant != tt.wantTenant {
+				t.Errorf("countLBIPs() tenantCount = %d, want %d", gotTenant, tt.wantTenant)
+			}
+		})
+	}
+}
+
+func TestCountLBIPs_AvailableCapacity(t *testing.T) {
+	// Integration-style tests validating the capacity formula:
+	// availableIPs = totalAllocated - platformCount - tenantCount
+
+	tests := []struct {
+		name           string
+		totalAllocated int32
+		services       []corev1.Service
+		wantAvailable  int32
+	}{
+		{
+			// The original bug: allocated=1, Traefik owns it. Old code said available=1.
+			// Correct: available = 1 - 1(platform) - 0(tenant) = 0, growth should fire.
+			name:           "single allocation consumed by platform LB triggers growth",
+			totalAllocated: 1,
+			services: []corev1.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "traefik",
+						Namespace: "traefik",
+						Labels:    map[string]string{butlerv1alpha1.LabelPlatformLB: "true"},
+					},
+					Spec: corev1.ServiceSpec{Type: corev1.ServiceTypeLoadBalancer},
+					Status: corev1.ServiceStatus{
+						LoadBalancer: corev1.LoadBalancerStatus{
+							Ingress: []corev1.LoadBalancerIngress{{IP: "10.0.0.1"}},
+						},
+					},
+				},
+			},
+			wantAvailable: 0,
+		},
+		{
+			// allocated=3, platform=1, tenant=1. available = 3 - 1 - 1 = 1. No growth needed.
+			name:           "headroom exists when allocation exceeds usage",
+			totalAllocated: 3,
+			services: []corev1.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "traefik",
+						Namespace: "traefik",
+						Labels:    map[string]string{butlerv1alpha1.LabelPlatformLB: "true"},
+					},
+					Spec: corev1.ServiceSpec{Type: corev1.ServiceTypeLoadBalancer},
+					Status: corev1.ServiceStatus{
+						LoadBalancer: corev1.LoadBalancerStatus{
+							Ingress: []corev1.LoadBalancerIngress{{IP: "10.0.0.1"}},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "app", Namespace: "default"},
+					Spec:       corev1.ServiceSpec{Type: corev1.ServiceTypeLoadBalancer},
+					Status: corev1.ServiceStatus{
+						LoadBalancer: corev1.LoadBalancerStatus{
+							Ingress: []corev1.LoadBalancerIngress{{IP: "10.0.0.2"}},
+						},
+					},
+				},
+			},
+			wantAvailable: 1,
+		},
+		{
+			// No platform LB (ingress disabled). allocated=2, tenant=2. available=0.
+			name:           "no platform LB still calculates correctly",
+			totalAllocated: 2,
+			services: []corev1.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "svc-a", Namespace: "default"},
+					Spec:       corev1.ServiceSpec{Type: corev1.ServiceTypeLoadBalancer},
+					Status: corev1.ServiceStatus{
+						LoadBalancer: corev1.LoadBalancerStatus{
+							Ingress: []corev1.LoadBalancerIngress{{IP: "10.0.0.1"}},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "svc-b", Namespace: "default"},
+					Spec:       corev1.ServiceSpec{Type: corev1.ServiceTypeLoadBalancer},
+					Status: corev1.ServiceStatus{
+						LoadBalancer: corev1.LoadBalancerStatus{
+							Ingress: []corev1.LoadBalancerIngress{{IP: "10.0.0.2"}},
+						},
+					},
+				},
+			},
+			wantAvailable: 0,
+		},
+		{
+			// Fresh cluster: allocated=1, no services yet. available=1. No growth needed.
+			name:           "empty cluster has full capacity available",
+			totalAllocated: 1,
+			services:       nil,
+			wantAvailable:  1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clientset := fake.NewSimpleClientset()
+			for i := range tt.services {
+				_, err := clientset.CoreV1().Services(tt.services[i].Namespace).Create(
+					context.Background(), &tt.services[i], metav1.CreateOptions{})
+				if err != nil {
+					t.Fatalf("failed to create test service: %v", err)
+				}
+			}
+
+			tc := &tenant.TenantClient{Clientset: clientset}
+			r := &Reconciler{}
+
+			platformCount, tenantCount, err := r.countLBIPs(context.Background(), tc)
+			if err != nil {
+				t.Fatalf("countLBIPs() error = %v", err)
+			}
+
+			available := tt.totalAllocated - platformCount - tenantCount
+			if available != tt.wantAvailable {
+				t.Errorf("availableIPs = %d (total=%d - platform=%d - tenant=%d), want %d",
+					available, tt.totalAllocated, platformCount, tenantCount, tt.wantAvailable)
 			}
 		})
 	}
@@ -178,7 +384,6 @@ func TestEnsurePlatformLBLabels(t *testing.T) {
 
 		r.ensurePlatformLBLabels(context.Background(), tc)
 
-		// Verify no update was issued (label still present, no error)
 		updated, err := clientset.CoreV1().Services("traefik").Get(
 			context.Background(), "traefik", metav1.GetOptions{})
 		if err != nil {


### PR DESCRIPTION
## Summary

Fixes #69. The platform LB filtering introduced in #62 excluded labeled
services from the used-IP count entirely, which made elastic IPAM blind
to pool capacity consumed by Traefik. When a tenant had `allocated=1`
and Traefik held the only IP, `availableIPs` was reported as 1 instead
of 0, so growth never fired for pending tenant workloads.

- Replace `countUsedLBIPs` (single return) with `countLBIPs` returning
  separate `platformCount` and `tenantCount`
- Caller now computes `available = totalAllocated - platformCount - tenantCount`
- Platform LBs consume capacity but do not inflate tenant demand for
  shrink decisions
- Log output now shows platform and tenant counts separately for
  easier debugging

## Test plan

- [x] Unit tests for `countLBIPs` covering all service type combinations
- [x] Integration-style tests validating the capacity formula across 4
  scenarios (the original bug case, headroom case, no-platform case,
  empty cluster)
- [x] Existing `TestEnsurePlatformLBLabels` still passes
- [ ] Deploy to Company 1 management cluster and verify growth fires on
  victoria-metrics-dev (allocated=1, Traefik consuming it)