### PR TITLE
fix(ipam): allocation role labels, shrink safety, webhook validation

### DIFF
--- a/internal/controller/tenantcluster/reconcile_ipam.go
+++ b/internal/controller/tenantcluster/reconcile_ipam.go
@@ -318,6 +318,14 @@ func (r *Reconciler) reconcileElasticIPAM(ctx context.Context, tc *butlerv1alpha
 		}
 	}
 
+	// Re-fetch allocations to get a fresh slice. The shrink phase above may
+	// have deleted an allocation, so the original slice is stale. Using stale
+	// data for reclaim or MetalLB pool updates causes brief pool corruption.
+	allocs, err = r.listLBAllocations(ctx, tc)
+	if err != nil {
+		return fmt.Errorf("failed to re-list LB allocations after shrink: %w", err)
+	}
+
 	// Reclaim orphan allocations whose IPs are not used by any service on the tenant
 	r.reclaimOrphanAllocations(ctx, allocs, serviceIPs)
 

--- a/internal/controller/tenantcluster/reconcile_ipam.go
+++ b/internal/controller/tenantcluster/reconcile_ipam.go
@@ -285,12 +285,16 @@ func (r *Reconciler) reconcileElasticIPAM(ctx context.Context, tc *butlerv1alpha
 		}
 	}
 
-	// Shrink: if we have more than 1 allocation and at least one growth-increment of spare capacity
+	// Shrink: if we have more than 1 allocation and at least one growth-increment of spare capacity.
+	// Only growth allocations are shrink candidates — the initial allocation is never deleted
+	// regardless of its position in the List result (Kubernetes List ordering is undefined).
 	if len(allocs) > 1 && availableIPs >= growthIncrement {
-		// Find the newest allocation that is fully unused and older than 10 minutes
 		var shrinkCandidate *butlerv1alpha1.IPAllocation
-		for i := len(allocs) - 1; i >= 1; i-- { // Skip index 0 (initial allocation)
+		for i := len(allocs) - 1; i >= 0; i-- {
 			alloc := &allocs[i]
+			if alloc.Labels[LabelAllocationRole] != AllocationRoleGrowth {
+				continue
+			}
 			if alloc.Status.Phase != butlerv1alpha1.IPAllocationPhaseAllocated {
 				continue
 			}

--- a/internal/controller/tenantcluster/reconcile_ipam.go
+++ b/internal/controller/tenantcluster/reconcile_ipam.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"regexp"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -19,6 +20,9 @@ import (
 	butlerv1alpha1 "github.com/butlerdotdev/butler-api/api/v1alpha1"
 	"github.com/butlerdotdev/butler-controller/internal/tenant"
 )
+
+// growthSuffixPattern matches the "-N" suffix on growth allocation names.
+var growthSuffixPattern = regexp.MustCompile(`-\d+$`)
 
 // reconcileIPAllocation creates or checks LB IPAllocation for IPAM mode providers.
 // Returns true if IPAM is ready (allocated or not needed), false if waiting.
@@ -180,6 +184,11 @@ func (r *Reconciler) reconcileElasticIPAM(ctx context.Context, tc *butlerv1alpha
 	if len(allocs) == 0 {
 		return nil // No allocations yet, initial allocation handles this
 	}
+
+	// Migration: label any pre-existing allocations that lack the allocation-role label.
+	// Initial allocations have the pattern <team>-<tenant>-lb (no numeric suffix),
+	// growth allocations have the pattern <team>-<tenant>-lb-<N>.
+	r.migrateAllocationRoleLabels(ctx, allocs, tc)
 
 	// Count total allocated and available IPs
 	var totalAllocated int32
@@ -562,5 +571,48 @@ func (r *Reconciler) cleanupIPAllocations(ctx context.Context, tc *butlerv1alpha
 		} else {
 			logger.Info("deleted elastic IPAllocation during cleanup", "name", alloc.Name)
 		}
+	}
+}
+
+// migrateAllocationRoleLabels is a one-time migration that labels existing
+// IPAllocations that predate the allocation-role label. The name pattern is
+// used to infer the role:
+//
+//	<team>-<tenant>-lb       → initial
+//	<team>-<tenant>-lb-<N>   → growth
+//
+// This runs on every reconcile until all allocations are labeled, at which
+// point it becomes a no-op.
+func (r *Reconciler) migrateAllocationRoleLabels(ctx context.Context, allocs []butlerv1alpha1.IPAllocation, tc *butlerv1alpha1.TenantCluster) {
+	logger := log.FromContext(ctx)
+	initialName := fmt.Sprintf("%s-%s-lb", tc.Namespace, tc.Name)
+
+	for i := range allocs {
+		alloc := &allocs[i]
+		if alloc.Labels[LabelAllocationRole] != "" {
+			continue // already labeled
+		}
+
+		role := AllocationRoleGrowth
+		if alloc.Name == initialName {
+			role = AllocationRoleInitial
+		} else if !growthSuffixPattern.MatchString(alloc.Name) {
+			// Name doesn't match the growth pattern either — treat as initial
+			// for safety (don't allow it to be shrunk).
+			role = AllocationRoleInitial
+		}
+
+		patch := client.MergeFrom(alloc.DeepCopy())
+		if alloc.Labels == nil {
+			alloc.Labels = make(map[string]string)
+		}
+		alloc.Labels[LabelAllocationRole] = role
+		if err := r.Patch(ctx, alloc, patch); err != nil {
+			logger.Error(err, "failed to migrate allocation-role label",
+				"allocation", alloc.Name, "role", role)
+			continue
+		}
+		logger.Info("migrated allocation-role label",
+			"allocation", alloc.Name, "role", role)
 	}
 }

--- a/internal/controller/tenantcluster/reconcile_ipam.go
+++ b/internal/controller/tenantcluster/reconcile_ipam.go
@@ -115,6 +115,7 @@ func (r *Reconciler) reconcileIPAllocation(ctx context.Context, tc *butlerv1alph
 					butlerv1alpha1.LabelTeam:           tc.Namespace,
 					butlerv1alpha1.LabelTenant:         tc.Name,
 					butlerv1alpha1.LabelAllocationType: "loadbalancer",
+					LabelAllocationRole:                AllocationRoleInitial,
 				},
 			},
 			Spec: butlerv1alpha1.IPAllocationSpec{
@@ -252,6 +253,7 @@ func (r *Reconciler) reconcileElasticIPAM(ctx context.Context, tc *butlerv1alpha
 						butlerv1alpha1.LabelTeam:           tc.Namespace,
 						butlerv1alpha1.LabelTenant:         tc.Name,
 						butlerv1alpha1.LabelAllocationType: "loadbalancer",
+						LabelAllocationRole:                AllocationRoleGrowth,
 					},
 				},
 				Spec: butlerv1alpha1.IPAllocationSpec{

--- a/internal/controller/tenantcluster/reconcile_ipam_test.go
+++ b/internal/controller/tenantcluster/reconcile_ipam_test.go
@@ -5,6 +5,7 @@ package tenantcluster
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -714,5 +715,612 @@ func TestShrinkThreshold(t *testing.T) {
 					tt.availableIPs, tt.increment, got, tt.wantShrink)
 			}
 		})
