### PR TITLE
feat(ipam): add tenant LB Service inventory

### DIFF
--- a/internal/controller/tenantcluster/reconcile_ipam.go
+++ b/internal/controller/tenantcluster/reconcile_ipam.go
@@ -385,39 +385,91 @@ func (r *Reconciler) listLBAllocations(ctx context.Context, tc *butlerv1alpha1.T
 	return allocList.Items, nil
 }
 
-// countLBIPs counts LoadBalancer services with assigned IPs on a tenant cluster,
-// returning separate counts for platform-managed LBs and tenant workload LBs.
-// Platform LBs (labeled with LabelPlatformLB) consume pool capacity but should not
-// be treated as tenant workload demand for growth/shrink decisions.
-// Also returns the set of all assigned LB IPs for use in orphan detection.
-func (r *Reconciler) countLBIPs(ctx context.Context, tc *tenant.TenantClient) (platformCount, tenantCount int32, serviceIPs map[string]bool, err error) {
+// LBServiceSummary is a lightweight representation of a LoadBalancer Service
+// on a tenant cluster. Used by the Service inventory to track Pending services
+// that PR 6 will use for demand-driven growth decisions.
+type LBServiceSummary struct {
+	Name      string
+	Namespace string
+	CreatedAt time.Time
+}
+
+// LBServiceInventory is a snapshot of LoadBalancer Service state on a tenant
+// cluster. Built from a single cross-cluster list call per reconcile.
+// countLBIPs delegates to this for backwards compatibility with the existing
+// arithmetic growth/shrink logic. PR 6 will consume the full inventory for
+// demand-driven growth decisions.
+type LBServiceInventory struct {
+	// PendingServices are LB Services without an assigned external IP.
+	PendingServices []LBServiceSummary
+
+	// AssignedPlatformCount is the number of platform-labeled LB Services
+	// with at least one assigned external IP.
+	AssignedPlatformCount int32
+
+	// AssignedTenantCount is the number of non-platform LB Services with
+	// at least one assigned external IP.
+	AssignedTenantCount int32
+
+	// ServiceIPs is the set of all external IPs assigned to LB Services.
+	// Used by orphan detection to identify allocations with no matching service.
+	ServiceIPs map[string]bool
+}
+
+// buildLBServiceInventory fetches all Services from a tenant cluster and
+// returns a structured inventory of LoadBalancer Services. This is the single
+// cross-cluster read that growth, shrink, and orphan detection consume.
+func buildLBServiceInventory(ctx context.Context, tc *tenant.TenantClient) (*LBServiceInventory, error) {
 	svcList, err := tc.Clientset.CoreV1().Services("").List(ctx, metav1.ListOptions{})
 	if err != nil {
-		return 0, 0, nil, fmt.Errorf("failed to list services: %w", err)
+		return nil, fmt.Errorf("failed to list services: %w", err)
 	}
 
-	serviceIPs = make(map[string]bool)
+	inv := &LBServiceInventory{
+		ServiceIPs: make(map[string]bool),
+	}
+
 	for _, svc := range svcList.Items {
 		if svc.Spec.Type != corev1.ServiceTypeLoadBalancer {
 			continue
 		}
-		hasIP := false
+
+		var hasIP bool
 		for _, ing := range svc.Status.LoadBalancer.Ingress {
 			if ing.IP != "" {
-				serviceIPs[ing.IP] = true
+				inv.ServiceIPs[ing.IP] = true
 				hasIP = true
 			}
 		}
+
 		if !hasIP {
+			inv.PendingServices = append(inv.PendingServices, LBServiceSummary{
+				Name:      svc.Name,
+				Namespace: svc.Namespace,
+				CreatedAt: svc.CreationTimestamp.Time,
+			})
 			continue
 		}
+
 		if svc.Labels[butlerv1alpha1.LabelPlatformLB] == "true" {
-			platformCount++
+			inv.AssignedPlatformCount++
 		} else {
-			tenantCount++
+			inv.AssignedTenantCount++
 		}
 	}
-	return platformCount, tenantCount, serviceIPs, nil
+
+	return inv, nil
+}
+
+// countLBIPs counts LoadBalancer services with assigned IPs on a tenant cluster,
+// returning separate counts for platform-managed LBs and tenant workload LBs.
+// Delegates to buildLBServiceInventory for the cross-cluster read.
+func (r *Reconciler) countLBIPs(ctx context.Context, tc *tenant.TenantClient) (platformCount, tenantCount int32, serviceIPs map[string]bool, err error) {
+	inv, err := buildLBServiceInventory(ctx, tc)
+	if err != nil {
+		return 0, 0, nil, err
+	}
+	return inv.AssignedPlatformCount, inv.AssignedTenantCount, inv.ServiceIPs, nil
 }
 
 // ensurePlatformLBLabels ensures the Traefik service on a tenant cluster has the platform-lb

--- a/internal/controller/tenantcluster/reconcile_ipam_test.go
+++ b/internal/controller/tenantcluster/reconcile_ipam_test.go
@@ -467,6 +467,232 @@ func TestCountLBIPs_ServiceIPs(t *testing.T) {
 	}
 }
 
