### PR TITLE
feat(addons): failure visibility and steady-state retry

### DIFF
--- a/internal/controller/tenantcluster/reconcile_addons.go
+++ b/internal/controller/tenantcluster/reconcile_addons.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -43,6 +44,7 @@ func (r *Reconciler) reconcileAddons(ctx context.Context, tc *butlerv1alpha1.Ten
 	}
 
 	var addonStatuses []butlerv1alpha1.AddonStatus
+	var failedAddons []string
 
 	// 1. CNI - REQUIRED, nodes won't be Ready without it
 	ciliumVersion := addons.DefaultCiliumVersion
@@ -108,6 +110,12 @@ func (r *Reconciler) reconcileAddons(ctx context.Context, tc *butlerv1alpha1.Ten
 	logger.Info("installing cert-manager", "version", certManagerVersion)
 	if err := r.Installer.InstallCertManager(ctx, kubeconfigData, certManagerVersion); err != nil {
 		logger.Error(err, "failed to install cert-manager")
+		failedAddons = append(failedAddons, "cert-manager")
+		r.Recorder.Eventf(tc, corev1.EventTypeWarning, "AddonInstallFailed",
+			"cert-manager %s installation failed: %s", certManagerVersion, truncateError(err))
+		addonStatuses = append(addonStatuses, butlerv1alpha1.AddonStatus{
+			Name: "cert-manager", Version: certManagerVersion, Status: "Failed", ManagedBy: "butler",
+		})
 	} else {
 		addonStatuses = append(addonStatuses, butlerv1alpha1.AddonStatus{
 			Name: "cert-manager", Version: certManagerVersion, Status: "Healthy", ManagedBy: "butler",
@@ -122,6 +130,12 @@ func (r *Reconciler) reconcileAddons(ctx context.Context, tc *butlerv1alpha1.Ten
 	logger.Info("installing Longhorn", "version", longhornVersion)
 	if err := r.Installer.InstallLonghorn(ctx, kubeconfigData, longhornVersion); err != nil {
 		logger.Error(err, "failed to install Longhorn")
+		failedAddons = append(failedAddons, "longhorn")
+		r.Recorder.Eventf(tc, corev1.EventTypeWarning, "AddonInstallFailed",
+			"longhorn %s installation failed: %s", longhornVersion, truncateError(err))
+		addonStatuses = append(addonStatuses, butlerv1alpha1.AddonStatus{
+			Name: "longhorn", Version: longhornVersion, Status: "Failed", ManagedBy: "butler",
+		})
 	} else {
 		addonStatuses = append(addonStatuses, butlerv1alpha1.AddonStatus{
 			Name: "longhorn", Version: longhornVersion, Status: "Healthy", ManagedBy: "butler",
@@ -133,25 +147,16 @@ func (r *Reconciler) reconcileAddons(ctx context.Context, tc *butlerv1alpha1.Ten
 	if tc.Spec.Addons.LoadBalancer != nil && tc.Spec.Addons.LoadBalancer.Version != "" {
 		metallbVersion = tc.Spec.Addons.LoadBalancer.Version
 	}
-	var poolStart, poolEnd string
-	// Check IPAM allocation first, fall back to manual loadBalancerPool
-	if tc.Status.LBAllocationRef != nil {
-		lbAlloc := &butlerv1alpha1.IPAllocation{}
-		if err := r.Get(ctx, types.NamespacedName{
-			Name:      tc.Status.LBAllocationRef.Name,
-			Namespace: "butler-system",
-		}, lbAlloc); err == nil && lbAlloc.Status.Phase == butlerv1alpha1.IPAllocationPhaseAllocated {
-			poolStart = lbAlloc.Status.StartAddress
-			poolEnd = lbAlloc.Status.EndAddress
-		}
-	}
-	if poolStart == "" && tc.Spec.Networking.LoadBalancerPool != nil {
-		poolStart = tc.Spec.Networking.LoadBalancerPool.Start
-		poolEnd = tc.Spec.Networking.LoadBalancerPool.End
-	}
+	poolStart, poolEnd := r.resolveMetalLBPool(ctx, tc)
 	logger.Info("installing MetalLB", "version", metallbVersion, "poolStart", poolStart, "poolEnd", poolEnd)
 	if err := r.Installer.InstallMetalLB(ctx, kubeconfigData, metallbVersion, poolStart, poolEnd); err != nil {
 		logger.Error(err, "failed to install MetalLB")
+		failedAddons = append(failedAddons, "metallb")
+		r.Recorder.Eventf(tc, corev1.EventTypeWarning, "AddonInstallFailed",
+			"metallb %s installation failed: %s", metallbVersion, truncateError(err))
+		addonStatuses = append(addonStatuses, butlerv1alpha1.AddonStatus{
+			Name: "metallb", Version: metallbVersion, Status: "Failed", ManagedBy: "butler",
+		})
 	} else {
 		addonStatuses = append(addonStatuses, butlerv1alpha1.AddonStatus{
 			Name: "metallb", Version: metallbVersion, Status: "Healthy", ManagedBy: "butler",
@@ -167,6 +172,12 @@ func (r *Reconciler) reconcileAddons(ctx context.Context, tc *butlerv1alpha1.Ten
 		logger.Info("installing Traefik", "version", traefikVersion)
 		if err := r.Installer.InstallTraefik(ctx, kubeconfigData, traefikVersion); err != nil {
 			logger.Error(err, "failed to install Traefik")
+			failedAddons = append(failedAddons, "traefik")
+			r.Recorder.Eventf(tc, corev1.EventTypeWarning, "AddonInstallFailed",
+				"traefik %s installation failed: %s", traefikVersion, truncateError(err))
+			addonStatuses = append(addonStatuses, butlerv1alpha1.AddonStatus{
+				Name: "traefik", Version: traefikVersion, Status: "Failed", ManagedBy: "butler",
+			})
 		} else {
 			addonStatuses = append(addonStatuses, butlerv1alpha1.AddonStatus{
 				Name: "traefik", Version: traefikVersion, Status: "Healthy", ManagedBy: "butler",
@@ -182,14 +193,22 @@ func (r *Reconciler) reconcileAddons(ctx context.Context, tc *butlerv1alpha1.Ten
 	}
 	tc.Status.ObservedState.Addons = addonStatuses
 
-	r.setCondition(tc, butlerv1alpha1.TenantClusterConditionAddonsReady,
-		metav1.ConditionTrue, "AddonsInstalled", "All addons installed successfully")
+	if len(failedAddons) > 0 {
+		msg := fmt.Sprintf("failed to install: %s", strings.Join(failedAddons, ", "))
+		r.setCondition(tc, butlerv1alpha1.TenantClusterConditionAddonsReady,
+			metav1.ConditionFalse, ReasonAddonInstallFailed, msg)
+	} else {
+		r.setCondition(tc, butlerv1alpha1.TenantClusterConditionAddonsReady,
+			metav1.ConditionTrue, "AddonsInstalled", "All addons installed successfully")
+	}
 
 	// Set kubeconfig secret reference for TenantAddon controller
 	tc.Status.KubeconfigSecretRef = &butlerv1alpha1.LocalObjectReference{
 		Name: fmt.Sprintf("%s-admin-kubeconfig", tc.Name),
 	}
 
+	// Transition to Ready even with addon failures -- the cluster is functional
+	// and the steady-state retry loop will attempt to heal failed addons.
 	tc.Status.Phase = butlerv1alpha1.TenantClusterPhaseReady
 	now := metav1.Now()
 	tc.Status.LastTransitionTime = &now
@@ -202,6 +221,106 @@ func (r *Reconciler) reconcileAddons(ctx context.Context, tc *butlerv1alpha1.Ten
 	logger.Info("TenantCluster is ready", "name", tc.Name)
 
 	return ctrl.Result{}, nil
+}
+
+// resolveMetalLBPool determines the MetalLB IP pool range for a tenant cluster.
+// It checks the IPAM allocation first, then falls back to the manual loadBalancerPool spec.
+func (r *Reconciler) resolveMetalLBPool(ctx context.Context, tc *butlerv1alpha1.TenantCluster) (string, string) {
+	var poolStart, poolEnd string
+	if tc.Status.LBAllocationRef != nil {
+		lbAlloc := &butlerv1alpha1.IPAllocation{}
+		if err := r.Get(ctx, types.NamespacedName{
+			Name:      tc.Status.LBAllocationRef.Name,
+			Namespace: "butler-system",
+		}, lbAlloc); err == nil && lbAlloc.Status.Phase == butlerv1alpha1.IPAllocationPhaseAllocated {
+			poolStart = lbAlloc.Status.StartAddress
+			poolEnd = lbAlloc.Status.EndAddress
+		}
+	}
+	if poolStart == "" && tc.Spec.Networking.LoadBalancerPool != nil {
+		poolStart = tc.Spec.Networking.LoadBalancerPool.Start
+		poolEnd = tc.Spec.Networking.LoadBalancerPool.End
+	}
+	return poolStart, poolEnd
+}
+
+// reconcileAddonHealth checks for failed platform addons on a Ready cluster and
+// attempts to reinstall them. Returns true if any addons still need retry, which
+// signals the caller to cap the requeue interval.
+func (r *Reconciler) reconcileAddonHealth(ctx context.Context, tc *butlerv1alpha1.TenantCluster, butlerConfig *butlerv1alpha1.ButlerConfig) (bool, error) {
+	logger := log.FromContext(ctx)
+
+	if tc.Status.ObservedState == nil || len(tc.Status.ObservedState.Addons) == 0 {
+		return false, nil
+	}
+
+	// Collect failed addons from observed state
+	var failed []butlerv1alpha1.AddonStatus
+	for _, a := range tc.Status.ObservedState.Addons {
+		if a.Status == "Failed" {
+			failed = append(failed, a)
+		}
+	}
+	if len(failed) == 0 {
+		return false, nil
+	}
+
+	kubeconfigData, err := r.getTenantKubeconfig(ctx, tc, butlerConfig)
+	if err != nil {
+		return true, fmt.Errorf("addon health: failed to get tenant kubeconfig: %w", err)
+	}
+
+	var stillFailed []string
+	updated := make(map[string]string) // addon name -> new status
+
+	for _, addon := range failed {
+		var installErr error
+		switch addon.Name {
+		case "cert-manager":
+			installErr = r.Installer.InstallCertManager(ctx, kubeconfigData, addon.Version)
+		case "longhorn":
+			installErr = r.Installer.InstallLonghorn(ctx, kubeconfigData, addon.Version)
+		case "metallb":
+			poolStart, poolEnd := r.resolveMetalLBPool(ctx, tc)
+			installErr = r.Installer.InstallMetalLB(ctx, kubeconfigData, addon.Version, poolStart, poolEnd)
+		case "traefik":
+			installErr = r.Installer.InstallTraefik(ctx, kubeconfigData, addon.Version)
+		default:
+			logger.V(1).Info("skipping unknown addon for retry", "addon", addon.Name)
+			continue
+		}
+
+		if installErr != nil {
+			logger.Error(installErr, "addon retry failed", "addon", addon.Name)
+			stillFailed = append(stillFailed, addon.Name)
+		} else {
+			logger.Info("addon retry succeeded", "addon", addon.Name)
+			r.Recorder.Eventf(tc, corev1.EventTypeNormal, "AddonRetrySucceeded",
+				"%s installed successfully on retry", addon.Name)
+			updated[addon.Name] = "Healthy"
+		}
+	}
+
+	// Apply status changes to observed state
+	if len(updated) > 0 {
+		for i := range tc.Status.ObservedState.Addons {
+			if newStatus, ok := updated[tc.Status.ObservedState.Addons[i].Name]; ok {
+				tc.Status.ObservedState.Addons[i].Status = newStatus
+			}
+		}
+	}
+
+	// Update AddonsReady condition
+	if len(stillFailed) > 0 {
+		msg := fmt.Sprintf("failed to install: %s", strings.Join(stillFailed, ", "))
+		r.setCondition(tc, butlerv1alpha1.TenantClusterConditionAddonsReady,
+			metav1.ConditionFalse, ReasonAddonInstallFailed, msg)
+	} else {
+		r.setCondition(tc, butlerv1alpha1.TenantClusterConditionAddonsReady,
+			metav1.ConditionTrue, "AddonsInstalled", "All addons installed successfully")
+	}
+
+	return len(stillFailed) > 0, nil
 }
 
 // reconcileAutoEnrollObservability creates TenantAddon resources for observability

--- a/internal/controller/tenantcluster/reconcile_addons_test.go
+++ b/internal/controller/tenantcluster/reconcile_addons_test.go
@@ -1,0 +1,493 @@
+// Copyright 2026 The Butler Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package tenantcluster
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	butlerv1alpha1 "github.com/butlerdotdev/butler-api/api/v1alpha1"
+	"github.com/butlerdotdev/butler-controller/internal/addons"
+)
+
+// mockInstaller implements PlatformAddonInstaller for testing.
+type mockInstaller struct {
+	installCertManagerErr error
+	installLonghornErr    error
+	installMetalLBErr     error
+	installTraefikErr     error
+	installCiliumErr      error
+	updateMetalLBPoolErr  error
+
+	certManagerCalls int
+	longhornCalls    int
+	metalLBCalls     int
+	traefikCalls     int
+}
+
+func (m *mockInstaller) InstallCilium(_ context.Context, _ []byte, _ addons.CiliumConfig) error {
+	return m.installCiliumErr
+}
+
+func (m *mockInstaller) InstallCertManager(_ context.Context, _ []byte, _ string) error {
+	m.certManagerCalls++
+	return m.installCertManagerErr
+}
+
+func (m *mockInstaller) InstallLonghorn(_ context.Context, _ []byte, _ string) error {
+	m.longhornCalls++
+	return m.installLonghornErr
+}
+
+func (m *mockInstaller) InstallMetalLB(_ context.Context, _ []byte, _, _, _ string) error {
+	m.metalLBCalls++
+	return m.installMetalLBErr
+}
+
+func (m *mockInstaller) InstallTraefik(_ context.Context, _ []byte, _ string) error {
+	m.traefikCalls++
+	return m.installTraefikErr
+}
+
+func (m *mockInstaller) UpdateMetalLBPool(_ context.Context, _ []byte, _ []string) error {
+	return m.updateMetalLBPoolErr
+}
+
+func TestReconcileAddonHealth_NoFailedAddons(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = butlerv1alpha1.AddToScheme(scheme)
+	_ = corev1.AddToScheme(scheme)
+
+	tc := &butlerv1alpha1.TenantCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "team-a"},
+		Status: butlerv1alpha1.TenantClusterStatus{
+			ObservedState: &butlerv1alpha1.ObservedClusterState{
+				Addons: []butlerv1alpha1.AddonStatus{
+					{Name: "cilium", Version: "1.17.0", Status: "Healthy", ManagedBy: "butler"},
+					{Name: "cert-manager", Version: "v1.16.2", Status: "Healthy", ManagedBy: "butler"},
+				},
+			},
+		},
+	}
+
+	cl := fakeclient.NewClientBuilder().WithScheme(scheme).Build()
+	installer := &mockInstaller{}
+	r := &Reconciler{
+		Client:    cl,
+		Scheme:    scheme,
+		Installer: installer,
+		Recorder:  record.NewFakeRecorder(10),
+	}
+
+	retryNeeded, err := r.reconcileAddonHealth(context.Background(), tc, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if retryNeeded {
+		t.Error("expected retryNeeded=false when no addons are failed")
+	}
+	if installer.certManagerCalls != 0 {
+		t.Errorf("expected 0 cert-manager calls, got %d", installer.certManagerCalls)
+	}
+}
+
+func TestReconcileAddonHealth_NilObservedState(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = butlerv1alpha1.AddToScheme(scheme)
+
+	tc := &butlerv1alpha1.TenantCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "team-a"},
+		Status:     butlerv1alpha1.TenantClusterStatus{},
+	}
+
+	cl := fakeclient.NewClientBuilder().WithScheme(scheme).Build()
+	r := &Reconciler{
+		Client:    cl,
+		Scheme:    scheme,
+		Installer: &mockInstaller{},
+		Recorder:  record.NewFakeRecorder(10),
+	}
+
+	retryNeeded, err := r.reconcileAddonHealth(context.Background(), tc, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if retryNeeded {
+		t.Error("expected retryNeeded=false with nil ObservedState")
+	}
+}
+
+func TestReconcileAddonHealth_RetrySucceeds(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = butlerv1alpha1.AddToScheme(scheme)
+	_ = corev1.AddToScheme(scheme)
+
+	// Simulate a cluster where cert-manager and longhorn initially failed.
+	// The kubeconfig secret must exist for getTenantKubeconfig to succeed.
+	kubeconfigSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-admin-kubeconfig",
+			Namespace: "test-abc123",
+		},
+		Data: map[string][]byte{
+			"admin.conf": []byte("fake-kubeconfig"),
+		},
+	}
+
+	tc := &butlerv1alpha1.TenantCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "team-a"},
+		Status: butlerv1alpha1.TenantClusterStatus{
+			TenantNamespace: "test-abc123",
+			ObservedState: &butlerv1alpha1.ObservedClusterState{
+				Addons: []butlerv1alpha1.AddonStatus{
+					{Name: "cilium", Version: "1.17.0", Status: "Healthy", ManagedBy: "butler"},
+					{Name: "cert-manager", Version: "v1.16.2", Status: "Failed", ManagedBy: "butler"},
+					{Name: "longhorn", Version: "1.7.2", Status: "Failed", ManagedBy: "butler"},
+					{Name: "metallb", Version: "0.14.9", Status: "Healthy", ManagedBy: "butler"},
+				},
+			},
+		},
+	}
+
+	cl := fakeclient.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(kubeconfigSecret).
+		Build()
+
+	recorder := record.NewFakeRecorder(10)
+	installer := &mockInstaller{} // all installs succeed
+	r := &Reconciler{
+		Client:    cl,
+		Scheme:    scheme,
+		Installer: installer,
+		Recorder:  recorder,
+	}
+
+	retryNeeded, err := r.reconcileAddonHealth(context.Background(), tc, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if retryNeeded {
+		t.Error("expected retryNeeded=false when all retries succeed")
+	}
+	if installer.certManagerCalls != 1 {
+		t.Errorf("expected 1 cert-manager call, got %d", installer.certManagerCalls)
+	}
+	if installer.longhornCalls != 1 {
+		t.Errorf("expected 1 longhorn call, got %d", installer.longhornCalls)
+	}
+	if installer.metalLBCalls != 0 {
+		t.Errorf("expected 0 metallb calls (was healthy), got %d", installer.metalLBCalls)
+	}
+
+	// Verify observed state was updated
+	for _, a := range tc.Status.ObservedState.Addons {
+		if a.Status == "Failed" {
+			t.Errorf("addon %s still shows Failed after successful retry", a.Name)
+		}
+	}
+
+	// Verify AddonsReady condition was set to True
+	for _, c := range tc.Status.Conditions {
+		if c.Type == butlerv1alpha1.TenantClusterConditionAddonsReady {
+			if c.Status != metav1.ConditionTrue {
+				t.Errorf("AddonsReady condition = %s, want True", c.Status)
+			}
+			return
+		}
+	}
+	t.Error("AddonsReady condition not found")
+}
+
+func TestReconcileAddonHealth_RetryPartialFailure(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = butlerv1alpha1.AddToScheme(scheme)
+	_ = corev1.AddToScheme(scheme)
+
+	kubeconfigSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-admin-kubeconfig",
+			Namespace: "test-abc123",
+		},
+		Data: map[string][]byte{
+			"admin.conf": []byte("fake-kubeconfig"),
+		},
+	}
+
+	tc := &butlerv1alpha1.TenantCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "team-a"},
+		Status: butlerv1alpha1.TenantClusterStatus{
+			TenantNamespace: "test-abc123",
+			ObservedState: &butlerv1alpha1.ObservedClusterState{
+				Addons: []butlerv1alpha1.AddonStatus{
+					{Name: "cert-manager", Version: "v1.16.2", Status: "Failed", ManagedBy: "butler"},
+					{Name: "longhorn", Version: "1.7.2", Status: "Failed", ManagedBy: "butler"},
+				},
+			},
+		},
+	}
+
+	cl := fakeclient.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(kubeconfigSecret).
+		Build()
+
+	recorder := record.NewFakeRecorder(10)
+	// cert-manager succeeds, longhorn still fails
+	installer := &mockInstaller{
+		installLonghornErr: fmt.Errorf("helm timeout"),
+	}
+	r := &Reconciler{
+		Client:    cl,
+		Scheme:    scheme,
+		Installer: installer,
+		Recorder:  recorder,
+	}
+
+	retryNeeded, err := r.reconcileAddonHealth(context.Background(), tc, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !retryNeeded {
+		t.Error("expected retryNeeded=true when longhorn still fails")
+	}
+
+	// cert-manager should be Healthy, longhorn should still be Failed
+	for _, a := range tc.Status.ObservedState.Addons {
+		switch a.Name {
+		case "cert-manager":
+			if a.Status != "Healthy" {
+				t.Errorf("cert-manager status = %s, want Healthy", a.Status)
+			}
+		case "longhorn":
+			if a.Status != "Failed" {
+				t.Errorf("longhorn status = %s, want Failed", a.Status)
+			}
+		}
+	}
+
+	// AddonsReady should be False
+	for _, c := range tc.Status.Conditions {
+		if c.Type == butlerv1alpha1.TenantClusterConditionAddonsReady {
+			if c.Status != metav1.ConditionFalse {
+				t.Errorf("AddonsReady condition = %s, want False", c.Status)
+			}
+			if c.Reason != ReasonAddonInstallFailed {
+				t.Errorf("AddonsReady reason = %s, want %s", c.Reason, ReasonAddonInstallFailed)
+			}
+			return
+		}
+	}
+	t.Error("AddonsReady condition not found")
+}
+
+func TestReconcileAddonHealth_MetalLBRetryUsesPoolResolution(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = butlerv1alpha1.AddToScheme(scheme)
+	_ = corev1.AddToScheme(scheme)
+
+	kubeconfigSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-admin-kubeconfig",
+			Namespace: "test-abc123",
+		},
+		Data: map[string][]byte{
+			"admin.conf": []byte("fake-kubeconfig"),
+		},
+	}
+
+	// MetalLB failed on initial install. The pool allocation exists.
+	lbAlloc := &butlerv1alpha1.IPAllocation{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "team-a-test-lb",
+			Namespace: "butler-system",
+		},
+		Status: butlerv1alpha1.IPAllocationStatus{
+			Phase:        butlerv1alpha1.IPAllocationPhaseAllocated,
+			StartAddress: "10.0.0.1",
+			EndAddress:   "10.0.0.4",
+		},
+	}
+
+	tc := &butlerv1alpha1.TenantCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "team-a"},
+		Status: butlerv1alpha1.TenantClusterStatus{
+			TenantNamespace: "test-abc123",
+			LBAllocationRef: &butlerv1alpha1.LocalObjectReference{
+				Name: "team-a-test-lb",
+			},
+			ObservedState: &butlerv1alpha1.ObservedClusterState{
+				Addons: []butlerv1alpha1.AddonStatus{
+					{Name: "metallb", Version: "0.14.9", Status: "Failed", ManagedBy: "butler"},
+				},
+			},
+		},
+	}
+
+	cl := fakeclient.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(kubeconfigSecret, lbAlloc).
+		Build()
+
+	installer := &mockInstaller{}
+	r := &Reconciler{
+		Client:    cl,
+		Scheme:    scheme,
+		Installer: installer,
+		Recorder:  record.NewFakeRecorder(10),
+	}
+
+	retryNeeded, err := r.reconcileAddonHealth(context.Background(), tc, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if retryNeeded {
+		t.Error("expected retryNeeded=false after successful MetalLB retry")
+	}
+	if installer.metalLBCalls != 1 {
+		t.Errorf("expected 1 metallb call, got %d", installer.metalLBCalls)
+	}
+}
+
+func TestReconcileAddonHealth_SkipsUnknownAddons(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = butlerv1alpha1.AddToScheme(scheme)
+	_ = corev1.AddToScheme(scheme)
+
+	kubeconfigSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-admin-kubeconfig",
+			Namespace: "test-abc123",
+		},
+		Data: map[string][]byte{
+			"admin.conf": []byte("fake-kubeconfig"),
+		},
+	}
+
+	tc := &butlerv1alpha1.TenantCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "team-a"},
+		Status: butlerv1alpha1.TenantClusterStatus{
+			TenantNamespace: "test-abc123",
+			ObservedState: &butlerv1alpha1.ObservedClusterState{
+				Addons: []butlerv1alpha1.AddonStatus{
+					{Name: "unknown-addon", Version: "1.0.0", Status: "Failed", ManagedBy: "butler"},
+				},
+			},
+		},
+	}
+
+	cl := fakeclient.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(kubeconfigSecret).
+		Build()
+
+	installer := &mockInstaller{}
+	r := &Reconciler{
+		Client:    cl,
+		Scheme:    scheme,
+		Installer: installer,
+		Recorder:  record.NewFakeRecorder(10),
+	}
+
+	retryNeeded, err := r.reconcileAddonHealth(context.Background(), tc, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Unknown addons are skipped, not counted as still-failed
+	if retryNeeded {
+		t.Error("expected retryNeeded=false for unknown addon")
+	}
+}
+
+func TestResolveMetalLBPool_FromAllocation(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = butlerv1alpha1.AddToScheme(scheme)
+
+	lbAlloc := &butlerv1alpha1.IPAllocation{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "team-a-test-lb",
+			Namespace: "butler-system",
+		},
+		Status: butlerv1alpha1.IPAllocationStatus{
+			Phase:        butlerv1alpha1.IPAllocationPhaseAllocated,
+			StartAddress: "10.0.0.1",
+			EndAddress:   "10.0.0.8",
+		},
+	}
+
+	tc := &butlerv1alpha1.TenantCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "team-a"},
+		Status: butlerv1alpha1.TenantClusterStatus{
+			LBAllocationRef: &butlerv1alpha1.LocalObjectReference{
+				Name: "team-a-test-lb",
+			},
+		},
+	}
+
+	cl := fakeclient.NewClientBuilder().WithScheme(scheme).WithObjects(lbAlloc).Build()
+	r := &Reconciler{Client: cl}
+
+	start, end := r.resolveMetalLBPool(context.Background(), tc)
+	if start != "10.0.0.1" {
+		t.Errorf("poolStart = %q, want 10.0.0.1", start)
+	}
+	if end != "10.0.0.8" {
+		t.Errorf("poolEnd = %q, want 10.0.0.8", end)
+	}
+}
+
+func TestResolveMetalLBPool_FallbackToSpec(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = butlerv1alpha1.AddToScheme(scheme)
+
+	tc := &butlerv1alpha1.TenantCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "team-a"},
+		Spec: butlerv1alpha1.TenantClusterSpec{
+			Networking: butlerv1alpha1.NetworkingSpec{
+				LoadBalancerPool: &butlerv1alpha1.IPPool{
+					Start: "192.168.1.100",
+					End:   "192.168.1.110",
+				},
+			},
+		},
+	}
+
+	cl := fakeclient.NewClientBuilder().WithScheme(scheme).Build()
+	r := &Reconciler{Client: cl}
+
+	start, end := r.resolveMetalLBPool(context.Background(), tc)
+	if start != "192.168.1.100" {
+		t.Errorf("poolStart = %q, want 192.168.1.100", start)
+	}
+	if end != "192.168.1.110" {
+		t.Errorf("poolEnd = %q, want 192.168.1.110", end)
+	}
+}
+
+func TestResolveMetalLBPool_NoPool(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = butlerv1alpha1.AddToScheme(scheme)
+
+	tc := &butlerv1alpha1.TenantCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "team-a"},
+	}
+
+	cl := fakeclient.NewClientBuilder().WithScheme(scheme).Build()
+	r := &Reconciler{Client: cl}
+
+	start, end := r.resolveMetalLBPool(context.Background(), tc)
+	if start != "" {
+		t.Errorf("poolStart = %q, want empty", start)
+	}
+	if end != "" {
+		t.Errorf("poolEnd = %q, want empty", end)
+	}
+}

