### PR TITLE
feat(ipam): migration hardening for pre-existing allocations

### DIFF
--- a/docs/architecture/ADR-016-demand-driven-ipam.md
+++ b/docs/architecture/ADR-016-demand-driven-ipam.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Proposed
+Accepted
 
 ## Date
 
@@ -24,16 +24,16 @@ Growth fires when `availableIPs < 1`. Shrink fires when `availableIPs >= growthI
 
 A 1Gi memory limit on the controller absorbs the burst allocation patterns this cycle creates, but the underlying bug persists.
 
-### Phase 1 foundation
+### Foundation work
 
-Phase 1 of the IPAM redesign shipped in butler-controller v0.18.0 (#84, #85, #86, #87). It addressed infrastructure gaps without changing allocation behavior:
+Several infrastructure improvements shipped in butler-controller v0.18.0 (#84, #85, #86, #87) to address gaps without changing allocation behavior:
 
 - **IPAllocation watch on TenantCluster controller** (#84): Eliminated the 1-15 minute propagation delay for IPAllocation state changes. The TenantCluster controller now reacts to allocation changes within seconds rather than waiting for timer-based requeue.
 - **Dynamic client for MetalLB sync** (#85): Replaced the kubectl subprocess with server-side apply via a dynamic client. Adds timeout, retry with exponential backoff, and read-back verification.
 - **Tiered capacity events** (#86): Rate-limited events at 70%, 85%, and 95% utilization with recovery events. Replaces the previous behavior of emitting an event every 60 seconds above 80%.
 - **Capacity status conditions** (#87): Always-present `CapacityWarning`, `CapacityCritical`, and `CapacityExhausted` conditions on NetworkPool, consumable by kubectl, ArgoCD, Flux, and butler-console.
 
-Phase 1 improved observability and propagation speed. Phase 2, described by this ADR, addresses the root cause: the allocation trigger model.
+These improvements addressed observability and propagation speed. This ADR addresses the root cause: the allocation trigger model.
 
 ### Root problem
 
@@ -69,7 +69,7 @@ This follows the standard Kubernetes pattern: desired state in CRs, controllers 
 
 **Drift correction.** On every MetalLB sync, the controller computes the expected pool state from IPAllocations and applies it to the tenant. If the tenant pool has been manually edited, the edit is overwritten. Operators who need custom MetalLB pools should create separate IPAddressPool resources with different names, not modify `default-pool`.
 
-Phase 1 already established the mechanism for this: PR #85 introduced server-side apply with the `butler-controller/ipam` field manager and `Force: true`, which overwrites fields managed by other actors. Phase 2 formalizes this as the authority model.
+The mechanism for this already exists: #85 introduced server-side apply with the `butler-controller/ipam` field manager and `Force: true`, which overwrites fields managed by other actors. This ADR formalizes that behavior as the authority model.
 
 ### 3. State recovery: full reconciliation from source with startup sweep
 
@@ -81,23 +81,21 @@ The startup sweep is rate-limited via the existing `MaxConcurrentReconciles` set
 
 ## Implementation Plan
 
-Phase 2 ships as four sequential PRs in butler-controller. Each builds on the previous but is independently deployable. The detailed per-PR specifications are in the IPAM Redesign Plan (Phase 5, PRs 5-8).
+The demand-driven IPAM changes ship as four sequential PRs in butler-controller. Each builds on the previous but is independently deployable.
 
-**PR 5: Tenant LB Service watch infrastructure.** Extends the existing tenant client with a structured Service inventory. Plumbing only, no behavior change. Required before PR 6.
+**Tenant LB Service inventory** (#89): Extends the existing tenant client with a structured Service inventory. Plumbing only, no behavior change. Required before the demand-driven growth trigger.
 
-**PR 6: Demand-driven growth.** Replaces the `availableIPs < 1` trigger with "any LB Service Pending without externalIP." Uses the Service inventory from PR 5. Batch assessment: count all Pending Services, allocate enough IPs for all in one growth event. The old shrink logic stays temporarily.
+**Demand-driven growth** (#90): Replaces the `availableIPs < 1` trigger with "any LB Service Pending without externalIP." Uses the Service inventory from #89. Batch assessment: count all Pending Services, allocate enough IPs for all in one growth event. The old shrink logic stays temporarily.
 
-**PR 7: Demand-driven shrink.** Replaces arithmetic shrink with "allocated IPs with no matching Service for sustained grace period." This eliminates the phantom growth cycle entirely. Configurable grace period (default 10 minutes).
+**Demand-driven shrink** (#91): Replaces arithmetic shrink with "allocated IPs with no matching Service for sustained grace period." This eliminates the phantom growth cycle entirely. Configurable grace period (default 10 minutes).
 
-**PR 8: Migration logic for existing allocations.** Ensures existing allocations created under speculative allocation remain valid under demand-driven allocation. Existing clusters are not disrupted during rollout. Idempotent on re-run.
-
-The sequence matters: PR 5 is a no-op behavior change; PR 6 changes the growth trigger; PR 7 eliminates the phantom cycle; PR 8 handles migration edge cases.
+**Migration hardening**: Ensures existing allocations created under speculative allocation remain valid under demand-driven allocation. Adds PinnedRange protection to the shrink path. Existing clusters are not disrupted during rollout. Idempotent on re-run.
 
 ## Validation Strategy
 
 ### Before merge
 
-Local validation against the Company 1 management cluster, following the same pattern Phase 1 used: scale the deployed controller to 0 replicas, run the local controller binary with `--leader-elect=false`, validate, then restore the deployed controller.
+Local validation against the Company 1 management cluster: scale the deployed controller to 0 replicas, run the local controller binary with `--leader-elect=false`, validate, then restore the deployed controller.
 
 Specific validation criteria:
 
@@ -115,11 +113,11 @@ Specific validation criteria:
 
 ## Rollback
 
-Phase 2 PRs ship independently. If PR 6 or PR 7 causes problems, revert to butler-controller v0.18.0 (Phase 1 foundation). The Phase 1 behavior (speculative arithmetic with the phantom cycle) resumes, absorbed by the 1Gi memory limit.
+Each demand-driven IPAM PR ships independently. If the growth trigger (#90) or shrink logic (#91) causes problems, revert to butler-controller v0.18.0. The v0.18.0 behavior (speculative arithmetic with the phantom cycle) resumes, absorbed by the 1Gi memory limit.
 
-Existing allocations remain functional under v0.18.0. The migration in PR 8 is forward-compatible: allocations created under speculative allocation are valid CRs under demand-driven allocation. Rolling back does not require reverse migration.
+Existing allocations remain functional under v0.18.0. Allocations created under speculative allocation are valid CRs under demand-driven allocation. Rolling back does not require reverse migration.
 
-If pure demand-driven shrink (PR 7) proves operationally risky during implementation, the documented fallback is hybrid: demand-driven growth with arithmetic shrink using an improved dead zone. See Alternatives Considered below.
+If pure demand-driven shrink proves operationally risky, the documented fallback is hybrid: demand-driven growth with arithmetic shrink using an improved dead zone. See Alternatives Considered below.
 
 ## Consequences
 
@@ -129,23 +127,23 @@ If pure demand-driven shrink (PR 7) proves operationally risky during implementa
 - **Allocation accuracy improves.** Growth fires on actual demand (a Service needs an IP), not on accounting projections that can have no stable equilibrium.
 - **Single source of truth with clear authority.** Management-side IPAllocations are authoritative. Tenant-side MetalLB pools are derived. No ambiguity about which state wins on disagreement.
 - **Controller stability improves.** No more cascade of phantom IPAllocation creates/deletes hitting the reclaim grace period simultaneously. Allocation count is stable at rest.
-- **Pool exhaustion becomes visible earlier.** Capacity conditions from Phase 1 surface utilization tiers before exhaustion. Combined with demand-driven allocation (which only allocates when needed), pools last longer because speculative allocations no longer waste IPs.
+- **Pool exhaustion becomes visible earlier.** Capacity conditions (#86, #87) surface utilization tiers before exhaustion. Combined with demand-driven allocation (which only allocates when needed), pools last longer because speculative allocations no longer waste IPs.
 
 ### Negative
 
 - **Tenant API server is a hot dependency for growth decisions.** If a tenant's API server is unreachable, growth stalls for that tenant. The current system already requires tenant API access for `countLBIPs`, so this is the same failure mode, not a new one. Other tenants are unaffected (failure isolation per the requirements).
 - **Manual edits to `default-pool` are reverted.** Operators who manually configure tenant MetalLB pools will see their edits overwritten on next reconcile. This must be documented. Operators needing custom pools should create additional IPAddressPool resources with different names.
-- **Migration requires careful sequencing.** PR 8 must validate that existing allocations (created under speculative logic) transition cleanly to demand-driven logic without disrupting Ready clusters.
-- **Polling latency for growth.** Growth latency depends on the TenantCluster reconcile interval. For a mature cluster (>24h), the worst case before a Pending Service is detected is the requeue interval. The IPAllocation watch from Phase 1 accelerates follow-up reconciles after the growth allocation is fulfilled, but the initial detection still depends on the timer. If this proves unacceptable, a dedicated cross-cluster Service watch could reduce latency further (future work, not in this phase).
+- **Migration requires careful sequencing.** Existing allocations created under speculative logic must transition cleanly to demand-driven logic without disrupting Ready clusters.
+- **Polling latency for growth.** Growth latency depends on the TenantCluster reconcile interval. For a mature cluster (>24h), the worst case before a Pending Service is detected is the requeue interval. The IPAllocation watch (#84) accelerates follow-up reconciles after the growth allocation is fulfilled, but the initial detection still depends on the timer. If this proves unacceptable, a dedicated cross-cluster Service watch could reduce latency further (future work).
 
 ### Deferred
 
-- **Multi-pool selection priority** (Phase 3 PR 11): Proper priority-ordered pool selection for growth allocations when ProviderConfig references multiple pools.
-- **Read-back verification with event emission** (Phase 3 PR 10): Extends Phase 1's logged-only MetalLB verification to emit a Kubernetes event on drift detection.
-- **Pool exhaustion queueing**: Admission queueing for new TenantClusters when pools are near capacity. Deferred unless pool exhaustion becomes a recurring operational problem despite tiered advance warning from Phase 1 conditions.
+- **Multi-pool selection priority**: Proper priority-ordered pool selection for growth allocations when ProviderConfig references multiple pools.
+- **Read-back verification with event emission**: Extends the logged-only MetalLB verification from #85 to emit a Kubernetes event on drift detection.
+- **Pool exhaustion queueing**: Admission queueing for new TenantClusters when pools are near capacity. Deferred unless pool exhaustion becomes a recurring operational problem despite tiered advance warning from capacity conditions.
 - **Drift detection checkpointing**: Persistent snapshots of expected-vs-actual state per tenant. Deferred unless operator-driven drift becomes a recurring support issue.
 - **IPv6 support**: All current on-prem providers use IPv4. Explicitly out of scope.
-- **Optional butler-ipam-metrics addon**: Prometheus-specific metrics endpoint, PrometheusRule, ServiceMonitor, and Grafana dashboard. Opt-in addon for operators using prometheus-operator. Butler core remains stack-agnostic (Phase 4, future).
+- **Optional butler-ipam-metrics addon**: Prometheus-specific metrics endpoint, PrometheusRule, ServiceMonitor, and Grafana dashboard. Opt-in addon for operators using prometheus-operator. Butler core remains stack-agnostic.
 
 ## Alternatives Considered
 
@@ -155,7 +153,7 @@ Growth is demand-driven (same as the decision above), but shrink uses improved a
 
 **Why not chosen as the primary approach:** The dead zone fixes the symptom (oscillation) but preserves the split source of truth for shrink decisions. Management-side accounting still mixes with tenant-side data. Pure demand-driven eliminates the speculative-allocation category of bug entirely.
 
-**Retained as fallback:** If pure demand-driven shrink proves operationally risky during PR 7 implementation (e.g., tenant-side Service inventory is unreliable for shrink decisions), hybrid is the documented fallback. The growth side is identical; only the shrink trigger changes.
+**Retained as fallback:** If pure demand-driven shrink proves operationally risky (e.g., tenant-side Service inventory is unreliable for shrink decisions), hybrid is the documented fallback. The growth side is identical; only the shrink trigger changes.
 
 ### Authority model: tenant authoritative, management derived
 
@@ -173,5 +171,5 @@ Both management and tenant can be modified independently. Reconciliation detects
 
 - [ADR-008: Enterprise Networking and IPAM](ADR-008-enterprise-networking-ipam.md): Established the PVC/PV pattern, bitmap allocator, and NetworkPool/IPAllocation CRDs that this ADR builds on.
 - [butler-controller#83](https://github.com/butlerdotdev/butler-controller/issues/83): Tracking issue for the IPAM redesign.
-- Phase 1 PRs (foundation): [#84](https://github.com/butlerdotdev/butler-controller/pull/84) (IPAllocation watch), [#85](https://github.com/butlerdotdev/butler-controller/pull/85) (dynamic MetalLB client), [#86](https://github.com/butlerdotdev/butler-controller/pull/86) (tiered events), [#87](https://github.com/butlerdotdev/butler-controller/pull/87) (capacity conditions).
-- IPAM Redesign Plan: Working document containing the full current-state inventory, problems catalog (10 items with severity assessment), requirements, architectural premises, and five architecture decisions with implementation sequencing. Source material for this ADR.
+- Foundation PRs: [#84](https://github.com/butlerdotdev/butler-controller/pull/84) (IPAllocation watch), [#85](https://github.com/butlerdotdev/butler-controller/pull/85) (dynamic MetalLB client), [#86](https://github.com/butlerdotdev/butler-controller/pull/86) (tiered events), [#87](https://github.com/butlerdotdev/butler-controller/pull/87) (capacity conditions).
+- Demand-driven PRs: [#89](https://github.com/butlerdotdev/butler-controller/pull/89) (Service inventory), [#90](https://github.com/butlerdotdev/butler-controller/pull/90) (demand-driven growth), [#91](https://github.com/butlerdotdev/butler-controller/pull/91) (demand-driven shrink).

--- a/internal/controller/tenantcluster/reconcile_ipam.go
+++ b/internal/controller/tenantcluster/reconcile_ipam.go
@@ -317,15 +317,17 @@ func (r *Reconciler) reconcileElasticIPAM(ctx context.Context, tc *butlerv1alpha
 		}
 	}
 
-	// Shrink: demand-driven — release growth allocations whose IPs are not in
-	// use by any tenant LB Service for longer than the grace period. Only growth
-	// allocations are candidates; the initial allocation is never released. This
-	// replaces both the old arithmetic shrink and the separate orphan reclaim
-	// into a single demand-driven mechanism (ADR-016).
+	// Shrink: release growth allocations whose IPs are not in use by any tenant
+	// LB Service for longer than the grace period. Only growth allocations are
+	// candidates; the initial allocation is never released, and pinned
+	// allocations are always preserved regardless of role label.
 	var shrunk bool
 	for i := range allocs {
 		alloc := &allocs[i]
 		if alloc.Labels[LabelAllocationRole] != AllocationRoleGrowth {
+			continue
+		}
+		if alloc.Spec.PinnedRange != nil {
 			continue
 		}
 		if alloc.Status.Phase != butlerv1alpha1.IPAllocationPhaseAllocated {
@@ -658,6 +660,10 @@ func (r *Reconciler) migrateAllocationRoleLabels(ctx context.Context, allocs []b
 
 		role := AllocationRoleGrowth
 		if alloc.Name == initialName {
+			role = AllocationRoleInitial
+		} else if alloc.Spec.PinnedRange != nil {
+			// Pinned allocations are operator-defined and must never be
+			// auto-released by shrink, regardless of naming pattern.
 			role = AllocationRoleInitial
 		} else if !growthSuffixPattern.MatchString(alloc.Name) {
 			// Name doesn't match the growth pattern either — treat as initial

--- a/internal/controller/tenantcluster/reconcile_ipam_test.go
+++ b/internal/controller/tenantcluster/reconcile_ipam_test.go
@@ -1244,6 +1244,29 @@ func TestDemandDrivenShrink(t *testing.T) {
 			serviceIPs: map[string]bool{},
 			wantDelete: false,
 		},
+		{
+			name: "growth, pinned range, no IPs in use, grace exceeded: kept",
+			alloc: &butlerv1alpha1.IPAllocation{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "team-a-test-lb-1", Namespace: "butler-system",
+					CreationTimestamp: oldTime,
+					Labels:           map[string]string{LabelAllocationRole: AllocationRoleGrowth},
+				},
+				Spec: butlerv1alpha1.IPAllocationSpec{
+					Count: &count,
+					PinnedRange: &butlerv1alpha1.PinnedIPRange{
+						StartAddress: "10.0.0.5",
+						EndAddress:   "10.0.0.5",
+					},
+				},
+				Status: butlerv1alpha1.IPAllocationStatus{
+					Phase: butlerv1alpha1.IPAllocationPhaseAllocated,
+					StartAddress: "10.0.0.5", EndAddress: "10.0.0.5",
+				},
+			},
+			serviceIPs: map[string]bool{},
+			wantDelete: false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -1256,6 +1279,9 @@ func TestDemandDrivenShrink(t *testing.T) {
 			for i := range allocs {
 				alloc := &allocs[i]
 				if alloc.Labels[LabelAllocationRole] != AllocationRoleGrowth {
+					continue
+				}
+				if alloc.Spec.PinnedRange != nil {
 					continue
 				}
 				if alloc.Status.Phase != butlerv1alpha1.IPAllocationPhaseAllocated {
@@ -1578,6 +1604,58 @@ func TestMigrateAllocationRoleLabels_AlreadyLabeled(t *testing.T) {
 	}
 	if updated.Labels[LabelAllocationRole] != AllocationRoleInitial {
 		t.Errorf("label changed unexpectedly: got %q", updated.Labels[LabelAllocationRole])
+	}
+}
+
+func TestMigrateAllocationRoleLabels_PinnedRange(t *testing.T) {
+	// A pinned allocation with a growth-like name pattern (-lb-1) should
+	// still be labeled as initial, because pinned allocations are operator-
+	// defined and must never be auto-released by shrink.
+	scheme := runtime.NewScheme()
+	_ = butlerv1alpha1.AddToScheme(scheme)
+
+	tc := &butlerv1alpha1.TenantCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "team-a"},
+	}
+	count := int32(2)
+
+	pinnedAlloc := &butlerv1alpha1.IPAllocation{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "team-a-test-lb-1",
+			Namespace: "butler-system",
+			Labels: map[string]string{
+				butlerv1alpha1.LabelTeam:           "team-a",
+				butlerv1alpha1.LabelTenant:         "test",
+				butlerv1alpha1.LabelAllocationType: "loadbalancer",
+				// No allocation-role label — needs migration
+			},
+		},
+		Spec: butlerv1alpha1.IPAllocationSpec{
+			Count: &count,
+			PinnedRange: &butlerv1alpha1.PinnedIPRange{
+				StartAddress: "10.0.0.100",
+				EndAddress:   "10.0.0.101",
+			},
+		},
+		Status: butlerv1alpha1.IPAllocationStatus{Phase: butlerv1alpha1.IPAllocationPhaseAllocated},
+	}
+
+	cl := fakeclient.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(pinnedAlloc).
+		Build()
+	r := &Reconciler{Client: cl}
+
+	allocs := []butlerv1alpha1.IPAllocation{*pinnedAlloc}
+	r.migrateAllocationRoleLabels(context.Background(), allocs, tc)
+
+	updated := &butlerv1alpha1.IPAllocation{}
+	if err := cl.Get(context.Background(), client.ObjectKeyFromObject(pinnedAlloc), updated); err != nil {
+		t.Fatalf("failed to get allocation: %v", err)
+	}
+	if updated.Labels[LabelAllocationRole] != AllocationRoleInitial {
+		t.Errorf("pinned allocation labeled %q, want %q (pinned allocations must be treated as initial)",
+			updated.Labels[LabelAllocationRole], AllocationRoleInitial)
 	}
 }
 


### PR DESCRIPTION
## Summary

Adds defensive guards so that existing IPAllocations created before
demand-driven IPAM are handled correctly on the new reconcile path.

**PinnedRange protection in shrink.** Pinned allocations are operator-
defined (used for migration scenarios where specific IP ranges must be
preserved). The shrink loop now skips any allocation with
`Spec.PinnedRange` set, regardless of its role label. Without this,
a pinned growth allocation whose IPs aren't yet assigned to a Service
would be auto-released after the grace period.

**PinnedRange handling in role label migration.** When the one-time
migration infers role labels from allocation names, a pinned allocation
with a growth-like name pattern (e.g., `-lb-1`) is now labeled as
`initial` rather than `growth`. Belt-and-suspenders with the shrink
guard above.

**ADR-016 updates.** Status changed to Accepted. Plan-internal
sequencing references replaced with concrete PR numbers (#84-#91).
Added references to the demand-driven PRs.

## Why

Pinned allocations are a documented feature for operators migrating
existing infrastructure to Butler-managed IPAM. The demand-driven
shrink path (butler-controller#91) correctly protects initial
allocations via the role label guard, but had no explicit protection
for pinned allocations. A pinned allocation with a growth-like name
pattern would pass through the role label migration as `growth` and
then be eligible for auto-release.

No pinned allocations exist in production today, so this is preventive
hardening rather than a bug fix.

## How tested

- `TestDemandDrivenShrink` — new case: pinned growth allocation with
  no matching service IPs and exceeded grace period is kept
- `TestMigrateAllocationRoleLabels_PinnedRange` — pinned allocation
  with growth-like name gets labeled `initial`
- All existing IPAM tests pass (23 functions, 53 subtests)
- `go build ./...` and `go vet` clean

## What's preserved

- All 8 existing initial allocations on Company 1 are unaffected
- Demand-driven growth behavior unchanged
- Demand-driven shrink behavior unchanged for non-pinned allocations
- Role label migration remains idempotent

Refs butler-controller#83.