### PR TITLE
fix(addons): use --set-string for Traefik commonLabels

### DIFF
--- a/internal/addons/installer.go
+++ b/internal/addons/installer.go
@@ -690,7 +690,7 @@ func (i *Installer) InstallTraefik(ctx context.Context, kubeconfig []byte, versi
 		"--set", "ingressClass.enabled=true",
 		"--set", "ingressClass.isDefaultClass=true",
 		"--set", "service.type=LoadBalancer",
-		"--set", `commonLabels.butler\.butlerlabs\.dev/platform-lb=true`,
+		"--set-string", `commonLabels.butler\.butlerlabs\.dev/platform-lb=true`,
 		"--wait",
 		"--timeout", "2m",
 	}

--- a/internal/addons/installer_test.go
+++ b/internal/addons/installer_test.go
@@ -1,0 +1,72 @@
+// Copyright 2026 The Butler Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package addons
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestInstallTraefikUsesSetStringForLabels(t *testing.T) {
+	// Create a temp dir for the fake helm binary and its output
+	tmpDir := t.TempDir()
+	argsFile := filepath.Join(tmpDir, "helm-args")
+	fakeHelm := filepath.Join(tmpDir, "helm")
+
+	// Write a fake helm script that records all arguments
+	script := "#!/bin/sh\necho \"$@\" >> " + argsFile + "\n"
+	if err := os.WriteFile(fakeHelm, []byte(script), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	installer := &Installer{
+		kubectlPath: filepath.Join(tmpDir, "kubectl"),
+		helmPath:    fakeHelm,
+	}
+
+	// Create a fake kubectl that does nothing (for ensurePrivilegedNamespace)
+	fakeKubectl := "#!/bin/sh\nexit 0\n"
+	if err := os.WriteFile(installer.kubectlPath, []byte(fakeKubectl), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a dummy kubeconfig
+	kubeconfig := []byte("apiVersion: v1\nkind: Config\nclusters: []\ncontexts: []\nusers: []")
+
+	err := installer.InstallTraefik(context.Background(), kubeconfig, "34.3.0")
+	if err != nil {
+		// The fake helm returns exit 0 so this should succeed
+		t.Fatalf("InstallTraefik() error = %v", err)
+	}
+
+	recorded, err := os.ReadFile(argsFile)
+	if err != nil {
+		t.Fatalf("failed to read recorded args: %v", err)
+	}
+
+	lines := strings.Split(strings.TrimSpace(string(recorded)), "\n")
+
+	// Find the helm upgrade --install invocation (last line, after repo add and repo update)
+	var installLine string
+	for _, line := range lines {
+		if strings.Contains(line, "upgrade --install") {
+			installLine = line
+			break
+		}
+	}
+	if installLine == "" {
+		t.Fatalf("no 'upgrade --install' invocation found in recorded args:\n%s", string(recorded))
+	}
+
+	// The commonLabels value must use --set-string, not --set
+	if !strings.Contains(installLine, "--set-string commonLabels") {
+		t.Errorf("expected --set-string for commonLabels, got:\n%s", installLine)
+	}
+	if strings.Contains(installLine, "--set commonLabels") {
+		t.Errorf("found --set (not --set-string) for commonLabels, got:\n%s", installLine)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes Traefik install failure on new tenants. Helm's `--set` flag interprets `true` as a boolean, which Kubernetes rejects for label values (`json: cannot unmarshal bool into Go struct field ObjectMeta.metadata.labels of type string`).

Changed `--set` to `--set-string` for the `commonLabels.butler.butlerlabs.dev/platform-lb=true` argument so Helm passes the value as a string.

## Context

- Introduced in #62 (platform LB labeling)
- Dev tenants unaffected (Traefik pre-dates #62, label was patched by ensurePlatformLBLabels fallback)
- Prd tenants actively failing (victoria-metrics-prd and observability-pipeline-prd, provisioned 2026-04-29)

## Changes

- `internal/addons/installer.go`: `--set` -> `--set-string` for the commonLabels entry (line 693)
- `internal/addons/installer_test.go`: Regression test that captures helm args via a fake binary and asserts `--set-string` is used for commonLabels

## Verification

```
helm template ... --set "commonLabels.butler\.butlerlabs\.dev/platform-lb=true"
  -> renders: butler.butlerlabs.dev/platform-lb: true  (boolean, rejected by K8s)

helm template ... --set-string "commonLabels.butler\.butlerlabs\.dev/platform-lb=true"
  -> renders: butler.butlerlabs.dev/platform-lb: "true"  (string, accepted)
```

Closes #75