### PR TITLE
feat(ipam): add capacity status conditions to NetworkPool

### DIFF
--- a/internal/controller/networkpool/capacity_conditions_test.go
+++ b/internal/controller/networkpool/capacity_conditions_test.go
@@ -1,0 +1,160 @@
+/*
+Copyright 2026 The Butler Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package networkpool
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	butlerv1alpha1 "github.com/butlerdotdev/butler-api/api/v1alpha1"
+)
+
+func TestSetCapacityConditions(t *testing.T) {
+	tests := []struct {
+		name         string
+		usage        float64
+		allocated    int32
+		total        int32
+		wantWarning  metav1.ConditionStatus
+		wantCritical metav1.ConditionStatus
+		wantExhaust  metav1.ConditionStatus
+	}{
+		{
+			name:         "below all thresholds",
+			usage:        50,
+			allocated:    50,
+			total:        100,
+			wantWarning:  metav1.ConditionFalse,
+			wantCritical: metav1.ConditionFalse,
+			wantExhaust:  metav1.ConditionFalse,
+		},
+		{
+			name:         "at warning threshold",
+			usage:        70,
+			allocated:    70,
+			total:        100,
+			wantWarning:  metav1.ConditionTrue,
+			wantCritical: metav1.ConditionFalse,
+			wantExhaust:  metav1.ConditionFalse,
+		},
+		{
+			name:         "between warning and critical",
+			usage:        80,
+			allocated:    80,
+			total:        100,
+			wantWarning:  metav1.ConditionTrue,
+			wantCritical: metav1.ConditionFalse,
+			wantExhaust:  metav1.ConditionFalse,
+		},
+		{
+			name:         "at critical threshold",
+			usage:        85,
+			allocated:    85,
+			total:        100,
+			wantWarning:  metav1.ConditionTrue,
+			wantCritical: metav1.ConditionTrue,
+			wantExhaust:  metav1.ConditionFalse,
+		},
+		{
+			name:         "at exhausted threshold",
+			usage:        95,
+			allocated:    95,
+			total:        100,
+			wantWarning:  metav1.ConditionTrue,
+			wantCritical: metav1.ConditionTrue,
+			wantExhaust:  metav1.ConditionTrue,
+		},
+		{
+			name:         "fully exhausted",
+			usage:        100,
+			allocated:    100,
+			total:        100,
+			wantWarning:  metav1.ConditionTrue,
+			wantCritical: metav1.ConditionTrue,
+			wantExhaust:  metav1.ConditionTrue,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pool := &butlerv1alpha1.NetworkPool{
+				ObjectMeta: metav1.ObjectMeta{Generation: 1},
+			}
+
+			setCapacityConditions(pool, tt.usage, tt.allocated, tt.total)
+
+			checkCondition(t, pool, ConditionCapacityWarning, tt.wantWarning)
+			checkCondition(t, pool, ConditionCapacityCritical, tt.wantCritical)
+			checkCondition(t, pool, ConditionCapacityExhausted, tt.wantExhaust)
+		})
+	}
+}
+
+func TestSetCapacityConditions_TransitionsCorrectly(t *testing.T) {
+	pool := &butlerv1alpha1.NetworkPool{
+		ObjectMeta: metav1.ObjectMeta{Generation: 1},
+	}
+
+	// Start above critical
+	setCapacityConditions(pool, 90, 90, 100)
+	checkCondition(t, pool, ConditionCapacityWarning, metav1.ConditionTrue)
+	checkCondition(t, pool, ConditionCapacityCritical, metav1.ConditionTrue)
+	checkCondition(t, pool, ConditionCapacityExhausted, metav1.ConditionFalse)
+
+	// Drop below all thresholds
+	setCapacityConditions(pool, 50, 50, 100)
+	checkCondition(t, pool, ConditionCapacityWarning, metav1.ConditionFalse)
+	checkCondition(t, pool, ConditionCapacityCritical, metav1.ConditionFalse)
+	checkCondition(t, pool, ConditionCapacityExhausted, metav1.ConditionFalse)
+}
+
+func TestSetCapacityConditions_Reasons(t *testing.T) {
+	pool := &butlerv1alpha1.NetworkPool{
+		ObjectMeta: metav1.ObjectMeta{Generation: 1},
+	}
+
+	setCapacityConditions(pool, 90, 90, 100)
+
+	warning := meta.FindStatusCondition(pool.Status.Conditions, ConditionCapacityWarning)
+	if warning == nil {
+		t.Fatal("CapacityWarning condition not found")
+	}
+	if warning.Reason != "UtilizationAboveThreshold" {
+		t.Errorf("warning reason = %q, want UtilizationAboveThreshold", warning.Reason)
+	}
+
+	exhausted := meta.FindStatusCondition(pool.Status.Conditions, ConditionCapacityExhausted)
+	if exhausted == nil {
+		t.Fatal("CapacityExhausted condition not found")
+	}
+	if exhausted.Reason != "UtilizationBelowThreshold" {
+		t.Errorf("exhausted reason = %q, want UtilizationBelowThreshold", exhausted.Reason)
+	}
+}
+
+func checkCondition(t *testing.T, pool *butlerv1alpha1.NetworkPool, condType string, want metav1.ConditionStatus) {
+	t.Helper()
+	cond := meta.FindStatusCondition(pool.Status.Conditions, condType)
+	if cond == nil {
+		t.Fatalf("condition %q not found", condType)
+	}
+	if cond.Status != want {
+		t.Errorf("condition %q status = %v, want %v", condType, cond.Status, want)
+	}
+}

--- a/internal/controller/networkpool/networkpool_controller.go
+++ b/internal/controller/networkpool/networkpool_controller.go
@@ -51,6 +51,15 @@ const (
 	capacityEventInterval = 10 * time.Minute
 )
 
+// Capacity condition types. These are set on NetworkPool.Status.Conditions
+// to surface utilization state to integrations (kubectl, ArgoCD, Flux, etc.).
+// Intended for promotion to butler-api once the thresholds are validated.
+const (
+	ConditionCapacityWarning   = "CapacityWarning"
+	ConditionCapacityCritical  = "CapacityCritical"
+	ConditionCapacityExhausted = "CapacityExhausted"
+)
+
 // Reconciler reconciles a NetworkPool object.
 // It is the sole allocator -- it processes Pending IPAllocations.
 type Reconciler struct {
@@ -430,6 +439,13 @@ func (r *Reconciler) updatePoolStatus(ctx context.Context, pool *butlerv1alpha1.
 		ObservedGeneration: pool.Generation,
 	})
 
+	// Set capacity tier conditions based on utilization thresholds.
+	// Each condition is True when utilization exceeds its threshold.
+	if totalIPs > 0 {
+		usagePercent := float64(allocatedIPs) / float64(totalIPs) * 100
+		setCapacityConditions(pool, usagePercent, allocatedIPs, totalIPs)
+	}
+
 	// Update Prometheus metrics
 	labels := []string{pool.Name, pool.Namespace}
 	poolTotalIPs.WithLabelValues(labels...).Set(float64(totalIPs))
@@ -513,6 +529,37 @@ func (r *Reconciler) hasPreviousEvent(poolName string) bool {
 	return false
 }
 
+// setCapacityConditions sets CapacityWarning, CapacityCritical, and
+// CapacityExhausted conditions based on pool utilization thresholds.
+func setCapacityConditions(pool *butlerv1alpha1.NetworkPool, usagePercent float64, allocated, total int32) {
+	msg := fmt.Sprintf("Pool utilization is %.0f%% (%d/%d IPs)", usagePercent, allocated, total)
+
+	thresholds := []struct {
+		condType  string
+		threshold float64
+	}{
+		{ConditionCapacityWarning, 70},
+		{ConditionCapacityCritical, 85},
+		{ConditionCapacityExhausted, 95},
+	}
+
+	for _, t := range thresholds {
+		status := metav1.ConditionFalse
+		reason := "UtilizationBelowThreshold"
+		if usagePercent >= t.threshold {
+			status = metav1.ConditionTrue
+			reason = "UtilizationAboveThreshold"
+		}
+
+		meta.SetStatusCondition(&pool.Status.Conditions, metav1.Condition{
+			Type:               t.condType,
+			Status:             status,
+			Reason:             reason,
+			Message:            msg,
+			ObservedGeneration: pool.Generation,
+		})
+	}
+}
 // gcOrphanedAllocations deletes IPAllocations whose tenantClusterRef points
 // to a TenantCluster that no longer exists. Returns the number of allocations deleted.
 func (r *Reconciler) gcOrphanedAllocations(ctx context.Context, pool *butlerv1alpha1.NetworkPool, allocList *butlerv1alpha1.IPAllocationList) int {


### PR DESCRIPTION
## Summary

- Add `CapacityWarning` (70%), `CapacityCritical` (85%), and `CapacityExhausted` (95%) conditions to `NetworkPool.Status.Conditions`
- Each condition is always present (True or False), with stable reason strings and utilization details in the message
- Consumable by kubectl, ArgoCD health checks, Flux kstatus, butler-console, or any CRD status reader
- Condition type constants defined locally, intended for promotion to butler-api once validated

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] New `TestSetCapacityConditions` covers all threshold boundaries (below, at 70%, 80%, 85%, 95%, 100%)
- [x] `TestSetCapacityConditions_TransitionsCorrectly` verifies conditions flip from True to False correctly
- [x] `TestSetCapacityConditions_Reasons` verifies reason strings match threshold state
- [ ] Deploy to dev cluster and verify conditions appear via `kubectl get networkpool -o yaml`
- [ ] Verify `lastTransitionTime` only updates when crossing a threshold

Refs butler-controller#83