### PR TITLE
feat(ipam): add IPAllocation watch to TenantCluster controller

### DIFF
--- a/internal/controller/tenantcluster/reconcile_ipam_test.go
+++ b/internal/controller/tenantcluster/reconcile_ipam_test.go
@@ -1324,3 +1324,76 @@ func TestReconcileIPAllocation_InitialLabelPresent(t *testing.T) {
 			alloc.Labels[LabelAllocationRole], AllocationRoleInitial)
 	}
 }
+
+func TestMapIPAllocationToTenantCluster(t *testing.T) {
+	r := &Reconciler{}
+
+	tests := []struct {
+		name     string
+		obj      client.Object
+		wantLen  int
+		wantName string
+		wantNS   string
+	}{
+		{
+			name: "valid allocation maps to tenant cluster",
+			obj: &butlerv1alpha1.IPAllocation{
+				Spec: butlerv1alpha1.IPAllocationSpec{
+					TenantClusterRef: butlerv1alpha1.NamespacedObjectReference{
+						Name:      "my-cluster",
+						Namespace: "team-alpha",
+					},
+				},
+			},
+			wantLen:  1,
+			wantName: "my-cluster",
+			wantNS:   "team-alpha",
+		},
+		{
+			name: "empty name returns nothing",
+			obj: &butlerv1alpha1.IPAllocation{
+				Spec: butlerv1alpha1.IPAllocationSpec{
+					TenantClusterRef: butlerv1alpha1.NamespacedObjectReference{
+						Name:      "",
+						Namespace: "team-alpha",
+					},
+				},
+			},
+			wantLen: 0,
+		},
+		{
+			name: "empty namespace returns nothing",
+			obj: &butlerv1alpha1.IPAllocation{
+				Spec: butlerv1alpha1.IPAllocationSpec{
+					TenantClusterRef: butlerv1alpha1.NamespacedObjectReference{
+						Name:      "my-cluster",
+						Namespace: "",
+					},
+				},
+			},
+			wantLen: 0,
+		},
+		{
+			name:    "wrong type returns nothing",
+			obj:     &corev1.ConfigMap{},
+			wantLen: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := r.mapIPAllocationToTenantCluster(context.Background(), tt.obj)
+			if len(result) != tt.wantLen {
+				t.Fatalf("got %d requests, want %d", len(result), tt.wantLen)
+			}
+			if tt.wantLen > 0 {
+				if result[0].Name != tt.wantName {
+					t.Errorf("name = %q, want %q", result[0].Name, tt.wantName)
+				}
+				if result[0].Namespace != tt.wantNS {
+					t.Errorf("namespace = %q, want %q", result[0].Namespace, tt.wantNS)
+				}
+			}
+		})
+	}
+}

--- a/internal/controller/tenantcluster/tenantcluster_controller.go
+++ b/internal/controller/tenantcluster/tenantcluster_controller.go
@@ -34,8 +34,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	butlerv1alpha1 "github.com/butlerdotdev/butler-api/api/v1alpha1"
 	"github.com/butlerdotdev/butler-controller/internal/addons"
@@ -387,9 +389,32 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&corev1.Namespace{}).
 		Owns(&corev1.Secret{}).
 		Owns(&rbacv1.RoleBinding{}).
+		Watches(&butlerv1alpha1.IPAllocation{},
+			handler.EnqueueRequestsFromMapFunc(r.mapIPAllocationToTenantCluster),
+		).
 		Named("tenantcluster").
 		WithOptions(controller.Options{
 			MaxConcurrentReconciles: r.MaxConcurrentReconciles,
 		}).
 		Complete(r)
+}
+
+// mapIPAllocationToTenantCluster maps an IPAllocation to its owning TenantCluster
+// so that IPAM state changes (Pending -> Allocated, deletion, etc.) trigger a
+// TenantCluster reconcile without waiting for the timer-based requeue.
+func (r *Reconciler) mapIPAllocationToTenantCluster(_ context.Context, obj client.Object) []reconcile.Request {
+	alloc, ok := obj.(*butlerv1alpha1.IPAllocation)
+	if !ok {
+		return nil
+	}
+	ref := alloc.Spec.TenantClusterRef
+	if ref.Name == "" || ref.Namespace == "" {
+		return nil
+	}
+	return []reconcile.Request{
+		{NamespacedName: client.ObjectKey{
+			Name:      ref.Name,
+			Namespace: ref.Namespace,
+		}},
+	}
 }


### PR DESCRIPTION
## Summary

- Add `Watches(&IPAllocation{})` to the TenantCluster controller's `SetupWithManager`, mapping IPAllocation events to their owning TenantCluster via `Spec.TenantClusterRef`
- Eliminates the 1-15 minute propagation delay for IPAM state changes (e.g., Pending -> Allocated transitions now trigger immediate reconciliation instead of waiting for timer-based requeue)
- Follows the same `EnqueueRequestsFromMapFunc` pattern used by the NetworkPool controller's IPAllocation watch

### Predicate decision

No predicate filter applied. The TenantCluster controller needs status transitions (Pending -> Allocated -> Released) to drive elastic IPAM decisions, so filtering (e.g., `GenerationChangedPredicate`) would lose required signals. Generation only increments on spec changes; status-only updates from the NetworkPool controller (which writes allocation results) would be invisible. The unfiltered watch is intentional.

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] New `TestMapIPAllocationToTenantCluster` covers: valid mapping, empty name, empty namespace, wrong object type
- [ ] Deploy to dev cluster and verify TenantCluster reconciles immediately when an IPAllocation transitions from Pending to Allocated (check controller logs for requeue source)

Refs butler-controller#83