### PR TITLE
Bump butler-api to v0.13.0, adopt IsPlatformAdmin() method

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/butlerdotdev/butler-controller
 go 1.24.6
 
 require (
-	github.com/butlerdotdev/butler-api v0.12.0
+	github.com/butlerdotdev/butler-api v0.13.0
 	github.com/onsi/ginkgo/v2 v2.22.0
 	github.com/onsi/gomega v1.36.1
 	github.com/prometheus/client_golang v1.22.0

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
-github.com/butlerdotdev/butler-api v0.12.0 h1:vVdFo0gonfebZkc1/5hlxnTGEbyD4WG45ZGpfPtuGX8=
-github.com/butlerdotdev/butler-api v0.12.0/go.mod h1:q/RjPFM/r2ELq4DqR78OiAxerKBvH5D4nTGsVLKbjqY=
+github.com/butlerdotdev/butler-api v0.13.0 h1:mnW1YEPD0QG9d2P+kr7DWSs5ViGf5DXSHnVWmE5Cjt8=
+github.com/butlerdotdev/butler-api v0.13.0/go.mod h1:q/RjPFM/r2ELq4DqR78OiAxerKBvH5D4nTGsVLKbjqY=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/internal/webhook/team_webhook.go
+++ b/internal/webhook/team_webhook.go
@@ -240,7 +240,9 @@ func environmentLimitsChanged(old, new []butlerv1alpha1.EnvironmentSpec) bool {
 
 // isPlatformAdmin returns true when the user is a platform admin. Primary
 // path: list User CRDs and match on Spec.Email == user.Username; the
-// matching User's Spec.IsPlatformAdmin is the authoritative answer. The
+// matching User's effective platform role is the authoritative answer,
+// checked via IsPlatformAdmin() which honors both the deprecated
+// Spec.IsPlatformAdmin bool and the new Spec.PlatformRole field. The
 // SAR fallback fires only when no User CRD matches the caller's username,
 // which is the case for kubectl-direct operators holding the admin
 // kubeconfig but not mapped to a User CRD. List errors surface to the
@@ -255,7 +257,7 @@ func (v *TeamValidator) isPlatformAdmin(ctx context.Context, user authnv1.UserIn
 	for i := range userList.Items {
 		u := &userList.Items[i]
 		if strings.EqualFold(u.Spec.Email, user.Username) {
-			return u.Spec.IsPlatformAdmin, nil
+			return u.IsPlatformAdmin(), nil
 		}
 	}
 	// No matching User CRD; fall back to the K8s authz model via SAR.


### PR DESCRIPTION
## Context

butler-api v0.13.0 (ADR-014 PR 1) adds the `PlatformRole` field to
`UserSpec` alongside the deprecated `IsPlatformAdmin` bool.

## Changes

- Bump `butler-api` from v0.12.0 to v0.13.0
- Switch `team_webhook.go` from reading `u.Spec.IsPlatformAdmin` directly
  to calling `u.IsPlatformAdmin()`, which checks both the deprecated bool
  and the new `PlatformRole` field. Users with `platformRole: "admin"` are
  now recognized as platform admins by the webhook.

## Test plan

- Webhook unit tests pass (all platform admin test cases unchanged)
- Build and vet clean
- Envtest suite tests skipped (no local etcd binary; pre-existing)

Refs butlerdotdev/butler-api#33