+	}
+}
+
+func TestShrinkSelectsGrowthNotInitial(t *testing.T) {
+	// Verifies that the shrink loop only considers growth allocations, never
+	// the initial allocation, regardless of the order allocations appear in
+	// the slice (simulating undefined Kubernetes List ordering).
+	oldTime := metav1.NewTime(time.Now().Add(-15 * time.Minute))
+	count := int32(2)
+
+	// Create 3 allocations: initial + 2 growth, deliberately in non-alphabetical
+	// order to prove we don't depend on ordering.
+	allocs := []butlerv1alpha1.IPAllocation{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "team-a-cluster-lb-2",
+				Namespace:         "butler-system",
+				CreationTimestamp: oldTime,
+				Labels: map[string]string{
+					LabelAllocationRole: AllocationRoleGrowth,
+				},
+			},
+			Spec:   butlerv1alpha1.IPAllocationSpec{Count: &count},
+			Status: butlerv1alpha1.IPAllocationStatus{Phase: butlerv1alpha1.IPAllocationPhaseAllocated},
+		},
+		{
+			// The initial allocation is at index 1 — not index 0.
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "team-a-cluster-lb",
+				Namespace:         "butler-system",
+				CreationTimestamp: oldTime,
+				Labels: map[string]string{
+					LabelAllocationRole: AllocationRoleInitial,
+				},
+			},
+			Spec:   butlerv1alpha1.IPAllocationSpec{Count: &count},
+			Status: butlerv1alpha1.IPAllocationStatus{Phase: butlerv1alpha1.IPAllocationPhaseAllocated},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "team-a-cluster-lb-1",
+				Namespace:         "butler-system",
+				CreationTimestamp: oldTime,
+				Labels: map[string]string{
+					LabelAllocationRole: AllocationRoleGrowth,
+				},
+			},
+			Spec:   butlerv1alpha1.IPAllocationSpec{Count: &count},
+			Status: butlerv1alpha1.IPAllocationStatus{Phase: butlerv1alpha1.IPAllocationPhaseAllocated},
+		},
+	}
+
+	// Simulate the shrink selection logic from reconcileElasticIPAM
+	var shrinkCandidate *butlerv1alpha1.IPAllocation
+	for i := len(allocs) - 1; i >= 0; i-- {
+		alloc := &allocs[i]
+		if alloc.Labels[LabelAllocationRole] != AllocationRoleGrowth {
+			continue
+		}
+		if alloc.Status.Phase != butlerv1alpha1.IPAllocationPhaseAllocated {
+			continue
+		}
+		if alloc.Spec.Count == nil {
+			continue
+		}
+		if time.Since(alloc.CreationTimestamp.Time) < 10*time.Minute {
+			continue
+		}
+		shrinkCandidate = alloc
+		break
+	}
+
+	if shrinkCandidate == nil {
+		t.Fatal("expected a shrink candidate but got nil")
+	}
+	if shrinkCandidate.Labels[LabelAllocationRole] != AllocationRoleGrowth {
+		t.Errorf("expected shrink candidate to be a growth allocation, got role=%q",
+			shrinkCandidate.Labels[LabelAllocationRole])
+	}
+	// Verify initial was never selected
+	if shrinkCandidate.Name == "team-a-cluster-lb" {
+		t.Error("shrink selected the initial allocation; this must never happen")
+	}
+}
+
+func TestShrinkThenReclaimUsesFreshData(t *testing.T) {
+	// Verifies that after shrink deletes an allocation, reclaim uses a fresh
+	// slice rather than the stale one. We simulate this by checking that a
+	// deleted allocation's name does not appear in the fresh slice.
+	scheme := runtime.NewScheme()
+	_ = butlerv1alpha1.AddToScheme(scheme)
+
+	oldTime := metav1.NewTime(time.Now().Add(-15 * time.Minute))
+	count := int32(2)
+
+	initialAlloc := &butlerv1alpha1.IPAllocation{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "team-a-test-lb",
+			Namespace:         "butler-system",
+			CreationTimestamp: oldTime,
+			Labels: map[string]string{
+				butlerv1alpha1.LabelTeam:           "team-a",
+				butlerv1alpha1.LabelTenant:         "test",
+				butlerv1alpha1.LabelAllocationType: "loadbalancer",
+				LabelAllocationRole:                AllocationRoleInitial,
+			},
+		},
+		Spec: butlerv1alpha1.IPAllocationSpec{Count: &count},
+		Status: butlerv1alpha1.IPAllocationStatus{
+			Phase:        butlerv1alpha1.IPAllocationPhaseAllocated,
+			StartAddress: "10.0.0.1",
+			EndAddress:   "10.0.0.2",
+		},
+	}
+	growthAlloc := &butlerv1alpha1.IPAllocation{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "team-a-test-lb-1",
+			Namespace:         "butler-system",
+			CreationTimestamp: oldTime,
+			Labels: map[string]string{
+				butlerv1alpha1.LabelTeam:           "team-a",
+				butlerv1alpha1.LabelTenant:         "test",
+				butlerv1alpha1.LabelAllocationType: "loadbalancer",
+				LabelAllocationRole:                AllocationRoleGrowth,
+			},
+		},
+		Spec: butlerv1alpha1.IPAllocationSpec{Count: &count},
+		Status: butlerv1alpha1.IPAllocationStatus{
+			Phase:        butlerv1alpha1.IPAllocationPhaseAllocated,
+			StartAddress: "10.0.0.3",
+			EndAddress:   "10.0.0.4",
+		},
+	}
+
+	cl := fakeclient.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(initialAlloc, growthAlloc).
+		Build()
+	r := &Reconciler{Client: cl}
+	tc := &butlerv1alpha1.TenantCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "team-a"},
+	}
+
+	// Simulate shrink: delete the growth allocation
+	if err := cl.Delete(context.Background(), growthAlloc); err != nil {
+		t.Fatalf("failed to delete growth allocation: %v", err)
+	}
+
+	// Now re-fetch — this is what the fix does
+	freshAllocs, err := r.listLBAllocations(context.Background(), tc)
+	if err != nil {
+		t.Fatalf("listLBAllocations() error = %v", err)
+	}
+
+	// The deleted allocation should not appear in the fresh list
+	for _, alloc := range freshAllocs {
+		if alloc.Name == "team-a-test-lb-1" {
+			t.Error("deleted growth allocation still appears in fresh list")
+		}
+	}
+	if len(freshAllocs) != 1 {
+		t.Errorf("expected 1 allocation after shrink, got %d", len(freshAllocs))
+	}
+}
+
+func TestMigrateAllocationRoleLabels(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = butlerv1alpha1.AddToScheme(scheme)
+
+	tc := &butlerv1alpha1.TenantCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "mycluster", Namespace: "team-x"},
+	}
+
+	count := int32(2)
+	oldTime := metav1.NewTime(time.Now().Add(-10 * time.Minute))
+
+	// Create unlabeled allocations: one initial pattern, two growth patterns
+	initialAlloc := &butlerv1alpha1.IPAllocation{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "team-x-mycluster-lb",
+			Namespace:         "butler-system",
+			CreationTimestamp: oldTime,
+			Labels: map[string]string{
+				butlerv1alpha1.LabelTeam:           "team-x",
+				butlerv1alpha1.LabelTenant:         "mycluster",
+				butlerv1alpha1.LabelAllocationType: "loadbalancer",
+				// No allocation-role label — needs migration
+			},
+		},
+		Spec:   butlerv1alpha1.IPAllocationSpec{Count: &count},
+		Status: butlerv1alpha1.IPAllocationStatus{Phase: butlerv1alpha1.IPAllocationPhaseAllocated},
+	}
+	growth1 := &butlerv1alpha1.IPAllocation{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "team-x-mycluster-lb-1",
+			Namespace:         "butler-system",
+			CreationTimestamp: oldTime,
+			Labels: map[string]string{
+				butlerv1alpha1.LabelTeam:           "team-x",
+				butlerv1alpha1.LabelTenant:         "mycluster",
+				butlerv1alpha1.LabelAllocationType: "loadbalancer",
+			},
+		},
+		Spec:   butlerv1alpha1.IPAllocationSpec{Count: &count},
+		Status: butlerv1alpha1.IPAllocationStatus{Phase: butlerv1alpha1.IPAllocationPhaseAllocated},
+	}
+	growth2 := &butlerv1alpha1.IPAllocation{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "team-x-mycluster-lb-2",
+			Namespace:         "butler-system",
+			CreationTimestamp: oldTime,
+			Labels: map[string]string{
+				butlerv1alpha1.LabelTeam:           "team-x",
+				butlerv1alpha1.LabelTenant:         "mycluster",
+				butlerv1alpha1.LabelAllocationType: "loadbalancer",
+			},
+		},
+		Spec:   butlerv1alpha1.IPAllocationSpec{Count: &count},
+		Status: butlerv1alpha1.IPAllocationStatus{Phase: butlerv1alpha1.IPAllocationPhaseAllocated},
+	}
+
+	cl := fakeclient.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(initialAlloc, growth1, growth2).
+		Build()
+	r := &Reconciler{Client: cl}
+
+	allocs := []butlerv1alpha1.IPAllocation{*initialAlloc, *growth1, *growth2}
+	r.migrateAllocationRoleLabels(context.Background(), allocs, tc)
+
+	// Verify the initial allocation got labeled correctly
+	updated := &butlerv1alpha1.IPAllocation{}
+	if err := cl.Get(context.Background(), client.ObjectKeyFromObject(initialAlloc), updated); err != nil {
+		t.Fatalf("failed to get initial allocation: %v", err)
+	}
+	if updated.Labels[LabelAllocationRole] != AllocationRoleInitial {
+		t.Errorf("expected initial allocation role=%q, got %q",
+			AllocationRoleInitial, updated.Labels[LabelAllocationRole])
+	}
+
+	// Verify growth allocations got labeled correctly
+	for _, name := range []string{"team-x-mycluster-lb-1", "team-x-mycluster-lb-2"} {
+		g := &butlerv1alpha1.IPAllocation{}
+		if err := cl.Get(context.Background(), client.ObjectKey{Name: name, Namespace: "butler-system"}, g); err != nil {
+			t.Fatalf("failed to get %s: %v", name, err)
+		}
+		if g.Labels[LabelAllocationRole] != AllocationRoleGrowth {
+			t.Errorf("%s: expected growth allocation role=%q, got %q",
+				name, AllocationRoleGrowth, g.Labels[LabelAllocationRole])
+		}
+	}
+}
+
+func TestMigrateAllocationRoleLabels_AlreadyLabeled(t *testing.T) {
+	// Verify migration is a no-op for already-labeled allocations
+	scheme := runtime.NewScheme()
+	_ = butlerv1alpha1.AddToScheme(scheme)
+
+	tc := &butlerv1alpha1.TenantCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "team-a"},
+	}
+	count := int32(2)
+
+	alloc := &butlerv1alpha1.IPAllocation{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "team-a-test-lb",
+			Namespace: "butler-system",
+			Labels: map[string]string{
+				LabelAllocationRole: AllocationRoleInitial,
+			},
+		},
+		Spec: butlerv1alpha1.IPAllocationSpec{Count: &count},
+	}
+
+	cl := fakeclient.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(alloc).
+		Build()
+	r := &Reconciler{Client: cl}
+
+	allocs := []butlerv1alpha1.IPAllocation{*alloc}
+	r.migrateAllocationRoleLabels(context.Background(), allocs, tc)
+
+	updated := &butlerv1alpha1.IPAllocation{}
+	if err := cl.Get(context.Background(), client.ObjectKeyFromObject(alloc), updated); err != nil {
+		t.Fatalf("failed to get allocation: %v", err)
+	}
+	if updated.Labels[LabelAllocationRole] != AllocationRoleInitial {
+		t.Errorf("label changed unexpectedly: got %q", updated.Labels[LabelAllocationRole])
+	}
+}
+
+func TestGrowthSuffixPattern(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  bool
+	}{
+		{"initial (no suffix)", "team-a-cluster-lb", false},
+		{"growth -1", "team-a-cluster-lb-1", true},
+		{"growth -12", "team-a-cluster-lb-12", true},
+		{"growth -0", "team-a-cluster-lb-0", true},
+		{"not a number suffix", "team-a-cluster-lb-abc", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := growthSuffixPattern.MatchString(tt.input)
+			if got != tt.want {
+				t.Errorf("growthSuffixPattern.MatchString(%q) = %v, want %v",
+					tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCreationLabelsInitialAndGrowth(t *testing.T) {
+	// Verify that the label maps used during creation include the correct
+	// allocation-role values, matching what reconcileIPAllocation and the
+	// growth path in reconcileElasticIPAM produce.
+	initialLabels := map[string]string{
+		butlerv1alpha1.LabelNetworkPool:    "pool-1",
+		butlerv1alpha1.LabelTeam:           "team-a",
+		butlerv1alpha1.LabelTenant:         "test",
+		butlerv1alpha1.LabelAllocationType: "loadbalancer",
+		LabelAllocationRole:                AllocationRoleInitial,
+	}
+	if initialLabels[LabelAllocationRole] != "initial" {
+		t.Errorf("initial label = %q, want %q", initialLabels[LabelAllocationRole], "initial")
+	}
+
+	growthLabels := map[string]string{
+		butlerv1alpha1.LabelNetworkPool:    "pool-1",
+		butlerv1alpha1.LabelTeam:           "team-a",
+		butlerv1alpha1.LabelTenant:         "test",
+		butlerv1alpha1.LabelAllocationType: "loadbalancer",
+		LabelAllocationRole:                AllocationRoleGrowth,
+	}
+	if growthLabels[LabelAllocationRole] != "growth" {
+		t.Errorf("growth label = %q, want %q", growthLabels[LabelAllocationRole], "growth")
+	}
+}
+
+// TestListLBAllocations_Labels verifies that listLBAllocations filters by the
+// correct label combination and works with the fake client.
+func TestListLBAllocations_Labels(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = butlerv1alpha1.AddToScheme(scheme)
+
+	count := int32(2)
+	matching := &butlerv1alpha1.IPAllocation{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "team-a-test-lb",
+			Namespace: "butler-system",
+			Labels: map[string]string{
+				butlerv1alpha1.LabelTeam:           "team-a",
+				butlerv1alpha1.LabelTenant:         "test",
+				butlerv1alpha1.LabelAllocationType: "loadbalancer",
+				LabelAllocationRole:                AllocationRoleInitial,
+			},
+		},
+		Spec: butlerv1alpha1.IPAllocationSpec{Count: &count},
+	}
+	nonMatching := &butlerv1alpha1.IPAllocation{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "team-b-other-lb",
+			Namespace: "butler-system",
+			Labels: map[string]string{
+				butlerv1alpha1.LabelTeam:           "team-b",
+				butlerv1alpha1.LabelTenant:         "other",
+				butlerv1alpha1.LabelAllocationType: "loadbalancer",
+			},
+		},
+		Spec: butlerv1alpha1.IPAllocationSpec{Count: &count},
+	}
+
+	cl := fakeclient.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(matching, nonMatching).
+		Build()
+	r := &Reconciler{Client: cl}
+	tc := &butlerv1alpha1.TenantCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "team-a"},
+	}
+
+	allocs, err := r.listLBAllocations(context.Background(), tc)
+	if err != nil {
+		t.Fatalf("listLBAllocations() error = %v", err)
+	}
+	if len(allocs) != 1 {
+		t.Fatalf("expected 1 matching allocation, got %d", len(allocs))
+	}
+	if allocs[0].Name != "team-a-test-lb" {
+		t.Errorf("expected allocation name team-a-test-lb, got %s", allocs[0].Name)
+	}
+}
+
+// TestReclaimSkipsInitialAllocation verifies that reclaimOrphanAllocations
+// does not discriminate by role label — it uses service IPs. This is a
+// regression guard to confirm reclaim logic is orthogonal to the role label.
+func TestReclaimSkipsInitialAllocation(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = butlerv1alpha1.AddToScheme(scheme)
+
+	oldTime := metav1.NewTime(time.Now().Add(-10 * time.Minute))
+	count := int32(1)
+
+	// Initial allocation with a service IP — should NOT be reclaimed
+	initial := &butlerv1alpha1.IPAllocation{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "team-a-test-lb",
+			Namespace:         "butler-system",
+			CreationTimestamp: oldTime,
+			Labels: map[string]string{
+				LabelAllocationRole: AllocationRoleInitial,
+			},
+		},
+		Spec: butlerv1alpha1.IPAllocationSpec{Count: &count},
+		Status: butlerv1alpha1.IPAllocationStatus{
+			Phase:        butlerv1alpha1.IPAllocationPhaseAllocated,
+			StartAddress: "10.0.0.1",
+			EndAddress:   "10.0.0.1",
+		},
+	}
+
+	cl := fakeclient.NewClientBuilder().WithScheme(scheme).WithObjects(initial).Build()
+	r := &Reconciler{Client: cl}
+
+	serviceIPs := map[string]bool{"10.0.0.1": true}
+	r.reclaimOrphanAllocations(context.Background(), []butlerv1alpha1.IPAllocation{*initial}, serviceIPs)
+
+	// Verify NOT deleted
+	err := cl.Get(context.Background(), client.ObjectKeyFromObject(initial), &butlerv1alpha1.IPAllocation{})
+	if err != nil {
+		t.Errorf("initial allocation with active service IP was deleted: %v", err)
+	}
+}
+
+func TestShrinkCandidateSelection_MultipleMixed(t *testing.T) {
+	// Test with a mix of initial, growth, pending, and young allocations
+	// to verify the full filtering logic.
+	oldTime := metav1.NewTime(time.Now().Add(-15 * time.Minute))
+	youngTime := metav1.NewTime(time.Now().Add(-2 * time.Minute))
+	count := int32(2)
+
+	allocs := []butlerv1alpha1.IPAllocation{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "team-a-c-lb",
+				Namespace:         "butler-system",
+				CreationTimestamp: oldTime,
+				Labels:            map[string]string{LabelAllocationRole: AllocationRoleInitial},
+			},
+			Spec:   butlerv1alpha1.IPAllocationSpec{Count: &count},
+			Status: butlerv1alpha1.IPAllocationStatus{Phase: butlerv1alpha1.IPAllocationPhaseAllocated},
+		},
+		{
+			// Growth but too young
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "team-a-c-lb-1",
+				Namespace:         "butler-system",
+				CreationTimestamp: youngTime,
+				Labels:            map[string]string{LabelAllocationRole: AllocationRoleGrowth},
+			},
+			Spec:   butlerv1alpha1.IPAllocationSpec{Count: &count},
+			Status: butlerv1alpha1.IPAllocationStatus{Phase: butlerv1alpha1.IPAllocationPhaseAllocated},
+		},
+		{
+			// Growth, old enough, pending phase — should be skipped
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "team-a-c-lb-2",
+				Namespace:         "butler-system",
+				CreationTimestamp: oldTime,
+				Labels:            map[string]string{LabelAllocationRole: AllocationRoleGrowth},
+			},
+			Spec:   butlerv1alpha1.IPAllocationSpec{Count: &count},
+			Status: butlerv1alpha1.IPAllocationStatus{Phase: butlerv1alpha1.IPAllocationPhasePending},
+		},
+		{
+			// Growth, old enough, allocated — this is the only valid candidate
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              "team-a-c-lb-3",
+				Namespace:         "butler-system",
+				CreationTimestamp: oldTime,
+				Labels:            map[string]string{LabelAllocationRole: AllocationRoleGrowth},
+			},
+			Spec:   butlerv1alpha1.IPAllocationSpec{Count: &count},
+			Status: butlerv1alpha1.IPAllocationStatus{Phase: butlerv1alpha1.IPAllocationPhaseAllocated},
+		},
+	}
+
+	var shrinkCandidate *butlerv1alpha1.IPAllocation
+	for i := len(allocs) - 1; i >= 0; i-- {
+		alloc := &allocs[i]
+		if alloc.Labels[LabelAllocationRole] != AllocationRoleGrowth {
+			continue
+		}
+		if alloc.Status.Phase != butlerv1alpha1.IPAllocationPhaseAllocated {
+			continue
+		}
+		if alloc.Spec.Count == nil {
+			continue
+		}
+		if time.Since(alloc.CreationTimestamp.Time) < 10*time.Minute {
+			continue
+		}
+		shrinkCandidate = alloc
+		break
+	}
+
+	if shrinkCandidate == nil {
+		t.Fatal("expected a shrink candidate")
+	}
+	if shrinkCandidate.Name != "team-a-c-lb-3" {
+		t.Errorf("expected shrink candidate team-a-c-lb-3, got %s", shrinkCandidate.Name)
+	}
+}
+
+func TestGetInitialLBPoolSize(t *testing.T) {
+	r := &Reconciler{}
+
+	t.Run("defaults to 8 for non-elastic", func(t *testing.T) {
+		tc := &butlerv1alpha1.TenantCluster{}
+		pc := &butlerv1alpha1.ProviderConfig{}
+		got := r.getInitialLBPoolSize(tc, pc)
+		if got != 8 {
+			t.Errorf("expected 8, got %d", got)
+		}
+	})
+
+	t.Run("elastic defaults to 2", func(t *testing.T) {
+		tc := &butlerv1alpha1.TenantCluster{}
+		pc := &butlerv1alpha1.ProviderConfig{
+			Spec: butlerv1alpha1.ProviderConfigSpec{
+				Network: &butlerv1alpha1.ProviderNetworkConfig{
+					LoadBalancer: &butlerv1alpha1.ProviderLBConfig{
+						AllocationMode: "elastic",
+					},
+				},
+			},
+		}
+		got := r.getInitialLBPoolSize(tc, pc)
+		if got != 2 {
+			t.Errorf("expected 2, got %d", got)
+		}
+	})
+
+	t.Run("TC override takes priority", func(t *testing.T) {
+		size := int32(4)
+		tc := &butlerv1alpha1.TenantCluster{
+			Spec: butlerv1alpha1.TenantClusterSpec{
+				Networking: butlerv1alpha1.NetworkingSpec{
+					LBPoolSize: &size,
+				},
+			},
+		}
+		pc := &butlerv1alpha1.ProviderConfig{}
+		got := r.getInitialLBPoolSize(tc, pc)
+		if got != 4 {
+			t.Errorf("expected 4, got %d", got)
+		}
+	})
+}
+
+// TestReconcileIPAllocation_InitialLabelPresent verifies that a newly created
+// IPAllocation carries the allocation-role=initial label.
+func TestReconcileIPAllocation_InitialLabelPresent(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = butlerv1alpha1.AddToScheme(scheme)
+
+	pool := &butlerv1alpha1.NetworkPool{
+		ObjectMeta: metav1.ObjectMeta{Name: "pool-1", Namespace: "butler-system"},
+		Status:     butlerv1alpha1.NetworkPoolStatus{AvailableIPs: 10},
+	}
+
+	cl := fakeclient.NewClientBuilder().WithScheme(scheme).WithObjects(pool).Build()
+	r := &Reconciler{Client: cl}
+
+	tc := &butlerv1alpha1.TenantCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "team-a"},
+		Spec:       butlerv1alpha1.TenantClusterSpec{},
+	}
+
+	pc := &butlerv1alpha1.ProviderConfig{
+		Spec: butlerv1alpha1.ProviderConfigSpec{
+			Network: &butlerv1alpha1.ProviderNetworkConfig{
+				Mode: "ipam",
+				PoolRefs: []butlerv1alpha1.PoolReference{
+					{Name: "pool-1"},
+				},
+			},
+		},
+	}
+
+	_, err := r.reconcileIPAllocation(context.Background(), tc, pc)
+	if err != nil {
+		t.Fatalf("reconcileIPAllocation() error = %v", err)
+	}
+
+	alloc := &butlerv1alpha1.IPAllocation{}
+	allocName := fmt.Sprintf("%s-%s-lb", tc.Namespace, tc.Name)
+	if err := cl.Get(context.Background(), client.ObjectKey{Name: allocName, Namespace: "butler-system"}, alloc); err != nil {
+		t.Fatalf("failed to get allocation: %v", err)
+	}
+
+	if alloc.Labels[LabelAllocationRole] != AllocationRoleInitial {
+		t.Errorf("allocation-role label = %q, want %q",
+			alloc.Labels[LabelAllocationRole], AllocationRoleInitial)
 	}
 }