--- a/internal/controller/tenantcluster/reconcile_addons_test.go
+++ b/internal/controller/tenantcluster/reconcile_addons_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/butlerdotdev/butler-controller/internal/addons"
 )
 
-// mockInstaller implements PlatformAddonInstaller for testing.
+// mockInstaller implements AddonInstaller for testing.
 type mockInstaller struct {
 	installCertManagerErr error
 	installLonghornErr    error

--- a/internal/controller/tenantcluster/tenantcluster_controller.go
+++ b/internal/controller/tenantcluster/tenantcluster_controller.go
@@ -74,12 +74,25 @@ const (
 	ReasonProviderConfigNotFound = "ProviderConfigNotFound"
 	ReasonCAPIResourceError      = "CAPIResourceError"
 	ReasonReady                  = "Ready"
+	ReasonAddonInstallFailed     = "AddonInstallFailed"
 )
+
+// PlatformAddonInstaller abstracts the addon installation methods used by the
+// TenantCluster controller. The concrete implementation is *addons.Installer;
+// tests can supply a mock.
+type PlatformAddonInstaller interface {
+	InstallCilium(ctx context.Context, kubeconfig []byte, cfg addons.CiliumConfig) error
+	InstallCertManager(ctx context.Context, kubeconfig []byte, version string) error
+	InstallLonghorn(ctx context.Context, kubeconfig []byte, version string) error
+	InstallMetalLB(ctx context.Context, kubeconfig []byte, version, poolStart, poolEnd string) error
+	InstallTraefik(ctx context.Context, kubeconfig []byte, version string) error
+	UpdateMetalLBPool(ctx context.Context, kubeconfig []byte, ranges []string) error
+}
 
 type Reconciler struct {
 	client.Client
 	Scheme                  *runtime.Scheme
-	Installer               *addons.Installer
+	Installer               PlatformAddonInstaller
 	ClientManager           *tenant.ClientManager
 	Recorder                record.EventRecorder
 	MaxConcurrentReconciles int
@@ -257,12 +270,20 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	// failing the reconcile. The cluster remains Ready but operators can see
 	// which background operations need attention.
 	var degraded []string
+	addonRetryNeeded := false
 
 	if tc.Status.Phase == butlerv1alpha1.TenantClusterPhaseReady {
 		if err := r.reconcileAutoEnrollObservability(ctx, tc, butlerConfig); err != nil {
 			logger.Error(err, "failed to auto-enroll observability agents")
 			degraded = append(degraded, "observability sync failed ("+truncateError(err)+")")
 		}
+
+		retryNeeded, err := r.reconcileAddonHealth(ctx, tc, butlerConfig)
+		if err != nil {
+			logger.Error(err, "addon health check failed")
+			degraded = append(degraded, "addon health failed ("+truncateError(err)+")")
+		}
+		addonRetryNeeded = retryNeeded
 	}
 
 	if err := r.reconcileMachineDeploymentReplicas(ctx, tc, butlerConfig); err != nil {
@@ -325,7 +346,14 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		return ctrl.Result{}, err
 	}
 
-	return ctrl.Result{RequeueAfter: r.calculateRequeueInterval(tc)}, nil
+	requeueAfter := r.calculateRequeueInterval(tc)
+	// When addons need retry, cap requeue at 10 minutes so failed addons
+	// don't wait the full 15-minute mature-cluster interval.
+	if addonRetryNeeded && requeueAfter > 10*time.Minute {
+		requeueAfter = 10 * time.Minute
+	}
+
+	return ctrl.Result{RequeueAfter: requeueAfter}, nil
 }
 
 func (r *Reconciler) setFailedStatus(ctx context.Context, tc *butlerv1alpha1.TenantCluster, reason, message string) (ctrl.Result, error) {

--- a/internal/controller/tenantcluster/tenantcluster_controller.go
+++ b/internal/controller/tenantcluster/tenantcluster_controller.go
@@ -77,10 +77,15 @@ const (
 	ReasonAddonInstallFailed     = "AddonInstallFailed"
 )
 
-// PlatformAddonInstaller abstracts the addon installation methods used by the
-// TenantCluster controller. The concrete implementation is *addons.Installer;
-// tests can supply a mock.
-type PlatformAddonInstaller interface {
+// AddonInstaller abstracts the addon installation methods consumed by the
+// TenantCluster controller. Defined here (consumer side) rather than in the
+// addons package so the interface stays narrow to actual usage. The concrete
+// implementation is *addons.Installer, which shells out to Helm; this interface
+// enables unit testing of retry logic, condition setting, and event emission
+// without requiring Helm or kubectl. Other controllers that install addons
+// (tenantaddon, managementaddon) use the concrete type directly today but
+// could adopt this pattern in follow-up work.
+type AddonInstaller interface {
 	InstallCilium(ctx context.Context, kubeconfig []byte, cfg addons.CiliumConfig) error
 	InstallCertManager(ctx context.Context, kubeconfig []byte, version string) error
 	InstallLonghorn(ctx context.Context, kubeconfig []byte, version string) error
@@ -92,7 +97,7 @@ type PlatformAddonInstaller interface {
 type Reconciler struct {
 	client.Client
 	Scheme                  *runtime.Scheme
-	Installer               PlatformAddonInstaller
+	Installer               AddonInstaller
 	ClientManager           *tenant.ClientManager
 	Recorder                record.EventRecorder
 	MaxConcurrentReconciles int


### PR DESCRIPTION
## Summary

- Platform addon install failures (cert-manager, longhorn, metallb, traefik) are now visible via Warning events, Failed status in observedState.addons, and AddonsReady=False condition
- Failed addons are retried automatically during steady-state reconciliation via a new `reconcileAddonHealth` function
- Requeue interval capped at 10 minutes when addons need retry (down from 15 min on mature clusters)
- Extracts `PlatformAddonInstaller` interface for testability and `resolveMetalLBPool` helper for reuse

## What changed

| File | Change |
|------|--------|
| `reconcile_addons.go` | failedAddons tracking, per-addon Warning events, conditional AddonsReady condition, resolveMetalLBPool helper, reconcileAddonHealth function |
| `tenantcluster_controller.go` | PlatformAddonInstaller interface, ReasonAddonInstallFailed constant, reconcileAddonHealth call in steady-state loop, requeue capping |
| `reconcile_addons_test.go` | 9 unit tests: retry success, partial failure, MetalLB pool resolution, unknown addons, nil state |

## Design decisions

- Cilium remains fatal (blocks cluster progression). All other addons are non-fatal.
- Clusters still transition to Ready with failed addons. The steady-state loop handles self-healing.
- Retry uses the same Installer methods as initial install (helm upgrade --install is idempotent).
- Layer (c) blocking (failing the cluster on addon failure) is out of scope.

## Test plan

- [ ] Unit tests pass: `go test ./internal/controller/tenantcluster/ -run "TestReconcileAddonHealth|TestResolveMetalLBPool"`
- [ ] Full build compiles: `go build ./...`
- [ ] Existing unit tests unaffected
- [ ] Deploy to staging and verify: provision a cluster, observe AddonsReady=True; simulate addon failure (e.g., disconnect Helm repo), observe AddonsReady=False with AddonInstallFailed events, restore connectivity, observe AddonRetrySucceeded events and AddonsReady=True