+func TestBuildLBServiceInventory(t *testing.T) {
+	tests := []struct {
+		name                 string
+		services             []corev1.Service
+		wantPendingCount     int
+		wantAssignedPlatform int32
+		wantAssignedTenant   int32
+		wantServiceIPCount   int
+	}{
+		{
+			name:                 "empty cluster",
+			services:             nil,
+			wantPendingCount:     0,
+			wantAssignedPlatform: 0,
+			wantAssignedTenant:   0,
+			wantServiceIPCount:   0,
+		},
+		{
+			name: "ClusterIP services filtered out",
+			services: []corev1.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "web", Namespace: "default"},
+					Spec:       corev1.ServiceSpec{Type: corev1.ServiceTypeClusterIP},
+				},
+			},
+			wantPendingCount:     0,
+			wantAssignedPlatform: 0,
+			wantAssignedTenant:   0,
+			wantServiceIPCount:   0,
+		},
+		{
+			name: "pending LB service captured",
+			services: []corev1.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "new-svc",
+						Namespace:         "default",
+						CreationTimestamp: metav1.NewTime(time.Now().Add(-45 * time.Second)),
+					},
+					Spec:   corev1.ServiceSpec{Type: corev1.ServiceTypeLoadBalancer},
+					Status: corev1.ServiceStatus{},
+				},
+			},
+			wantPendingCount:     1,
+			wantAssignedPlatform: 0,
+			wantAssignedTenant:   0,
+			wantServiceIPCount:   0,
+		},
+		{
+			name: "assigned tenant LB counted",
+			services: []corev1.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "app-lb", Namespace: "default"},
+					Spec:       corev1.ServiceSpec{Type: corev1.ServiceTypeLoadBalancer},
+					Status: corev1.ServiceStatus{
+						LoadBalancer: corev1.LoadBalancerStatus{
+							Ingress: []corev1.LoadBalancerIngress{{IP: "10.0.0.1"}},
+						},
+					},
+				},
+			},
+			wantPendingCount:     0,
+			wantAssignedPlatform: 0,
+			wantAssignedTenant:   1,
+			wantServiceIPCount:   1,
+		},
+		{
+			name: "assigned platform LB counted",
+			services: []corev1.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "traefik",
+						Namespace: "traefik",
+						Labels:    map[string]string{butlerv1alpha1.LabelPlatformLB: "true"},
+					},
+					Spec: corev1.ServiceSpec{Type: corev1.ServiceTypeLoadBalancer},
+					Status: corev1.ServiceStatus{
+						LoadBalancer: corev1.LoadBalancerStatus{
+							Ingress: []corev1.LoadBalancerIngress{{IP: "10.0.0.2"}},
+						},
+					},
+				},
+			},
+			wantPendingCount:     0,
+			wantAssignedPlatform: 1,
+			wantAssignedTenant:   0,
+			wantServiceIPCount:   1,
+		},
+		{
+			name: "mixed: platform, tenant, pending, and non-LB",
+			services: []corev1.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "traefik",
+						Namespace: "traefik",
+						Labels:    map[string]string{butlerv1alpha1.LabelPlatformLB: "true"},
+					},
+					Spec: corev1.ServiceSpec{Type: corev1.ServiceTypeLoadBalancer},
+					Status: corev1.ServiceStatus{
+						LoadBalancer: corev1.LoadBalancerStatus{
+							Ingress: []corev1.LoadBalancerIngress{{IP: "10.0.0.1"}},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "app", Namespace: "default"},
+					Spec:       corev1.ServiceSpec{Type: corev1.ServiceTypeLoadBalancer},
+					Status: corev1.ServiceStatus{
+						LoadBalancer: corev1.LoadBalancerStatus{
+							Ingress: []corev1.LoadBalancerIngress{{IP: "10.0.0.2"}},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "pending-svc",
+						Namespace:         "default",
+						CreationTimestamp: metav1.NewTime(time.Now().Add(-2 * time.Minute)),
+					},
+					Spec:   corev1.ServiceSpec{Type: corev1.ServiceTypeLoadBalancer},
+					Status: corev1.ServiceStatus{},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "internal", Namespace: "default"},
+					Spec:       corev1.ServiceSpec{Type: corev1.ServiceTypeClusterIP},
+				},
+			},
+			wantPendingCount:     1,
+			wantAssignedPlatform: 1,
+			wantAssignedTenant:   1,
+			wantServiceIPCount:   2,
+		},
+		{
+			name: "multiple pending services tracked separately",
+			services: []corev1.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "svc-a",
+						Namespace:         "default",
+						CreationTimestamp: metav1.NewTime(time.Now().Add(-5 * time.Minute)),
+					},
+					Spec:   corev1.ServiceSpec{Type: corev1.ServiceTypeLoadBalancer},
+					Status: corev1.ServiceStatus{},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "svc-b",
+						Namespace:         "other",
+						CreationTimestamp: metav1.NewTime(time.Now().Add(-10 * time.Second)),
+					},
+					Spec:   corev1.ServiceSpec{Type: corev1.ServiceTypeLoadBalancer},
+					Status: corev1.ServiceStatus{},
+				},
+			},
+			wantPendingCount:     2,
+			wantAssignedPlatform: 0,
+			wantAssignedTenant:   0,
+			wantServiceIPCount:   0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clientset := fake.NewSimpleClientset()
+			for i := range tt.services {
+				_, err := clientset.CoreV1().Services(tt.services[i].Namespace).Create(
+					context.Background(), &tt.services[i], metav1.CreateOptions{})
+				if err != nil {
+					t.Fatalf("failed to create test service: %v", err)
+				}
+			}
+
+			tc := &tenant.TenantClient{Clientset: clientset}
+			inv, err := buildLBServiceInventory(context.Background(), tc)
+			if err != nil {
+				t.Fatalf("buildLBServiceInventory() error = %v", err)
+			}
+			if len(inv.PendingServices) != tt.wantPendingCount {
+				t.Errorf("PendingServices count = %d, want %d", len(inv.PendingServices), tt.wantPendingCount)
+			}
+			if inv.AssignedPlatformCount != tt.wantAssignedPlatform {
+				t.Errorf("AssignedPlatformCount = %d, want %d", inv.AssignedPlatformCount, tt.wantAssignedPlatform)
+			}
+			if inv.AssignedTenantCount != tt.wantAssignedTenant {
+				t.Errorf("AssignedTenantCount = %d, want %d", inv.AssignedTenantCount, tt.wantAssignedTenant)
+			}
+			if len(inv.ServiceIPs) != tt.wantServiceIPCount {
+				t.Errorf("ServiceIPs count = %d, want %d", len(inv.ServiceIPs), tt.wantServiceIPCount)
+			}
+		})
+	}
+}
+
+func TestBuildLBServiceInventory_PendingMetadata(t *testing.T) {
+	createdAt := time.Now().Add(-90 * time.Second)
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "my-svc",
+			Namespace:         "my-ns",
+			CreationTimestamp: metav1.NewTime(createdAt),
+		},
+		Spec:   corev1.ServiceSpec{Type: corev1.ServiceTypeLoadBalancer},
+		Status: corev1.ServiceStatus{},
+	}
+
+	clientset := fake.NewSimpleClientset(svc)
+	tc := &tenant.TenantClient{Clientset: clientset}
+	inv, err := buildLBServiceInventory(context.Background(), tc)
+	if err != nil {
+		t.Fatalf("buildLBServiceInventory() error = %v", err)
+	}
+	if len(inv.PendingServices) != 1 {
+		t.Fatalf("expected 1 pending service, got %d", len(inv.PendingServices))
+	}
+	ps := inv.PendingServices[0]
+	if ps.Name != "my-svc" {
+		t.Errorf("Name = %q, want %q", ps.Name, "my-svc")
+	}
+	if ps.Namespace != "my-ns" {
+		t.Errorf("Namespace = %q, want %q", ps.Namespace, "my-ns")
+	}
+	if ps.CreatedAt.IsZero() {
+		t.Error("CreatedAt is zero")
+	}
+}
+
 func TestAllocationHasServiceIP(t *testing.T) {
 	tests := []struct {
 		name       string


### PR DESCRIPTION
## Summary

Adds `LBServiceInventory` type and `buildLBServiceInventory` function that captures the full state of LoadBalancer Services on a tenant cluster in a single cross-cluster list call:

- **Pending services** (type=LoadBalancer, no external IP) with name, namespace, and creation timestamp
- **Assigned platform/tenant counts** (same split as existing `countLBIPs`)
- **Service IP set** (for orphan detection, same as existing)

Refactors `countLBIPs` to delegate to the new inventory function. External behavior is unchanged.

## What this does NOT change

The existing arithmetic-based growth/shrink logic (`availableIPs < 1` / `availableIPs >= growthIncrement`) continues to run unmodified. This PR is plumbing only. PRs 6 (demand-driven growth) and 7 (demand-driven shrink) will consume the full inventory to replace the arithmetic triggers.

## How tested

- 9 new unit tests for `buildLBServiceInventory` (table-driven + metadata verification)
- All 20 existing `reconcile_ipam_test.go` tests pass as regression coverage
- `go build ./...` and `go vet ./...` clean

Refs #83