### PR TITLE
Bump butler-api to v0.15.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/butlerdotdev/butler-controller
 go 1.24.6
 
 require (
-	github.com/butlerdotdev/butler-api v0.13.0
+	github.com/butlerdotdev/butler-api v0.15.0
 	github.com/onsi/ginkgo/v2 v2.22.0
 	github.com/onsi/gomega v1.36.1
 	github.com/prometheus/client_golang v1.22.0

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
-github.com/butlerdotdev/butler-api v0.13.0 h1:mnW1YEPD0QG9d2P+kr7DWSs5ViGf5DXSHnVWmE5Cjt8=
-github.com/butlerdotdev/butler-api v0.13.0/go.mod h1:q/RjPFM/r2ELq4DqR78OiAxerKBvH5D4nTGsVLKbjqY=
+github.com/butlerdotdev/butler-api v0.15.0 h1:re+6YTS/CbBspGPK2Z6BO/OxNVXZHemOWqZ/pIE4s2U=
+github.com/butlerdotdev/butler-api v0.15.0/go.mod h1:q/RjPFM/r2ELq4DqR78OiAxerKBvH5D4nTGsVLKbjqY=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=


### PR DESCRIPTION
## Context

Ecosystem version consistency bump. butler-api v0.15.0 added the `IconData` field to `AddonDefinitionSpec` (butlerdotdev/butler-api#38). butler-controller doesn't consume this field but should stay on the same butler-api version as butler-server.

## Changes

- `go.mod`: butler-api v0.13.0 -> v0.15.0
- `go.sum`: updated checksums

No code changes. butler-controller uses `GetEffectivePlatformRole()` from v0.13.0 and the `AddonDefinition` types for CRD reconciliation — both are unaffected.

## Test plan

- [x] `go build ./...` succeeds
- [x] `go vet ./...` passes
- [x] Unit tests pass (`internal/addons`, `internal/capi`)
- [x] envtest suite failures are pre-existing (missing local kubebuilder/etcd binaries, unrelated to this change)

Tracked in butlerdotdev/butler-api#37.