--- a/internal/controller/tenantcluster/tenantcluster_controller.go
+++ b/internal/controller/tenantcluster/tenantcluster_controller.go
@@ -45,6 +45,19 @@ import (
 const (
 	ButlerConfigSingletonName = "butler"
 
+	// LabelAllocationRole distinguishes initial vs growth IPAllocations.
+	// The butler-api does not define this label yet, so it lives here until
+	// the next API release.
+	LabelAllocationRole = "butler.butlerlabs.dev/allocation-role"
+
+	// AllocationRoleInitial marks the first IPAllocation created during
+	// reconcileIPAllocation (the "seed" allocation for a new tenant).
+	AllocationRoleInitial = "initial"
+
+	// AllocationRoleGrowth marks IPAllocations created by the elastic IPAM
+	// growth path inside reconcileElasticIPAM.
+	AllocationRoleGrowth = "growth"
+
 	ReasonValidating             = "Validating"
 	ReasonValidationFailed       = "ValidationFailed"
 	ReasonTeamNotFound           = "TeamNotFound"

--- a/internal/webhook/networkpool_webhook.go
+++ b/internal/webhook/networkpool_webhook.go
@@ -19,6 +19,7 @@ package webhook
 import (
 	"context"
 	"fmt"
+	"net"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -48,7 +49,7 @@ func (v *NetworkPoolValidator) ValidateCreate(_ context.Context, obj runtime.Obj
 }
 
 // ValidateUpdate validates a NetworkPool on update.
-func (v *NetworkPoolValidator) ValidateUpdate(_ context.Context, oldObj, newObj runtime.Object) (admission.Warnings, error) {
+func (v *NetworkPoolValidator) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Object) (admission.Warnings, error) {
 	oldPool, ok := oldObj.(*butlerv1alpha1.NetworkPool)
 	if !ok {
 		return nil, fmt.Errorf("expected NetworkPool for old object, got %T", oldObj)
@@ -92,7 +93,100 @@ func (v *NetworkPoolValidator) ValidateUpdate(_ context.Context, oldObj, newObj 
 		}
 	}
 
+	// Validate tenant allocation range narrowing: if the range was narrowed,
+	// ensure no existing IPAllocations have addresses outside the new range.
+	if err := v.validateTenantAllocationNarrowing(ctx, oldPool, newPool); err != nil {
+		return nil, err
+	}
+
 	return nil, nil
+}
+
+// validateTenantAllocationNarrowing rejects narrowing of the tenant allocation
+// range when existing IPAllocations have addresses outside the proposed range.
+func (v *NetworkPoolValidator) validateTenantAllocationNarrowing(ctx context.Context, oldPool, newPool *butlerv1alpha1.NetworkPool) error {
+	if oldPool.Spec.TenantAllocation == nil || newPool.Spec.TenantAllocation == nil {
+		return nil
+	}
+
+	oldStart := oldPool.Spec.TenantAllocation.Start
+	oldEnd := oldPool.Spec.TenantAllocation.End
+	newStart := newPool.Spec.TenantAllocation.Start
+	newEnd := newPool.Spec.TenantAllocation.End
+
+	// If the range didn't change, nothing to validate
+	if oldStart == newStart && oldEnd == newEnd {
+		return nil
+	}
+
+	// Parse new range boundaries
+	newStartIP := net.ParseIP(newStart).To4()
+	newEndIP := net.ParseIP(newEnd).To4()
+	if newStartIP == nil || newEndIP == nil {
+		return nil // validation of IPs themselves is done by validatePoolSpec
+	}
+	newStartUint := ipam.IPToUint32(newStartIP)
+	newEndUint := ipam.IPToUint32(newEndIP)
+
+	// List all IPAllocations referencing this pool
+	var allocList butlerv1alpha1.IPAllocationList
+	if err := v.Client.List(ctx, &allocList, client.MatchingLabels{
+		butlerv1alpha1.LabelNetworkPool: newPool.Name,
+	}); err != nil {
+		return fmt.Errorf("failed to list IPAllocations for pool %q: %w", newPool.Name, err)
+	}
+
+	var allErrs field.ErrorList
+	for i := range allocList.Items {
+		alloc := &allocList.Items[i]
+		if alloc.Status.Phase != butlerv1alpha1.IPAllocationPhaseAllocated {
+			continue
+		}
+
+		// Check each address in the allocation
+		for _, addr := range alloc.Status.Addresses {
+			ip := net.ParseIP(addr).To4()
+			if ip == nil {
+				continue
+			}
+			ipUint := ipam.IPToUint32(ip)
+			if ipUint < newStartUint || ipUint > newEndUint {
+				allErrs = append(allErrs, field.Forbidden(
+					field.NewPath("spec", "tenantAllocation"),
+					fmt.Sprintf(
+						"cannot narrow tenant allocation range: IPAllocation %q has address %s outside the proposed range %s-%s. Migrate or delete affected allocations first",
+						alloc.Name, addr, newStart, newEnd,
+					),
+				))
+				break // one violation per allocation is enough
+			}
+		}
+
+		// Also check start/end addresses for allocations that may not have
+		// Addresses populated (belt and suspenders).
+		if len(alloc.Status.Addresses) == 0 && alloc.Status.StartAddress != "" {
+			startIP := net.ParseIP(alloc.Status.StartAddress).To4()
+			endIP := net.ParseIP(alloc.Status.EndAddress).To4()
+			if startIP != nil && endIP != nil {
+				sUint := ipam.IPToUint32(startIP)
+				eUint := ipam.IPToUint32(endIP)
+				if sUint < newStartUint || eUint > newEndUint {
+					allErrs = append(allErrs, field.Forbidden(
+						field.NewPath("spec", "tenantAllocation"),
+						fmt.Sprintf(
+							"cannot narrow tenant allocation range: IPAllocation %q has addresses %s-%s outside the proposed range %s-%s. Migrate or delete affected allocations first",
+							alloc.Name, alloc.Status.StartAddress, alloc.Status.EndAddress, newStart, newEnd,
+						),
+					))
+				}
+			}
+		}
+	}
+
+	if len(allErrs) > 0 {
+		return allErrs.ToAggregate()
+	}
+	return nil
 }
 
 // ValidateDelete validates a NetworkPool on deletion.

--- a/internal/webhook/networkpool_webhook_test.go
+++ b/internal/webhook/networkpool_webhook_test.go
@@ -1,0 +1,263 @@
+/*
+Copyright 2026 The Butler Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhook
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	butlerv1alpha1 "github.com/butlerdotdev/butler-api/api/v1alpha1"
+)
+
+func TestValidateUpdate_TenantAllocationNarrowing(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = butlerv1alpha1.AddToScheme(scheme)
+
+	// IPAllocation with addresses inside the old range but outside the proposed new range.
+	allocInRange := &butlerv1alpha1.IPAllocation{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "team-a-test-lb",
+			Namespace: "butler-system",
+			Labels: map[string]string{
+				butlerv1alpha1.LabelNetworkPool: "pool-1",
+			},
+		},
+		Status: butlerv1alpha1.IPAllocationStatus{
+			Phase:        butlerv1alpha1.IPAllocationPhaseAllocated,
+			StartAddress: "10.0.0.5",
+			EndAddress:   "10.0.0.6",
+			Addresses:    []string{"10.0.0.5", "10.0.0.6"},
+		},
+	}
+
+	tests := []struct {
+		name      string
+		allocs    []butlerv1alpha1.IPAllocation
+		oldStart  string
+		oldEnd    string
+		newStart  string
+		newEnd    string
+		wantErr   bool
+		errSubstr string
+	}{
+		{
+			name:     "narrowing with allocation outside new range rejects",
+			allocs:   []butlerv1alpha1.IPAllocation{*allocInRange},
+			oldStart: "10.0.0.1",
+			oldEnd:   "10.0.0.10",
+			newStart: "10.0.0.7",
+			newEnd:   "10.0.0.10",
+			wantErr:  true,
+			// 10.0.0.5 is outside 10.0.0.7-10.0.0.10
+			errSubstr: "cannot narrow tenant allocation range",
+		},
+		{
+			name:     "widening is allowed",
+			allocs:   []butlerv1alpha1.IPAllocation{*allocInRange},
+			oldStart: "10.0.0.3",
+			oldEnd:   "10.0.0.8",
+			newStart: "10.0.0.1",
+			newEnd:   "10.0.0.10",
+			wantErr:  false,
+		},
+		{
+			name:     "same range is allowed",
+			allocs:   []butlerv1alpha1.IPAllocation{*allocInRange},
+			oldStart: "10.0.0.1",
+			oldEnd:   "10.0.0.10",
+			newStart: "10.0.0.1",
+			newEnd:   "10.0.0.10",
+			wantErr:  false,
+		},
+		{
+			name:     "narrowing with all allocations inside new range is allowed",
+			allocs:   []butlerv1alpha1.IPAllocation{*allocInRange},
+			oldStart: "10.0.0.1",
+			oldEnd:   "10.0.0.20",
+			newStart: "10.0.0.1",
+			newEnd:   "10.0.0.10",
+			wantErr:  false,
+		},
+		{
+			name:     "narrowing with no allocations is allowed",
+			allocs:   nil,
+			oldStart: "10.0.0.1",
+			oldEnd:   "10.0.0.20",
+			newStart: "10.0.0.10",
+			newEnd:   "10.0.0.15",
+			wantErr:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			builder := fake.NewClientBuilder().WithScheme(scheme)
+			for i := range tt.allocs {
+				builder = builder.WithObjects(&tt.allocs[i])
+			}
+			cl := builder.Build()
+
+			v := &NetworkPoolValidator{Client: cl}
+
+			oldPool := &butlerv1alpha1.NetworkPool{
+				ObjectMeta: metav1.ObjectMeta{Name: "pool-1", Namespace: "butler-system"},
+				Spec: butlerv1alpha1.NetworkPoolSpec{
+					CIDR: "10.0.0.0/24",
+					TenantAllocation: &butlerv1alpha1.TenantAllocationConfig{
+						Start: tt.oldStart,
+						End:   tt.oldEnd,
+					},
+				},
+			}
+			newPool := &butlerv1alpha1.NetworkPool{
+				ObjectMeta: metav1.ObjectMeta{Name: "pool-1", Namespace: "butler-system"},
+				Spec: butlerv1alpha1.NetworkPoolSpec{
+					CIDR: "10.0.0.0/24",
+					TenantAllocation: &butlerv1alpha1.TenantAllocationConfig{
+						Start: tt.newStart,
+						End:   tt.newEnd,
+					},
+				},
+			}
+
+			_, err := v.ValidateUpdate(context.Background(), oldPool, newPool)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				if tt.errSubstr != "" && !strings.Contains(err.Error(), tt.errSubstr) {
+					t.Errorf("error %q does not contain %q", err.Error(), tt.errSubstr)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+			}
+		})
+	}
+}
+
+func TestValidateUpdate_TenantAllocationNarrowing_StartEndFallback(t *testing.T) {
+	// Test the fallback path where Addresses is empty but StartAddress/EndAddress
+	// are populated.
+	scheme := runtime.NewScheme()
+	_ = butlerv1alpha1.AddToScheme(scheme)
+
+	alloc := &butlerv1alpha1.IPAllocation{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "team-a-test-lb",
+			Namespace: "butler-system",
+			Labels: map[string]string{
+				butlerv1alpha1.LabelNetworkPool: "pool-1",
+			},
+		},
+		Status: butlerv1alpha1.IPAllocationStatus{
+			Phase:        butlerv1alpha1.IPAllocationPhaseAllocated,
+			StartAddress: "10.0.0.5",
+			EndAddress:   "10.0.0.6",
+			// Addresses is empty — exercises the fallback path
+		},
+	}
+
+	cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(alloc).Build()
+	v := &NetworkPoolValidator{Client: cl}
+
+	oldPool := &butlerv1alpha1.NetworkPool{
+		ObjectMeta: metav1.ObjectMeta{Name: "pool-1", Namespace: "butler-system"},
+		Spec: butlerv1alpha1.NetworkPoolSpec{
+			CIDR: "10.0.0.0/24",
+			TenantAllocation: &butlerv1alpha1.TenantAllocationConfig{
+				Start: "10.0.0.1",
+				End:   "10.0.0.10",
+			},
+		},
+	}
+	newPool := &butlerv1alpha1.NetworkPool{
+		ObjectMeta: metav1.ObjectMeta{Name: "pool-1", Namespace: "butler-system"},
+		Spec: butlerv1alpha1.NetworkPoolSpec{
+			CIDR: "10.0.0.0/24",
+			TenantAllocation: &butlerv1alpha1.TenantAllocationConfig{
+				Start: "10.0.0.7",
+				End:   "10.0.0.10",
+			},
+		},
+	}
+
+	_, err := v.ValidateUpdate(context.Background(), oldPool, newPool)
+	if err == nil {
+		t.Fatal("expected error for narrowing with allocation outside range, got nil")
+	}
+	if !strings.Contains(err.Error(), "cannot narrow tenant allocation range") {
+		t.Errorf("error %q does not contain expected message", err.Error())
+	}
+}
+
+func TestValidateUpdate_TenantAllocationNarrowing_PendingSkipped(t *testing.T) {
+	// Pending allocations should not block range narrowing.
+	scheme := runtime.NewScheme()
+	_ = butlerv1alpha1.AddToScheme(scheme)
+
+	alloc := &butlerv1alpha1.IPAllocation{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "team-a-test-lb",
+			Namespace: "butler-system",
+			Labels: map[string]string{
+				butlerv1alpha1.LabelNetworkPool: "pool-1",
+			},
+		},
+		Status: butlerv1alpha1.IPAllocationStatus{
+			Phase:        butlerv1alpha1.IPAllocationPhasePending,
+			StartAddress: "10.0.0.5",
+			EndAddress:   "10.0.0.6",
+			Addresses:    []string{"10.0.0.5", "10.0.0.6"},
+		},
+	}
+
+	cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(alloc).Build()
+	v := &NetworkPoolValidator{Client: cl}
+
+	oldPool := &butlerv1alpha1.NetworkPool{
+		ObjectMeta: metav1.ObjectMeta{Name: "pool-1", Namespace: "butler-system"},
+		Spec: butlerv1alpha1.NetworkPoolSpec{
+			CIDR: "10.0.0.0/24",
+			TenantAllocation: &butlerv1alpha1.TenantAllocationConfig{
+				Start: "10.0.0.1",
+				End:   "10.0.0.10",
+			},
+		},
+	}
+	newPool := &butlerv1alpha1.NetworkPool{
+		ObjectMeta: metav1.ObjectMeta{Name: "pool-1", Namespace: "butler-system"},
+		Spec: butlerv1alpha1.NetworkPoolSpec{
+			CIDR: "10.0.0.0/24",
+			TenantAllocation: &butlerv1alpha1.TenantAllocationConfig{
+				Start: "10.0.0.7",
+				End:   "10.0.0.10",
+			},
+		},
+	}
+
+	_, err := v.ValidateUpdate(context.Background(), oldPool, newPool)
+	if err != nil {
+		t.Errorf("pending allocation should not block narrowing, got error: %v", err)
+	}
+}


### PR DESCRIPTION
## Context

Three compounding bugs in elastic IPAM caused IPAllocation thrashing on tenant clusters:

- Shrink relied on Kubernetes List ordering (undefined) to identify the initial allocation, sometimes deleting it instead of growth allocations
- Orphan reclaim reused a stale allocation slice after shrink had deleted entries, causing brief MetalLB pool corruption
- Narrowing the NetworkPool tenant allocation range had no validation, orphaning existing allocations and enabling double-allocation

## Changes

- Add `butler.butlerlabs.dev/allocation-role` label (initial/growth) to IPAllocations at creation time
- Migration path: unlabeled allocations get classified by name pattern on first reconcile
- Shrink filters on role label instead of slice index — initial allocation is never a shrink candidate
- Re-fetch allocations between shrink and reclaim phases to prevent stale-data issues
- NetworkPool validating webhook rejects tenant allocation range narrowing when existing allocations fall outside the new range

Ingress-disabled behavior is unchanged by this PR. Demand-driven IPAM (allocate based on pending LoadBalancer service demand rather than eagerly on cluster creation) is tracked separately in #83.

## Test plan

- [ ] Shrink selection: verify growth allocation deleted, not initial, regardless of List ordering
- [ ] Shrink-then-reclaim: verify reclaim uses fresh allocation data
- [ ] Webhook: verify tenant range narrowing rejected when allocations exist outside new range
- [ ] Migration: verify existing unlabeled allocations get correct role labels

## Migration

Existing IPAllocations without the allocation-role label are classified by name pattern:
- `<team>-<tenant>-lb` (no numeric suffix) → `initial`
- `<team>-<tenant>-lb-<N>` → `growth`

This runs on every reconcile until all allocations are labeled. No manual intervention required.