### PR TITLE
feat(ipam): demand-driven shrink (ADR-016 Phase 2, PR 7)

### DIFF
--- a/internal/controller/tenantcluster/reconcile_ipam.go
+++ b/internal/controller/tenantcluster/reconcile_ipam.go
@@ -26,6 +26,12 @@ import (
 // with MetalLB's normal IP assignment, which typically completes in seconds.
 const pendingServiceMinAge = 30 * time.Second
 
+// shrinkGracePeriod is the minimum age a growth allocation must reach before
+// it can be released for having no matching tenant LB Service. This prevents
+// releasing allocations that were just created and haven't propagated to
+// MetalLB yet, or whose Services were briefly restarted.
+const shrinkGracePeriod = 10 * time.Minute
+
 // growthSuffixPattern matches the "-N" suffix on growth allocation names.
 var growthSuffixPattern = regexp.MustCompile(`-\d+$`)
 
@@ -225,13 +231,11 @@ func (r *Reconciler) reconcileElasticIPAM(ctx context.Context, tc *butlerv1alpha
 	tenantCount := inv.AssignedTenantCount
 	serviceIPs := inv.ServiceIPs
 
-	availableIPs := totalAllocated - platformCount - tenantCount
 	growthIncrement := r.getGrowthIncrement(pc)
 
 	logger.V(1).Info("elastic IPAM status",
 		"totalAllocated", totalAllocated, "platformLBs", platformCount,
-		"tenantLBs", tenantCount, "availableIPs", availableIPs,
-		"growthIncrement", growthIncrement,
+		"tenantLBs", tenantCount, "growthIncrement", growthIncrement,
 		"pendingLBServices", len(inv.PendingServices))
 
 	// Grow: demand-driven — allocate when tenant LB Services are stuck Pending
@@ -313,49 +317,47 @@ func (r *Reconciler) reconcileElasticIPAM(ctx context.Context, tc *butlerv1alpha
 		}
 	}
 
-	// Shrink: if we have more than 1 allocation and at least one growth-increment of spare capacity.
-	// Only growth allocations are shrink candidates — the initial allocation is never deleted
-	// regardless of its position in the List result (Kubernetes List ordering is undefined).
-	if len(allocs) > 1 && availableIPs >= growthIncrement {
-		var shrinkCandidate *butlerv1alpha1.IPAllocation
-		for i := len(allocs) - 1; i >= 0; i-- {
-			alloc := &allocs[i]
-			if alloc.Labels[LabelAllocationRole] != AllocationRoleGrowth {
-				continue
-			}
-			if alloc.Status.Phase != butlerv1alpha1.IPAllocationPhaseAllocated {
-				continue
-			}
-			if alloc.Spec.Count == nil {
-				continue
-			}
-			// Only shrink allocations older than 10 minutes to avoid thrashing
-			if time.Since(alloc.CreationTimestamp.Time) < 10*time.Minute {
-				continue
-			}
-			shrinkCandidate = alloc
-			break
+	// Shrink: demand-driven — release growth allocations whose IPs are not in
+	// use by any tenant LB Service for longer than the grace period. Only growth
+	// allocations are candidates; the initial allocation is never released. This
+	// replaces both the old arithmetic shrink and the separate orphan reclaim
+	// into a single demand-driven mechanism (ADR-016).
+	var shrunk bool
+	for i := range allocs {
+		alloc := &allocs[i]
+		if alloc.Labels[LabelAllocationRole] != AllocationRoleGrowth {
+			continue
 		}
-
-		if shrinkCandidate != nil {
-			logger.Info("elastic IPAM: shrinking unused allocation",
-				"allocation", shrinkCandidate.Name, "availableIPs", availableIPs)
-			if err := r.Delete(ctx, shrinkCandidate); err != nil && !apierrors.IsNotFound(err) {
-				return fmt.Errorf("failed to delete shrink allocation: %w", err)
-			}
+		if alloc.Status.Phase != butlerv1alpha1.IPAllocationPhaseAllocated {
+			continue
 		}
+		if time.Since(alloc.CreationTimestamp.Time) < shrinkGracePeriod {
+			continue
+		}
+		if allocationHasServiceIP(alloc, serviceIPs) {
+			continue
+		}
+		logger.Info("elastic IPAM: releasing unused growth allocation",
+			"allocation", alloc.Name,
+			"start", alloc.Status.StartAddress,
+			"end", alloc.Status.EndAddress,
+			"age", time.Since(alloc.CreationTimestamp.Time).Round(time.Second))
+		if err := r.Delete(ctx, alloc); err != nil && !apierrors.IsNotFound(err) {
+			logger.Error(err, "failed to delete unused growth allocation", "allocation", alloc.Name)
+			continue
+		}
+		shrunk = true
 	}
 
-	// Re-fetch allocations to get a fresh slice. The shrink phase above may
-	// have deleted an allocation, so the original slice is stale. Using stale
-	// data for reclaim or MetalLB pool updates causes brief pool corruption.
-	allocs, err = r.listLBAllocations(ctx, tc)
-	if err != nil {
-		return fmt.Errorf("failed to re-list LB allocations after shrink: %w", err)
+	// Re-fetch allocations if any were deleted. The shrink phase above may have
+	// deleted allocations, so the original slice is stale. Using stale data for
+	// the MetalLB pool update causes brief pool corruption.
+	if shrunk {
+		allocs, err = r.listLBAllocations(ctx, tc)
+		if err != nil {
+			return fmt.Errorf("failed to re-list LB allocations after shrink: %w", err)
+		}
 	}
-
-	// Reclaim orphan allocations whose IPs are not used by any service on the tenant
-	r.reclaimOrphanAllocations(ctx, allocs, serviceIPs)
 
 	// Update MetalLB pool with all current allocated ranges
 	if err := r.updateMetalLBPool(ctx, tc, butlerConfig, allocs); err != nil {
@@ -521,36 +523,6 @@ func (r *Reconciler) ensurePlatformLBLabels(ctx context.Context, tc *tenant.Tena
 	svc.Labels[butlerv1alpha1.LabelPlatformLB] = "true"
 	if _, err := tc.Clientset.CoreV1().Services("traefik").Update(ctx, svc, metav1.UpdateOptions{}); err != nil {
 		logger.V(1).Info("ensurePlatformLBLabels: failed to patch label", "error", err)
-	}
-}
-
-// reclaimOrphanAllocations deletes IPAllocations whose IPs are not used by any
-// LoadBalancer service on the tenant cluster. Only allocations older than 5 minutes
-// are considered, to avoid racing normal allocation propagation.
-func (r *Reconciler) reclaimOrphanAllocations(ctx context.Context, allocs []butlerv1alpha1.IPAllocation, serviceIPs map[string]bool) {
-	logger := log.FromContext(ctx)
-
-	const orphanGracePeriod = 5 * time.Minute
-
-	for i := range allocs {
-		alloc := &allocs[i]
-		if alloc.Status.Phase != butlerv1alpha1.IPAllocationPhaseAllocated {
-			continue
-		}
-		if time.Since(alloc.CreationTimestamp.Time) < orphanGracePeriod {
-			continue
-		}
-		if allocationHasServiceIP(alloc, serviceIPs) {
-			continue
-		}
-		logger.Info("reclaiming orphan IPAllocation",
-			"allocation", alloc.Name,
-			"start", alloc.Status.StartAddress,
-			"end", alloc.Status.EndAddress,
-			"age", time.Since(alloc.CreationTimestamp.Time).Round(time.Second))
-		if err := r.Delete(ctx, alloc); err != nil && !apierrors.IsNotFound(err) {
-			logger.Error(err, "failed to delete orphan IPAllocation", "allocation", alloc.Name)
-		}
 	}
 }
 

--- a/internal/controller/tenantcluster/reconcile_ipam_test.go
+++ b/internal/controller/tenantcluster/reconcile_ipam_test.go
@@ -1145,234 +1145,205 @@ func TestAllocationHasServiceIP(t *testing.T) {
 	}
 }
 
-func TestReclaimOrphanAllocations(t *testing.T) {
+func TestDemandDrivenShrink(t *testing.T) {
+	// Validates the demand-driven shrink logic: growth allocations whose IPs
+	// are not in use by any tenant LB Service for longer than the grace period
+	// get released. Initial allocations are never released.
 	scheme := runtime.NewScheme()
 	_ = butlerv1alpha1.AddToScheme(scheme)
 
-	oldTime := metav1.NewTime(time.Now().Add(-10 * time.Minute))
-	newTime := metav1.NewTime(time.Now().Add(-2 * time.Minute))
+	oldTime := metav1.NewTime(time.Now().Add(-15 * time.Minute))
+	youngTime := metav1.NewTime(time.Now().Add(-5 * time.Minute))
 	count := int32(1)
 
-	t.Run("reclaims allocation with no matching service IP", func(t *testing.T) {
-		alloc := &butlerv1alpha1.IPAllocation{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:              "test-orphan",
-				Namespace:         "butler-system",
-				CreationTimestamp: oldTime,
-			},
-			Spec: butlerv1alpha1.IPAllocationSpec{Count: &count},
-			Status: butlerv1alpha1.IPAllocationStatus{
-				Phase:        butlerv1alpha1.IPAllocationPhaseAllocated,
-				StartAddress: "10.0.0.5",
-				EndAddress:   "10.0.0.5",
-			},
-		}
-
-		cl := fakeclient.NewClientBuilder().WithScheme(scheme).WithObjects(alloc).Build()
-		r := &Reconciler{Client: cl}
-
-		serviceIPs := map[string]bool{"10.0.0.1": true, "10.0.0.2": true}
-		r.reclaimOrphanAllocations(context.Background(), []butlerv1alpha1.IPAllocation{*alloc}, serviceIPs)
-
-		// Verify deletion
-		err := cl.Get(context.Background(), client.ObjectKeyFromObject(alloc), &butlerv1alpha1.IPAllocation{})
-		if err == nil {
-			t.Error("expected orphan allocation to be deleted")
-		}
-	})
-
-	t.Run("skips allocation with matching service IP", func(t *testing.T) {
-		alloc := &butlerv1alpha1.IPAllocation{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:              "test-used",
-				Namespace:         "butler-system",
-				CreationTimestamp: oldTime,
-			},
-			Spec: butlerv1alpha1.IPAllocationSpec{Count: &count},
-			Status: butlerv1alpha1.IPAllocationStatus{
-				Phase:        butlerv1alpha1.IPAllocationPhaseAllocated,
-				StartAddress: "10.0.0.1",
-				EndAddress:   "10.0.0.1",
-			},
-		}
-
-		cl := fakeclient.NewClientBuilder().WithScheme(scheme).WithObjects(alloc).Build()
-		r := &Reconciler{Client: cl}
-
-		serviceIPs := map[string]bool{"10.0.0.1": true}
-		r.reclaimOrphanAllocations(context.Background(), []butlerv1alpha1.IPAllocation{*alloc}, serviceIPs)
-
-		// Verify NOT deleted
-		err := cl.Get(context.Background(), client.ObjectKeyFromObject(alloc), &butlerv1alpha1.IPAllocation{})
-		if err != nil {
-			t.Errorf("expected used allocation to remain, got error: %v", err)
-		}
-	})
-
-	t.Run("skips allocation younger than grace period", func(t *testing.T) {
-		alloc := &butlerv1alpha1.IPAllocation{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:              "test-young",
-				Namespace:         "butler-system",
-				CreationTimestamp: newTime, // 2 minutes old, under 5-minute grace
-			},
-			Spec: butlerv1alpha1.IPAllocationSpec{Count: &count},
-			Status: butlerv1alpha1.IPAllocationStatus{
-				Phase:        butlerv1alpha1.IPAllocationPhaseAllocated,
-				StartAddress: "10.0.0.9",
-				EndAddress:   "10.0.0.9",
-			},
-		}
-
-		cl := fakeclient.NewClientBuilder().WithScheme(scheme).WithObjects(alloc).Build()
-		r := &Reconciler{Client: cl}
-
-		serviceIPs := map[string]bool{"10.0.0.1": true} // no match for .9
-		r.reclaimOrphanAllocations(context.Background(), []butlerv1alpha1.IPAllocation{*alloc}, serviceIPs)
-
-		// Verify NOT deleted (within grace period)
-		err := cl.Get(context.Background(), client.ObjectKeyFromObject(alloc), &butlerv1alpha1.IPAllocation{})
-		if err != nil {
-			t.Errorf("expected young allocation to remain, got error: %v", err)
-		}
-	})
-
-	t.Run("skips allocation in pending phase", func(t *testing.T) {
-		alloc := &butlerv1alpha1.IPAllocation{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:              "test-pending",
-				Namespace:         "butler-system",
-				CreationTimestamp: oldTime,
-			},
-			Spec: butlerv1alpha1.IPAllocationSpec{Count: &count},
-			Status: butlerv1alpha1.IPAllocationStatus{
-				Phase:        butlerv1alpha1.IPAllocationPhasePending,
-				StartAddress: "",
-				EndAddress:   "",
-			},
-		}
-
-		cl := fakeclient.NewClientBuilder().WithScheme(scheme).WithObjects(alloc).Build()
-		r := &Reconciler{Client: cl}
-
-		serviceIPs := map[string]bool{}
-		r.reclaimOrphanAllocations(context.Background(), []butlerv1alpha1.IPAllocation{*alloc}, serviceIPs)
-
-		// Verify NOT deleted (not yet allocated)
-		err := cl.Get(context.Background(), client.ObjectKeyFromObject(alloc), &butlerv1alpha1.IPAllocation{})
-		if err != nil {
-			t.Errorf("expected pending allocation to remain, got error: %v", err)
-		}
-	})
-}
-
-func TestShrinkThreshold(t *testing.T) {
-	// Validates the off-by-one fix: with growthIncrement=1, shrink should fire
-	// when availableIPs == 1 (one orphan present).
 	tests := []struct {
-		name         string
-		availableIPs int32
-		increment    int32
-		wantShrink   bool
+		name       string
+		alloc      *butlerv1alpha1.IPAllocation
+		serviceIPs map[string]bool
+		wantDelete bool
 	}{
 		{
-			name:         "available equals increment: shrink fires",
-			availableIPs: 1,
-			increment:    1,
-			wantShrink:   true,
+			name: "growth, no IPs in use, grace exceeded: released",
+			alloc: &butlerv1alpha1.IPAllocation{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "team-a-test-lb-1", Namespace: "butler-system",
+					CreationTimestamp: oldTime,
+					Labels:           map[string]string{LabelAllocationRole: AllocationRoleGrowth},
+				},
+				Spec: butlerv1alpha1.IPAllocationSpec{Count: &count},
+				Status: butlerv1alpha1.IPAllocationStatus{
+					Phase: butlerv1alpha1.IPAllocationPhaseAllocated,
+					StartAddress: "10.0.0.5", EndAddress: "10.0.0.5",
+				},
+			},
+			serviceIPs: map[string]bool{"10.0.0.1": true},
+			wantDelete: true,
 		},
 		{
-			name:         "available exceeds increment: shrink fires",
-			availableIPs: 2,
-			increment:    1,
-			wantShrink:   true,
+			name: "growth, no IPs in use, grace not exceeded: kept",
+			alloc: &butlerv1alpha1.IPAllocation{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "team-a-test-lb-1", Namespace: "butler-system",
+					CreationTimestamp: youngTime,
+					Labels:           map[string]string{LabelAllocationRole: AllocationRoleGrowth},
+				},
+				Spec: butlerv1alpha1.IPAllocationSpec{Count: &count},
+				Status: butlerv1alpha1.IPAllocationStatus{
+					Phase: butlerv1alpha1.IPAllocationPhaseAllocated,
+					StartAddress: "10.0.0.5", EndAddress: "10.0.0.5",
+				},
+			},
+			serviceIPs: map[string]bool{"10.0.0.1": true},
+			wantDelete: false,
 		},
 		{
-			name:         "available below increment: no shrink",
-			availableIPs: 0,
-			increment:    1,
-			wantShrink:   false,
+			name: "growth, IPs actively in use: kept",
+			alloc: &butlerv1alpha1.IPAllocation{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "team-a-test-lb-1", Namespace: "butler-system",
+					CreationTimestamp: oldTime,
+					Labels:           map[string]string{LabelAllocationRole: AllocationRoleGrowth},
+				},
+				Spec: butlerv1alpha1.IPAllocationSpec{Count: &count},
+				Status: butlerv1alpha1.IPAllocationStatus{
+					Phase: butlerv1alpha1.IPAllocationPhaseAllocated,
+					StartAddress: "10.0.0.5", EndAddress: "10.0.0.5",
+				},
+			},
+			serviceIPs: map[string]bool{"10.0.0.5": true},
+			wantDelete: false,
 		},
 		{
-			name:         "increment=2, available=2: shrink fires",
-			availableIPs: 2,
-			increment:    2,
-			wantShrink:   true,
+			name: "initial, no IPs in use, grace exceeded: kept (protection)",
+			alloc: &butlerv1alpha1.IPAllocation{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "team-a-test-lb", Namespace: "butler-system",
+					CreationTimestamp: oldTime,
+					Labels:           map[string]string{LabelAllocationRole: AllocationRoleInitial},
+				},
+				Spec: butlerv1alpha1.IPAllocationSpec{Count: &count},
+				Status: butlerv1alpha1.IPAllocationStatus{
+					Phase: butlerv1alpha1.IPAllocationPhaseAllocated,
+					StartAddress: "10.0.0.1", EndAddress: "10.0.0.1",
+				},
+			},
+			serviceIPs: map[string]bool{},
+			wantDelete: false,
 		},
 		{
-			name:         "increment=2, available=1: no shrink",
-			availableIPs: 1,
-			increment:    2,
-			wantShrink:   false,
+			name: "growth, pending phase: kept",
+			alloc: &butlerv1alpha1.IPAllocation{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "team-a-test-lb-1", Namespace: "butler-system",
+					CreationTimestamp: oldTime,
+					Labels:           map[string]string{LabelAllocationRole: AllocationRoleGrowth},
+				},
+				Spec:   butlerv1alpha1.IPAllocationSpec{Count: &count},
+				Status: butlerv1alpha1.IPAllocationStatus{Phase: butlerv1alpha1.IPAllocationPhasePending},
+			},
+			serviceIPs: map[string]bool{},
+			wantDelete: false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// The shrink condition from reconcileElasticIPAM:
-			// len(allocs) > 1 && availableIPs >= growthIncrement
-			allocCount := 2 // More than 1 to satisfy first condition
-			got := allocCount > 1 && tt.availableIPs >= tt.increment
-			if got != tt.wantShrink {
-				t.Errorf("shrink condition (available=%d >= increment=%d) = %v, want %v",
-					tt.availableIPs, tt.increment, got, tt.wantShrink)
+			cl := fakeclient.NewClientBuilder().WithScheme(scheme).WithObjects(tt.alloc).Build()
+			r := &Reconciler{Client: cl}
+
+			// Run the shrink logic inline (same as reconcileElasticIPAM)
+			allocs := []butlerv1alpha1.IPAllocation{*tt.alloc}
+			for i := range allocs {
+				alloc := &allocs[i]
+				if alloc.Labels[LabelAllocationRole] != AllocationRoleGrowth {
+					continue
+				}
+				if alloc.Status.Phase != butlerv1alpha1.IPAllocationPhaseAllocated {
+					continue
+				}
+				if time.Since(alloc.CreationTimestamp.Time) < shrinkGracePeriod {
+					continue
+				}
+				if allocationHasServiceIP(alloc, tt.serviceIPs) {
+					continue
+				}
+				_ = r.Delete(context.Background(), alloc)
+			}
+
+			err := cl.Get(context.Background(), client.ObjectKeyFromObject(tt.alloc), &butlerv1alpha1.IPAllocation{})
+			deleted := err != nil
+			if deleted != tt.wantDelete {
+				t.Errorf("deleted = %v, want %v", deleted, tt.wantDelete)
 			}
 		})
 	}
 }
 
 func TestShrinkSelectsGrowthNotInitial(t *testing.T) {
-	// Verifies that the shrink loop only considers growth allocations, never
-	// the initial allocation, regardless of the order allocations appear in
-	// the slice (simulating undefined Kubernetes List ordering).
-	oldTime := metav1.NewTime(time.Now().Add(-15 * time.Minute))
-	count := int32(2)
+	// Verifies that the demand-driven shrink loop only considers growth
+	// allocations, never the initial allocation, regardless of the order
+	// allocations appear in the slice (simulating undefined Kubernetes List
+	// ordering). Both growth allocations have no matching service IPs and
+	// exceed the grace period, so both should be released. The initial
+	// allocation must survive even though it also has no matching service IP.
+	scheme := runtime.NewScheme()
+	_ = butlerv1alpha1.AddToScheme(scheme)
 
-	// Create 3 allocations: initial + 2 growth, deliberately in non-alphabetical
-	// order to prove we don't depend on ordering.
-	allocs := []butlerv1alpha1.IPAllocation{
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:              "team-a-cluster-lb-2",
-				Namespace:         "butler-system",
-				CreationTimestamp: oldTime,
-				Labels: map[string]string{
-					LabelAllocationRole: AllocationRoleGrowth,
-				},
-			},
-			Spec:   butlerv1alpha1.IPAllocationSpec{Count: &count},
-			Status: butlerv1alpha1.IPAllocationStatus{Phase: butlerv1alpha1.IPAllocationPhaseAllocated},
+	oldTime := metav1.NewTime(time.Now().Add(-15 * time.Minute))
+	count := int32(1)
+
+	growthAlloc2 := &butlerv1alpha1.IPAllocation{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "team-a-cluster-lb-2",
+			Namespace:         "butler-system",
+			CreationTimestamp: oldTime,
+			Labels:            map[string]string{LabelAllocationRole: AllocationRoleGrowth},
 		},
-		{
-			// The initial allocation is at index 1 — not index 0.
-			ObjectMeta: metav1.ObjectMeta{
-				Name:              "team-a-cluster-lb",
-				Namespace:         "butler-system",
-				CreationTimestamp: oldTime,
-				Labels: map[string]string{
-					LabelAllocationRole: AllocationRoleInitial,
-				},
-			},
-			Spec:   butlerv1alpha1.IPAllocationSpec{Count: &count},
-			Status: butlerv1alpha1.IPAllocationStatus{Phase: butlerv1alpha1.IPAllocationPhaseAllocated},
+		Spec: butlerv1alpha1.IPAllocationSpec{Count: &count},
+		Status: butlerv1alpha1.IPAllocationStatus{
+			Phase:        butlerv1alpha1.IPAllocationPhaseAllocated,
+			StartAddress: "10.0.0.5", EndAddress: "10.0.0.5",
 		},
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:              "team-a-cluster-lb-1",
-				Namespace:         "butler-system",
-				CreationTimestamp: oldTime,
-				Labels: map[string]string{
-					LabelAllocationRole: AllocationRoleGrowth,
-				},
-			},
-			Spec:   butlerv1alpha1.IPAllocationSpec{Count: &count},
-			Status: butlerv1alpha1.IPAllocationStatus{Phase: butlerv1alpha1.IPAllocationPhaseAllocated},
+	}
+	initialAlloc := &butlerv1alpha1.IPAllocation{
+		// The initial allocation is at index 1 — not index 0.
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "team-a-cluster-lb",
+			Namespace:         "butler-system",
+			CreationTimestamp: oldTime,
+			Labels:            map[string]string{LabelAllocationRole: AllocationRoleInitial},
+		},
+		Spec: butlerv1alpha1.IPAllocationSpec{Count: &count},
+		Status: butlerv1alpha1.IPAllocationStatus{
+			Phase:        butlerv1alpha1.IPAllocationPhaseAllocated,
+			StartAddress: "10.0.0.1", EndAddress: "10.0.0.1",
+		},
+	}
+	growthAlloc1 := &butlerv1alpha1.IPAllocation{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "team-a-cluster-lb-1",
+			Namespace:         "butler-system",
+			CreationTimestamp: oldTime,
+			Labels:            map[string]string{LabelAllocationRole: AllocationRoleGrowth},
+		},
+		Spec: butlerv1alpha1.IPAllocationSpec{Count: &count},
+		Status: butlerv1alpha1.IPAllocationStatus{
+			Phase:        butlerv1alpha1.IPAllocationPhaseAllocated,
+			StartAddress: "10.0.0.3", EndAddress: "10.0.0.3",
 		},
 	}
 
