### PR TITLE
fix(ipam): correct shrink threshold and reclaim orphan allocations

### DIFF
--- a/internal/controller/tenantcluster/reconcile_ipam.go
+++ b/internal/controller/tenantcluster/reconcile_ipam.go
@@ -6,6 +6,7 @@ package tenantcluster
 import (
 	"context"
 	"fmt"
+	"net"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -200,7 +201,7 @@ func (r *Reconciler) reconcileElasticIPAM(ctx context.Context, tc *butlerv1alpha
 	// clusters provisioned before the label existed get correct IP accounting.
 	r.ensurePlatformLBLabels(ctx, tenantClient)
 
-	platformCount, tenantCount, err := r.countLBIPs(ctx, tenantClient)
+	platformCount, tenantCount, serviceIPs, err := r.countLBIPs(ctx, tenantClient)
 	if err != nil {
 		logger.V(1).Info("cannot count LB IPs, skipping", "error", err)
 		return nil
@@ -273,8 +274,8 @@ func (r *Reconciler) reconcileElasticIPAM(ctx context.Context, tc *butlerv1alpha
 		}
 	}
 
-	// Shrink: if we have more than 1 allocation and enough spare IPs
-	if len(allocs) > 1 && availableIPs > growthIncrement {
+	// Shrink: if we have more than 1 allocation and at least one growth-increment of spare capacity
+	if len(allocs) > 1 && availableIPs >= growthIncrement {
 		// Find the newest allocation that is fully unused and older than 10 minutes
 		var shrinkCandidate *butlerv1alpha1.IPAllocation
 		for i := len(allocs) - 1; i >= 1; i-- { // Skip index 0 (initial allocation)
@@ -301,6 +302,9 @@ func (r *Reconciler) reconcileElasticIPAM(ctx context.Context, tc *butlerv1alpha
 			}
 		}
 	}
+
+	// Reclaim orphan allocations whose IPs are not used by any service on the tenant
+	r.reclaimOrphanAllocations(ctx, allocs, serviceIPs)
 
 	// Update MetalLB pool with all current allocated ranges
 	if err := r.updateMetalLBPool(ctx, tc, butlerConfig, allocs); err != nil {
@@ -362,12 +366,14 @@ func (r *Reconciler) listLBAllocations(ctx context.Context, tc *butlerv1alpha1.T
 // returning separate counts for platform-managed LBs and tenant workload LBs.
 // Platform LBs (labeled with LabelPlatformLB) consume pool capacity but should not
 // be treated as tenant workload demand for growth/shrink decisions.
-func (r *Reconciler) countLBIPs(ctx context.Context, tc *tenant.TenantClient) (platformCount, tenantCount int32, err error) {
+// Also returns the set of all assigned LB IPs for use in orphan detection.
+func (r *Reconciler) countLBIPs(ctx context.Context, tc *tenant.TenantClient) (platformCount, tenantCount int32, serviceIPs map[string]bool, err error) {
 	svcList, err := tc.Clientset.CoreV1().Services("").List(ctx, metav1.ListOptions{})
 	if err != nil {
-		return 0, 0, fmt.Errorf("failed to list services: %w", err)
+		return 0, 0, nil, fmt.Errorf("failed to list services: %w", err)
 	}
 
+	serviceIPs = make(map[string]bool)
 	for _, svc := range svcList.Items {
 		if svc.Spec.Type != corev1.ServiceTypeLoadBalancer {
 			continue
@@ -375,8 +381,8 @@ func (r *Reconciler) countLBIPs(ctx context.Context, tc *tenant.TenantClient) (p
 		hasIP := false
 		for _, ing := range svc.Status.LoadBalancer.Ingress {
 			if ing.IP != "" {
+				serviceIPs[ing.IP] = true
 				hasIP = true
-				break
 			}
 		}
 		if !hasIP {
@@ -388,7 +394,7 @@ func (r *Reconciler) countLBIPs(ctx context.Context, tc *tenant.TenantClient) (p
 			tenantCount++
 		}
 	}
-	return platformCount, tenantCount, nil
+	return platformCount, tenantCount, serviceIPs, nil
 }
 
 // ensurePlatformLBLabels ensures the Traefik service on a tenant cluster has the platform-lb
@@ -413,6 +419,71 @@ func (r *Reconciler) ensurePlatformLBLabels(ctx context.Context, tc *tenant.Tena
 	svc.Labels[butlerv1alpha1.LabelPlatformLB] = "true"
 	if _, err := tc.Clientset.CoreV1().Services("traefik").Update(ctx, svc, metav1.UpdateOptions{}); err != nil {
 		logger.V(1).Info("ensurePlatformLBLabels: failed to patch label", "error", err)
+	}
+}
+
+// reclaimOrphanAllocations deletes IPAllocations whose IPs are not used by any
+// LoadBalancer service on the tenant cluster. Only allocations older than 5 minutes
+// are considered, to avoid racing normal allocation propagation.
+func (r *Reconciler) reclaimOrphanAllocations(ctx context.Context, allocs []butlerv1alpha1.IPAllocation, serviceIPs map[string]bool) {
+	logger := log.FromContext(ctx)
+
+	const orphanGracePeriod = 5 * time.Minute
+
+	for i := range allocs {
+		alloc := &allocs[i]
+		if alloc.Status.Phase != butlerv1alpha1.IPAllocationPhaseAllocated {
+			continue
+		}
+		if time.Since(alloc.CreationTimestamp.Time) < orphanGracePeriod {
+			continue
+		}
+		if allocationHasServiceIP(alloc, serviceIPs) {
+			continue
+		}
+		logger.Info("reclaiming orphan IPAllocation",
+			"allocation", alloc.Name,
+			"start", alloc.Status.StartAddress,
+			"end", alloc.Status.EndAddress,
+			"age", time.Since(alloc.CreationTimestamp.Time).Round(time.Second))
+		if err := r.Delete(ctx, alloc); err != nil && !apierrors.IsNotFound(err) {
+			logger.Error(err, "failed to delete orphan IPAllocation", "allocation", alloc.Name)
+		}
+	}
+}
+
+// allocationHasServiceIP returns true if any IP in the allocation's range matches
+// a service IP from the tenant cluster.
+func allocationHasServiceIP(alloc *butlerv1alpha1.IPAllocation, serviceIPs map[string]bool) bool {
+	if alloc.Status.StartAddress == "" {
+		return false
+	}
+	start := net.ParseIP(alloc.Status.StartAddress).To4()
+	end := net.ParseIP(alloc.Status.EndAddress).To4()
+	if start == nil || end == nil {
+		return false
+	}
+	ip := make(net.IP, 4)
+	copy(ip, start)
+	for i := 0; i < 256; i++ { // safety bound
+		if serviceIPs[ip.String()] {
+			return true
+		}
+		if ip.Equal(end) {
+			break
+		}
+		incrementIP(ip)
+	}
+	return false
+}
+
+// incrementIP advances an IPv4 address by one.
+func incrementIP(ip net.IP) {
+	for j := len(ip) - 1; j >= 0; j-- {
+		ip[j]++
+		if ip[j] > 0 {
+			break
+		}
 	}
 }
 

--- a/internal/controller/tenantcluster/reconcile_ipam_test.go
+++ b/internal/controller/tenantcluster/reconcile_ipam_test.go
@@ -6,10 +6,14 @@ package tenantcluster
 import (
 	"context"
 	"testing"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	butlerv1alpha1 "github.com/butlerdotdev/butler-api/api/v1alpha1"
 	"github.com/butlerdotdev/butler-controller/internal/tenant"
@@ -204,7 +208,7 @@ func TestCountLBIPs(t *testing.T) {
 			tc := &tenant.TenantClient{Clientset: clientset}
 			r := &Reconciler{}
 
-			gotPlatform, gotTenant, err := r.countLBIPs(context.Background(), tc)
+			gotPlatform, gotTenant, _, err := r.countLBIPs(context.Background(), tc)
 			if err != nil {
 				t.Fatalf("countLBIPs() error = %v", err)
 			}
@@ -329,7 +333,7 @@ func TestCountLBIPs_AvailableCapacity(t *testing.T) {
 			tc := &tenant.TenantClient{Clientset: clientset}
 			r := &Reconciler{}
 
-			platformCount, tenantCount, err := r.countLBIPs(context.Background(), tc)
+			platformCount, tenantCount, _, err := r.countLBIPs(context.Background(), tc)
 			if err != nil {
 				t.Fatalf("countLBIPs() error = %v", err)
 			}
@@ -402,4 +406,313 @@ func TestEnsurePlatformLBLabels(t *testing.T) {
 		// Should not panic or error
 		r.ensurePlatformLBLabels(context.Background(), tc)
 	})
+}
+
+func TestCountLBIPs_ServiceIPs(t *testing.T) {
+	services := []corev1.Service{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "traefik",
+				Namespace: "traefik",
+				Labels:    map[string]string{butlerv1alpha1.LabelPlatformLB: "true"},
+			},
+			Spec: corev1.ServiceSpec{Type: corev1.ServiceTypeLoadBalancer},
+			Status: corev1.ServiceStatus{
+				LoadBalancer: corev1.LoadBalancerStatus{
+					Ingress: []corev1.LoadBalancerIngress{{IP: "10.0.0.1"}},
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "app", Namespace: "default"},
+			Spec:       corev1.ServiceSpec{Type: corev1.ServiceTypeLoadBalancer},
+			Status: corev1.ServiceStatus{
+				LoadBalancer: corev1.LoadBalancerStatus{
+					Ingress: []corev1.LoadBalancerIngress{{IP: "10.0.0.2"}},
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "pending", Namespace: "default"},
+			Spec:       corev1.ServiceSpec{Type: corev1.ServiceTypeLoadBalancer},
+			Status:     corev1.ServiceStatus{},
+		},
+	}
+
+	clientset := fake.NewSimpleClientset()
+	for i := range services {
+		_, err := clientset.CoreV1().Services(services[i].Namespace).Create(
+			context.Background(), &services[i], metav1.CreateOptions{})
+		if err != nil {
+			t.Fatalf("failed to create test service: %v", err)
+		}
+	}
+
+	tc := &tenant.TenantClient{Clientset: clientset}
+	r := &Reconciler{}
+
+	_, _, serviceIPs, err := r.countLBIPs(context.Background(), tc)
+	if err != nil {
+		t.Fatalf("countLBIPs() error = %v", err)
+	}
+	if !serviceIPs["10.0.0.1"] {
+		t.Error("expected 10.0.0.1 in serviceIPs")
+	}
+	if !serviceIPs["10.0.0.2"] {
+		t.Error("expected 10.0.0.2 in serviceIPs")
+	}
+	if len(serviceIPs) != 2 {
+		t.Errorf("expected 2 service IPs, got %d: %v", len(serviceIPs), serviceIPs)
+	}
+}
+
+func TestAllocationHasServiceIP(t *testing.T) {
+	tests := []struct {
+		name       string
+		start      string
+		end        string
+		serviceIPs map[string]bool
+		want       bool
+	}{
+		{
+			name:       "single IP matches",
+			start:      "10.0.0.5",
+			end:        "10.0.0.5",
+			serviceIPs: map[string]bool{"10.0.0.5": true},
+			want:       true,
+		},
+		{
+			name:       "single IP no match",
+			start:      "10.0.0.5",
+			end:        "10.0.0.5",
+			serviceIPs: map[string]bool{"10.0.0.6": true},
+			want:       false,
+		},
+		{
+			name:       "range match on start",
+			start:      "10.0.0.10",
+			end:        "10.0.0.11",
+			serviceIPs: map[string]bool{"10.0.0.10": true},
+			want:       true,
+		},
+		{
+			name:       "range match on end",
+			start:      "10.0.0.10",
+			end:        "10.0.0.11",
+			serviceIPs: map[string]bool{"10.0.0.11": true},
+			want:       true,
+		},
+		{
+			name:       "range no match",
+			start:      "10.0.0.10",
+			end:        "10.0.0.11",
+			serviceIPs: map[string]bool{"10.0.0.12": true},
+			want:       false,
+		},
+		{
+			name:       "empty start address",
+			start:      "",
+			end:        "",
+			serviceIPs: map[string]bool{"10.0.0.1": true},
+			want:       false,
+		},
+		{
+			name:       "empty service IPs",
+			start:      "10.0.0.5",
+			end:        "10.0.0.5",
+			serviceIPs: map[string]bool{},
+			want:       false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			alloc := &butlerv1alpha1.IPAllocation{
+				Status: butlerv1alpha1.IPAllocationStatus{
+					StartAddress: tt.start,
+					EndAddress:   tt.end,
+				},
+			}
+			got := allocationHasServiceIP(alloc, tt.serviceIPs)
+			if got != tt.want {
+				t.Errorf("allocationHasServiceIP() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestReclaimOrphanAllocations(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = butlerv1alpha1.AddToScheme(scheme)
+
+	oldTime := metav1.NewTime(time.Now().Add(-10 * time.Minute))
+	newTime := metav1.NewTime(time.Now().Add(-2 * time.Minute))
+	count := int32(1)
+
+	t.Run("reclaims allocation with no matching service IP", func(t *testing.T) {
+		alloc := &butlerv1alpha1.IPAllocation{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "test-orphan",
+				Namespace:         "butler-system",
+				CreationTimestamp: oldTime,
+			},
+			Spec: butlerv1alpha1.IPAllocationSpec{Count: &count},
+			Status: butlerv1alpha1.IPAllocationStatus{
+				Phase:        butlerv1alpha1.IPAllocationPhaseAllocated,
+				StartAddress: "10.0.0.5",
+				EndAddress:   "10.0.0.5",
+			},
+		}
+
+		cl := fakeclient.NewClientBuilder().WithScheme(scheme).WithObjects(alloc).Build()
+		r := &Reconciler{Client: cl}
+
+		serviceIPs := map[string]bool{"10.0.0.1": true, "10.0.0.2": true}
+		r.reclaimOrphanAllocations(context.Background(), []butlerv1alpha1.IPAllocation{*alloc}, serviceIPs)
+
+		// Verify deletion
+		err := cl.Get(context.Background(), client.ObjectKeyFromObject(alloc), &butlerv1alpha1.IPAllocation{})
+		if err == nil {
+			t.Error("expected orphan allocation to be deleted")
+		}
+	})
+
+	t.Run("skips allocation with matching service IP", func(t *testing.T) {
+		alloc := &butlerv1alpha1.IPAllocation{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "test-used",
+				Namespace:         "butler-system",
+				CreationTimestamp: oldTime,
+			},
+			Spec: butlerv1alpha1.IPAllocationSpec{Count: &count},
+			Status: butlerv1alpha1.IPAllocationStatus{
+				Phase:        butlerv1alpha1.IPAllocationPhaseAllocated,
+				StartAddress: "10.0.0.1",
+				EndAddress:   "10.0.0.1",
+			},
+		}
+
+		cl := fakeclient.NewClientBuilder().WithScheme(scheme).WithObjects(alloc).Build()
+		r := &Reconciler{Client: cl}
+
+		serviceIPs := map[string]bool{"10.0.0.1": true}
+		r.reclaimOrphanAllocations(context.Background(), []butlerv1alpha1.IPAllocation{*alloc}, serviceIPs)
+
+		// Verify NOT deleted
+		err := cl.Get(context.Background(), client.ObjectKeyFromObject(alloc), &butlerv1alpha1.IPAllocation{})
+		if err != nil {
+			t.Errorf("expected used allocation to remain, got error: %v", err)
+		}
+	})
+
+	t.Run("skips allocation younger than grace period", func(t *testing.T) {
+		alloc := &butlerv1alpha1.IPAllocation{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "test-young",
+				Namespace:         "butler-system",
+				CreationTimestamp: newTime, // 2 minutes old, under 5-minute grace
+			},
+			Spec: butlerv1alpha1.IPAllocationSpec{Count: &count},
+			Status: butlerv1alpha1.IPAllocationStatus{
+				Phase:        butlerv1alpha1.IPAllocationPhaseAllocated,
+				StartAddress: "10.0.0.9",
+				EndAddress:   "10.0.0.9",
+			},
+		}
+
+		cl := fakeclient.NewClientBuilder().WithScheme(scheme).WithObjects(alloc).Build()
+		r := &Reconciler{Client: cl}
+
+		serviceIPs := map[string]bool{"10.0.0.1": true} // no match for .9
+		r.reclaimOrphanAllocations(context.Background(), []butlerv1alpha1.IPAllocation{*alloc}, serviceIPs)
+
+		// Verify NOT deleted (within grace period)
+		err := cl.Get(context.Background(), client.ObjectKeyFromObject(alloc), &butlerv1alpha1.IPAllocation{})
+		if err != nil {
+			t.Errorf("expected young allocation to remain, got error: %v", err)
+		}
+	})
+
+	t.Run("skips allocation in pending phase", func(t *testing.T) {
+		alloc := &butlerv1alpha1.IPAllocation{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "test-pending",
+				Namespace:         "butler-system",
+				CreationTimestamp: oldTime,
+			},
+			Spec: butlerv1alpha1.IPAllocationSpec{Count: &count},
+			Status: butlerv1alpha1.IPAllocationStatus{
+				Phase:        butlerv1alpha1.IPAllocationPhasePending,
+				StartAddress: "",
+				EndAddress:   "",
+			},
+		}
+
+		cl := fakeclient.NewClientBuilder().WithScheme(scheme).WithObjects(alloc).Build()
+		r := &Reconciler{Client: cl}
+
+		serviceIPs := map[string]bool{}
+		r.reclaimOrphanAllocations(context.Background(), []butlerv1alpha1.IPAllocation{*alloc}, serviceIPs)
+
+		// Verify NOT deleted (not yet allocated)
+		err := cl.Get(context.Background(), client.ObjectKeyFromObject(alloc), &butlerv1alpha1.IPAllocation{})
+		if err != nil {
+			t.Errorf("expected pending allocation to remain, got error: %v", err)
+		}
+	})
+}
+
+func TestShrinkThreshold(t *testing.T) {
+	// Validates the off-by-one fix: with growthIncrement=1, shrink should fire
+	// when availableIPs == 1 (one orphan present).
+	tests := []struct {
+		name         string
+		availableIPs int32
+		increment    int32
+		wantShrink   bool
+	}{
+		{
+			name:         "available equals increment: shrink fires",
+			availableIPs: 1,
+			increment:    1,
+			wantShrink:   true,
+		},
+		{
+			name:         "available exceeds increment: shrink fires",
+			availableIPs: 2,
+			increment:    1,
+			wantShrink:   true,
+		},
+		{
+			name:         "available below increment: no shrink",
+			availableIPs: 0,
+			increment:    1,
+			wantShrink:   false,
+		},
+		{
+			name:         "increment=2, available=2: shrink fires",
+			availableIPs: 2,
+			increment:    2,
+			wantShrink:   true,
+		},
+		{
+			name:         "increment=2, available=1: no shrink",
+			availableIPs: 1,
+			increment:    2,
+			wantShrink:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// The shrink condition from reconcileElasticIPAM:
+			// len(allocs) > 1 && availableIPs >= growthIncrement
+			allocCount := 2 // More than 1 to satisfy first condition
+			got := allocCount > 1 && tt.availableIPs >= tt.increment
+			if got != tt.wantShrink {
+				t.Errorf("shrink condition (available=%d >= increment=%d) = %v, want %v",
+					tt.availableIPs, tt.increment, got, tt.wantShrink)
+			}
+		})
+	}
 }


### PR DESCRIPTION
## Summary

Two related elastic IPAM fixes from the v0.17.1 deploy on Company 1:

**Shrink threshold off-by-one (#72):** The shrink condition was `availableIPs > growthIncrement`, which with growthIncrement=1 meant shrink only fired at availableIPs >= 2. Changed to `>=` so a single orphan allocation (available=1) is reclaimed.

**Crash-recovery orphan detection (#73):** After a controller restart that races MetalLB pool updates, IPAllocations can exist on the management cluster with no corresponding service on the tenant. Added `reclaimOrphanAllocations` which walks allocations after `countLBIPs`, checks each allocation's IP range against actual LB service IPs, and deletes allocations older than 5 minutes with no matching service.

## Changes

- `reconcile_ipam.go`: Changed shrink operator from `>` to `>=`. Added `reclaimOrphanAllocations`, `allocationHasServiceIP`, and `incrementIP` functions. Extended `countLBIPs` to return the set of service IPs for cross-referencing.
- `reconcile_ipam_test.go`: Added `TestShrinkThreshold` (5 cases), `TestAllocationHasServiceIP` (7 cases), `TestReclaimOrphanAllocations` (4 cases), `TestCountLBIPs_ServiceIPs`.

## Verification

With growthIncrement=1, the math:
- allocated=2, platform=1, tenant=1, available=0: shrink 0 >= 1 false. Steady state, no shrink.
- allocated=3, platform=1, tenant=1, available=1: shrink 1 >= 1 true. Reclaims orphan.
- allocated=4, platform=1, tenant=1, available=2: shrink fires twice over successive cycles.

Orphan grace period (5 min) prevents racing normal allocation propagation which completes in under 2 minutes.

Closes #72
Closes #73