-	// Simulate the shrink selection logic from reconcileElasticIPAM
-	var shrinkCandidate *butlerv1alpha1.IPAllocation
-	for i := len(allocs) - 1; i >= 0; i-- {
+	cl := fakeclient.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(growthAlloc2, initialAlloc, growthAlloc1).
+		Build()
+
+	// No service IPs — all allocations are unused.
+	serviceIPs := map[string]bool{}
+
+	// Run the demand-driven shrink loop (same logic as reconcileElasticIPAM).
+	allocs := []butlerv1alpha1.IPAllocation{*growthAlloc2, *initialAlloc, *growthAlloc1}
+	for i := range allocs {
 		alloc := &allocs[i]
 		if alloc.Labels[LabelAllocationRole] != AllocationRoleGrowth {
 			continue
@@ -1380,33 +1351,33 @@ func TestShrinkSelectsGrowthNotInitial(t *testing.T) {
 		if alloc.Status.Phase != butlerv1alpha1.IPAllocationPhaseAllocated {
 			continue
 		}
-		if alloc.Spec.Count == nil {
+		if time.Since(alloc.CreationTimestamp.Time) < shrinkGracePeriod {
 			continue
 		}
-		if time.Since(alloc.CreationTimestamp.Time) < 10*time.Minute {
+		if allocationHasServiceIP(alloc, serviceIPs) {
 			continue
 		}
-		shrinkCandidate = alloc
-		break
+		_ = cl.Delete(context.Background(), alloc)
 	}
 
-	if shrinkCandidate == nil {
-		t.Fatal("expected a shrink candidate but got nil")
+	// Both growth allocations should be deleted.
+	for _, name := range []string{"team-a-cluster-lb-1", "team-a-cluster-lb-2"} {
+		err := cl.Get(context.Background(), client.ObjectKey{Name: name, Namespace: "butler-system"}, &butlerv1alpha1.IPAllocation{})
+		if err == nil {
+			t.Errorf("growth allocation %s should have been deleted but still exists", name)
+		}
 	}
-	if shrinkCandidate.Labels[LabelAllocationRole] != AllocationRoleGrowth {
-		t.Errorf("expected shrink candidate to be a growth allocation, got role=%q",
-			shrinkCandidate.Labels[LabelAllocationRole])
-	}
-	// Verify initial was never selected
-	if shrinkCandidate.Name == "team-a-cluster-lb" {
-		t.Error("shrink selected the initial allocation; this must never happen")
+
+	// Initial allocation must survive.
+	err := cl.Get(context.Background(), client.ObjectKey{Name: "team-a-cluster-lb", Namespace: "butler-system"}, &butlerv1alpha1.IPAllocation{})
+	if err != nil {
+		t.Error("initial allocation was deleted; this must never happen")
 	}
 }
 
-func TestShrinkThenReclaimUsesFreshData(t *testing.T) {
-	// Verifies that after shrink deletes an allocation, reclaim uses a fresh
-	// slice rather than the stale one. We simulate this by checking that a
-	// deleted allocation's name does not appear in the fresh slice.
+func TestShrinkRefetchesAfterDelete(t *testing.T) {
+	// Verifies that after shrink deletes an allocation, the re-fetch via
+	// listLBAllocations returns a fresh slice without the deleted object.
 	scheme := runtime.NewScheme()
 	_ = butlerv1alpha1.AddToScheme(scheme)
 
@@ -1714,102 +1685,73 @@ func TestListLBAllocations_Labels(t *testing.T) {
 	}
 }
 
-// TestReclaimSkipsInitialAllocation verifies that reclaimOrphanAllocations
-// does not discriminate by role label — it uses service IPs. This is a
-// regression guard to confirm reclaim logic is orthogonal to the role label.
-func TestReclaimSkipsInitialAllocation(t *testing.T) {
+func TestShrinkFiltersMixedAllocations(t *testing.T) {
+	// Test demand-driven shrink with a mix of initial, growth, pending, and
+	// young allocations. Only the growth allocation that is Allocated, past
+	// the grace period, and has no matching service IP should be deleted.
 	scheme := runtime.NewScheme()
 	_ = butlerv1alpha1.AddToScheme(scheme)
 
-	oldTime := metav1.NewTime(time.Now().Add(-10 * time.Minute))
+	oldTime := metav1.NewTime(time.Now().Add(-15 * time.Minute))
+	youngTime := metav1.NewTime(time.Now().Add(-2 * time.Minute))
 	count := int32(1)
 
-	// Initial allocation with a service IP — should NOT be reclaimed
-	initial := &butlerv1alpha1.IPAllocation{
+	initialAlloc := &butlerv1alpha1.IPAllocation{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:              "team-a-test-lb",
-			Namespace:         "butler-system",
+			Name: "team-a-c-lb", Namespace: "butler-system",
 			CreationTimestamp: oldTime,
-			Labels: map[string]string{
-				LabelAllocationRole: AllocationRoleInitial,
-			},
+			Labels:            map[string]string{LabelAllocationRole: AllocationRoleInitial},
 		},
 		Spec: butlerv1alpha1.IPAllocationSpec{Count: &count},
 		Status: butlerv1alpha1.IPAllocationStatus{
-			Phase:        butlerv1alpha1.IPAllocationPhaseAllocated,
-			StartAddress: "10.0.0.1",
-			EndAddress:   "10.0.0.1",
+			Phase: butlerv1alpha1.IPAllocationPhaseAllocated,
+			StartAddress: "10.0.0.1", EndAddress: "10.0.0.1",
+		},
+	}
+	youngGrowth := &butlerv1alpha1.IPAllocation{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "team-a-c-lb-1", Namespace: "butler-system",
+			CreationTimestamp: youngTime,
+			Labels:            map[string]string{LabelAllocationRole: AllocationRoleGrowth},
+		},
+		Spec: butlerv1alpha1.IPAllocationSpec{Count: &count},
+		Status: butlerv1alpha1.IPAllocationStatus{
+			Phase: butlerv1alpha1.IPAllocationPhaseAllocated,
+			StartAddress: "10.0.0.3", EndAddress: "10.0.0.3",
+		},
+	}
+	pendingGrowth := &butlerv1alpha1.IPAllocation{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "team-a-c-lb-2", Namespace: "butler-system",
+			CreationTimestamp: oldTime,
+			Labels:            map[string]string{LabelAllocationRole: AllocationRoleGrowth},
+		},
+		Spec:   butlerv1alpha1.IPAllocationSpec{Count: &count},
+		Status: butlerv1alpha1.IPAllocationStatus{Phase: butlerv1alpha1.IPAllocationPhasePending},
+	}
+	eligibleGrowth := &butlerv1alpha1.IPAllocation{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "team-a-c-lb-3", Namespace: "butler-system",
+			CreationTimestamp: oldTime,
+			Labels:            map[string]string{LabelAllocationRole: AllocationRoleGrowth},
+		},
+		Spec: butlerv1alpha1.IPAllocationSpec{Count: &count},
+		Status: butlerv1alpha1.IPAllocationStatus{
+			Phase: butlerv1alpha1.IPAllocationPhaseAllocated,
+			StartAddress: "10.0.0.5", EndAddress: "10.0.0.5",
 		},
 	}
 
-	cl := fakeclient.NewClientBuilder().WithScheme(scheme).WithObjects(initial).Build()
-	r := &Reconciler{Client: cl}
+	cl := fakeclient.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(initialAlloc, youngGrowth, pendingGrowth, eligibleGrowth).
+		Build()
 
-	serviceIPs := map[string]bool{"10.0.0.1": true}
-	r.reclaimOrphanAllocations(context.Background(), []butlerv1alpha1.IPAllocation{*initial}, serviceIPs)
+	// No service IPs — all allocations are unused.
+	serviceIPs := map[string]bool{}
 
-	// Verify NOT deleted
-	err := cl.Get(context.Background(), client.ObjectKeyFromObject(initial), &butlerv1alpha1.IPAllocation{})
-	if err != nil {
-		t.Errorf("initial allocation with active service IP was deleted: %v", err)
-	}
-}
-
-func TestShrinkCandidateSelection_MultipleMixed(t *testing.T) {
-	// Test with a mix of initial, growth, pending, and young allocations
-	// to verify the full filtering logic.
-	oldTime := metav1.NewTime(time.Now().Add(-15 * time.Minute))
-	youngTime := metav1.NewTime(time.Now().Add(-2 * time.Minute))
-	count := int32(2)
-
-	allocs := []butlerv1alpha1.IPAllocation{
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:              "team-a-c-lb",
-				Namespace:         "butler-system",
-				CreationTimestamp: oldTime,
-				Labels:            map[string]string{LabelAllocationRole: AllocationRoleInitial},
-			},
-			Spec:   butlerv1alpha1.IPAllocationSpec{Count: &count},
-			Status: butlerv1alpha1.IPAllocationStatus{Phase: butlerv1alpha1.IPAllocationPhaseAllocated},
-		},
-		{
-			// Growth but too young
-			ObjectMeta: metav1.ObjectMeta{
-				Name:              "team-a-c-lb-1",
-				Namespace:         "butler-system",
-				CreationTimestamp: youngTime,
-				Labels:            map[string]string{LabelAllocationRole: AllocationRoleGrowth},
-			},
-			Spec:   butlerv1alpha1.IPAllocationSpec{Count: &count},
-			Status: butlerv1alpha1.IPAllocationStatus{Phase: butlerv1alpha1.IPAllocationPhaseAllocated},
-		},
-		{
-			// Growth, old enough, pending phase — should be skipped
-			ObjectMeta: metav1.ObjectMeta{
-				Name:              "team-a-c-lb-2",
-				Namespace:         "butler-system",
-				CreationTimestamp: oldTime,
-				Labels:            map[string]string{LabelAllocationRole: AllocationRoleGrowth},
-			},
-			Spec:   butlerv1alpha1.IPAllocationSpec{Count: &count},
-			Status: butlerv1alpha1.IPAllocationStatus{Phase: butlerv1alpha1.IPAllocationPhasePending},
-		},
-		{
-			// Growth, old enough, allocated — this is the only valid candidate
-			ObjectMeta: metav1.ObjectMeta{
-				Name:              "team-a-c-lb-3",
-				Namespace:         "butler-system",
-				CreationTimestamp: oldTime,
-				Labels:            map[string]string{LabelAllocationRole: AllocationRoleGrowth},
-			},
-			Spec:   butlerv1alpha1.IPAllocationSpec{Count: &count},
-			Status: butlerv1alpha1.IPAllocationStatus{Phase: butlerv1alpha1.IPAllocationPhaseAllocated},
-		},
-	}
-
-	var shrinkCandidate *butlerv1alpha1.IPAllocation
-	for i := len(allocs) - 1; i >= 0; i-- {
+	allocs := []butlerv1alpha1.IPAllocation{*initialAlloc, *youngGrowth, *pendingGrowth, *eligibleGrowth}
+	for i := range allocs {
 		alloc := &allocs[i]
 		if alloc.Labels[LabelAllocationRole] != AllocationRoleGrowth {
 			continue
@@ -1817,21 +1759,27 @@ func TestShrinkCandidateSelection_MultipleMixed(t *testing.T) {
 		if alloc.Status.Phase != butlerv1alpha1.IPAllocationPhaseAllocated {
 			continue
 		}
-		if alloc.Spec.Count == nil {
+		if time.Since(alloc.CreationTimestamp.Time) < shrinkGracePeriod {
 			continue
 		}
-		if time.Since(alloc.CreationTimestamp.Time) < 10*time.Minute {
+		if allocationHasServiceIP(alloc, serviceIPs) {
 			continue
 		}
-		shrinkCandidate = alloc
-		break
+		_ = cl.Delete(context.Background(), alloc)
 	}
 
-	if shrinkCandidate == nil {
-		t.Fatal("expected a shrink candidate")
+	// Only the eligible growth allocation should be deleted.
+	err := cl.Get(context.Background(), client.ObjectKey{Name: "team-a-c-lb-3", Namespace: "butler-system"}, &butlerv1alpha1.IPAllocation{})
+	if err == nil {
+		t.Error("eligible growth allocation should have been deleted but still exists")
 	}
-	if shrinkCandidate.Name != "team-a-c-lb-3" {
-		t.Errorf("expected shrink candidate team-a-c-lb-3, got %s", shrinkCandidate.Name)
+
+	// All others should survive.
+	for _, name := range []string{"team-a-c-lb", "team-a-c-lb-1", "team-a-c-lb-2"} {
+		err := cl.Get(context.Background(), client.ObjectKey{Name: name, Namespace: "butler-system"}, &butlerv1alpha1.IPAllocation{})
+		if err != nil {
+			t.Errorf("allocation %s should have survived but was deleted", name)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

- Replace speculative arithmetic shrink (`availableIPs >= growthIncrement`) with demand-driven shrink that releases growth allocations whose IPs have no matching tenant LB Service for longer than a 10-minute grace period
- Remove `availableIPs` computation entirely — no speculative arithmetic drives any IPAM decision
- Unify orphan reclaim into the demand-driven shrink loop with role label protection (initial allocations are never released)

This completes architectural symmetry with PR #90 (demand-driven growth). The phantom growth cycle (P1) is eliminated: no speculative growth means no speculative shrink, and no speculative shrink means the oscillation cannot restart.

## What changed

**reconcile_ipam.go:**
- Added `shrinkGracePeriod` constant (10 minutes, matching ADR-016 spec)
- Removed `availableIPs` computation and its log key
- Replaced single-candidate reverse-iteration shrink block with forward-iteration loop that evaluates all growth allocations against the service IP inventory
- Removed `reclaimOrphanAllocations` function (its functionality is now a subset of the demand-driven shrink with the role label guard added)
- Made post-shrink re-fetch conditional (`if shrunk`) instead of unconditional

**reconcile_ipam_test.go:**
- Added `TestDemandDrivenShrink` — 5 table-driven cases covering the shrink filter matrix (role, phase, age, service IP match)
- Rewrote `TestShrinkSelectsGrowthNotInitial` to test the new forward-iteration pattern with actual fake client deletes
- Rewrote `TestShrinkCandidateSelection_MultipleMixed` as `TestShrinkFiltersMixedAllocations` with actual deletes
- Renamed `TestShrinkThenReclaimUsesFreshData` to `TestShrinkRefetchesAfterDelete`
- Removed `TestReclaimOrphanAllocations`, `TestShrinkThreshold`, `TestReclaimSkipsInitialAllocation` (tested removed code)

## Test plan

- [x] `go vet ./internal/controller/tenantcluster/...` clean
- [x] `go build ./...` clean
- [x] All IPAM unit tests pass (21 functions, 49 subtests)
- [ ] Local validation against Company 1 management cluster (scale controller to 0, run local binary, verify initial allocations preserved, no spurious shrink)
- [ ] Post-deploy: 30-minute watch for stable IPAllocation count, zero phantom `-lb-N` churn