### PR TITLE
fix(addons): retry addons absent from observedState

### DIFF
--- a/internal/controller/tenantcluster/reconcile_addons.go
+++ b/internal/controller/tenantcluster/reconcile_addons.go
@@ -244,24 +244,66 @@ func (r *Reconciler) resolveMetalLBPool(ctx context.Context, tc *butlerv1alpha1.
 	return poolStart, poolEnd
 }
 
-// reconcileAddonHealth checks for failed platform addons on a Ready cluster and
-// attempts to reinstall them. Returns true if any addons still need retry, which
-// signals the caller to cap the requeue interval.
+// reconcileAddonHealth checks for failed or missing platform addons on a Ready
+// cluster and attempts to reinstall them. An addon needs retry if it is recorded
+// as Failed in observedState OR if it is expected by the spec but absent from
+// observedState entirely (e.g., it failed silently during initial install before
+// failure tracking was added). Returns true if any addons still need retry,
+// which signals the caller to cap the requeue interval.
 func (r *Reconciler) reconcileAddonHealth(ctx context.Context, tc *butlerv1alpha1.TenantCluster, butlerConfig *butlerv1alpha1.ButlerConfig) (bool, error) {
 	logger := log.FromContext(ctx)
 
-	if tc.Status.ObservedState == nil || len(tc.Status.ObservedState.Addons) == 0 {
-		return false, nil
+	// Build the expected non-CNI addons list from the spec. Cilium is excluded
+	// because its failure is fatal during initial install and it requires
+	// CiliumConfig (not just a version string).
+	type expectedAddon struct {
+		name    string
+		version string
 	}
 
-	// Collect failed addons from observed state
-	var failed []butlerv1alpha1.AddonStatus
-	for _, a := range tc.Status.ObservedState.Addons {
-		if a.Status == "Failed" {
-			failed = append(failed, a)
+	certManagerVersion := addons.DefaultCertManagerVersion
+	if tc.Spec.Addons.CertManager != nil && tc.Spec.Addons.CertManager.Version != "" {
+		certManagerVersion = tc.Spec.Addons.CertManager.Version
+	}
+	longhornVersion := addons.DefaultLonghornVersion
+	if tc.Spec.Addons.Storage != nil && tc.Spec.Addons.Storage.Version != "" {
+		longhornVersion = tc.Spec.Addons.Storage.Version
+	}
+	metallbVersion := addons.DefaultMetalLBVersion
+	if tc.Spec.Addons.LoadBalancer != nil && tc.Spec.Addons.LoadBalancer.Version != "" {
+		metallbVersion = tc.Spec.Addons.LoadBalancer.Version
+	}
+
+	expected := []expectedAddon{
+		{"cert-manager", certManagerVersion},
+		{"longhorn", longhornVersion},
+		{"metallb", metallbVersion},
+	}
+	if tc.Spec.Addons.Ingress.IsIngressEnabled() {
+		traefikVersion := addons.DefaultTraefikVersion
+		if tc.Spec.Addons.Ingress != nil && tc.Spec.Addons.Ingress.Version != "" {
+			traefikVersion = tc.Spec.Addons.Ingress.Version
+		}
+		expected = append(expected, expectedAddon{"traefik", traefikVersion})
+	}
+
+	// Index observed state by addon name for lookup.
+	observed := make(map[string]string) // name -> status
+	if tc.Status.ObservedState != nil {
+		for _, a := range tc.Status.ObservedState.Addons {
+			observed[a.Name] = a.Status
 		}
 	}
-	if len(failed) == 0 {
+
+	// Collect addons that need retry: Failed in observedState OR absent entirely.
+	var needsRetry []expectedAddon
+	for _, ea := range expected {
+		status, present := observed[ea.name]
+		if !present || status == "Failed" {
+			needsRetry = append(needsRetry, ea)
+		}
+	}
+	if len(needsRetry) == 0 {
 		return false, nil
 	}
 
@@ -271,43 +313,31 @@ func (r *Reconciler) reconcileAddonHealth(ctx context.Context, tc *butlerv1alpha
 	}
 
 	var stillFailed []string
-	updated := make(map[string]string) // addon name -> new status
 
-	for _, addon := range failed {
+	for _, addon := range needsRetry {
 		var installErr error
-		switch addon.Name {
+		switch addon.name {
 		case "cert-manager":
-			installErr = r.Installer.InstallCertManager(ctx, kubeconfigData, addon.Version)
+			installErr = r.Installer.InstallCertManager(ctx, kubeconfigData, addon.version)
 		case "longhorn":
-			installErr = r.Installer.InstallLonghorn(ctx, kubeconfigData, addon.Version)
+			installErr = r.Installer.InstallLonghorn(ctx, kubeconfigData, addon.version)
 		case "metallb":
 			poolStart, poolEnd := r.resolveMetalLBPool(ctx, tc)
-			installErr = r.Installer.InstallMetalLB(ctx, kubeconfigData, addon.Version, poolStart, poolEnd)
+			installErr = r.Installer.InstallMetalLB(ctx, kubeconfigData, addon.version, poolStart, poolEnd)
 		case "traefik":
-			installErr = r.Installer.InstallTraefik(ctx, kubeconfigData, addon.Version)
-		default:
-			logger.V(1).Info("skipping unknown addon for retry", "addon", addon.Name)
-			continue
+			installErr = r.Installer.InstallTraefik(ctx, kubeconfigData, addon.version)
 		}
 
 		if installErr != nil {
-			logger.Error(installErr, "addon retry failed", "addon", addon.Name)
-			stillFailed = append(stillFailed, addon.Name)
+			logger.Error(installErr, "addon retry failed", "addon", addon.name)
+			stillFailed = append(stillFailed, addon.name)
 		} else {
-			logger.Info("addon retry succeeded", "addon", addon.Name)
+			logger.Info("addon retry succeeded", "addon", addon.name)
 			r.Recorder.Eventf(tc, corev1.EventTypeNormal, "AddonRetrySucceeded",
-				"%s installed successfully on retry", addon.Name)
-			updated[addon.Name] = "Healthy"
+				"%s installed successfully on retry", addon.name)
 		}
-	}
-
-	// Apply status changes to observed state
-	if len(updated) > 0 {
-		for i := range tc.Status.ObservedState.Addons {
-			if newStatus, ok := updated[tc.Status.ObservedState.Addons[i].Name]; ok {
-				tc.Status.ObservedState.Addons[i].Status = newStatus
-			}
-		}
+		// Update or append observedState entry.
+		r.upsertAddonStatus(tc, addon.name, addon.version, installErr)
 	}
 
 	// Update AddonsReady condition
@@ -321,6 +351,31 @@ func (r *Reconciler) reconcileAddonHealth(ctx context.Context, tc *butlerv1alpha
 	}
 
 	return len(stillFailed) > 0, nil
+}
+
+// upsertAddonStatus updates an existing addon entry in observedState or appends
+// a new one if the addon was absent.
+func (r *Reconciler) upsertAddonStatus(tc *butlerv1alpha1.TenantCluster, name, version string, installErr error) {
+	status := "Healthy"
+	if installErr != nil {
+		status = "Failed"
+	}
+
+	if tc.Status.ObservedState == nil {
+		tc.Status.ObservedState = &butlerv1alpha1.ObservedClusterState{}
+	}
+
+	for i := range tc.Status.ObservedState.Addons {
+		if tc.Status.ObservedState.Addons[i].Name == name {
+			tc.Status.ObservedState.Addons[i].Status = status
+			tc.Status.ObservedState.Addons[i].Version = version
+			return
+		}
+	}
+	// Absent: append new entry.
+	tc.Status.ObservedState.Addons = append(tc.Status.ObservedState.Addons, butlerv1alpha1.AddonStatus{
+		Name: name, Version: version, Status: status, ManagedBy: "butler",
+	})
 }
 
 // reconcileAutoEnrollObservability creates TenantAddon resources for observability

--- a/internal/controller/tenantcluster/reconcile_addons_test.go
+++ b/internal/controller/tenantcluster/reconcile_addons_test.go
@@ -61,6 +61,32 @@ func (m *mockInstaller) UpdateMetalLBPool(_ context.Context, _ []byte, _ []strin
 	return m.updateMetalLBPoolErr
 }
 
+// allHealthyAddons returns an observedState with all expected non-CNI addons as
+// Healthy, matching what reconcileAddons would produce on a successful install.
+func allHealthyAddons() *butlerv1alpha1.ObservedClusterState {
+	return &butlerv1alpha1.ObservedClusterState{
+		Addons: []butlerv1alpha1.AddonStatus{
+			{Name: "cilium", Version: "1.17.0", Status: "Healthy", ManagedBy: "butler"},
+			{Name: "cert-manager", Version: "v1.16.2", Status: "Healthy", ManagedBy: "butler"},
+			{Name: "longhorn", Version: "1.7.2", Status: "Healthy", ManagedBy: "butler"},
+			{Name: "metallb", Version: "0.14.9", Status: "Healthy", ManagedBy: "butler"},
+			{Name: "traefik", Version: "34.3.0", Status: "Healthy", ManagedBy: "butler"},
+		},
+	}
+}
+
+func kubeconfigSecret(tcName, tenantNS string) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      tcName + "-admin-kubeconfig",
+			Namespace: tenantNS,
+		},
+		Data: map[string][]byte{
+			"admin.conf": []byte("fake-kubeconfig"),
+		},
+	}
+}
+
 func TestReconcileAddonHealth_NoFailedAddons(t *testing.T) {
 	scheme := runtime.NewScheme()
 	_ = butlerv1alpha1.AddToScheme(scheme)
@@ -69,12 +95,7 @@ func TestReconcileAddonHealth_NoFailedAddons(t *testing.T) {
 	tc := &butlerv1alpha1.TenantCluster{
 		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "team-a"},
 		Status: butlerv1alpha1.TenantClusterStatus{
-			ObservedState: &butlerv1alpha1.ObservedClusterState{
-				Addons: []butlerv1alpha1.AddonStatus{
-					{Name: "cilium", Version: "1.17.0", Status: "Healthy", ManagedBy: "butler"},
-					{Name: "cert-manager", Version: "v1.16.2", Status: "Healthy", ManagedBy: "butler"},
-				},
-			},
+			ObservedState: allHealthyAddons(),
 		},
 	}
 
@@ -92,7 +113,7 @@ func TestReconcileAddonHealth_NoFailedAddons(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if retryNeeded {
-		t.Error("expected retryNeeded=false when no addons are failed")
+		t.Error("expected retryNeeded=false when all addons are healthy")
 	}
 	if installer.certManagerCalls != 0 {
 		t.Errorf("expected 0 cert-manager calls, got %d", installer.certManagerCalls)
@@ -102,17 +123,27 @@ func TestReconcileAddonHealth_NoFailedAddons(t *testing.T) {
 func TestReconcileAddonHealth_NilObservedState(t *testing.T) {
 	scheme := runtime.NewScheme()
 	_ = butlerv1alpha1.AddToScheme(scheme)
+	_ = corev1.AddToScheme(scheme)
 
+	// Nil observedState with a Ready cluster means all expected addons are
+	// absent. Retry should be attempted for each one.
 	tc := &butlerv1alpha1.TenantCluster{
 		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "team-a"},
-		Status:     butlerv1alpha1.TenantClusterStatus{},
+		Status: butlerv1alpha1.TenantClusterStatus{
+			TenantNamespace: "test-abc123",
+		},
 	}
 
-	cl := fakeclient.NewClientBuilder().WithScheme(scheme).Build()
+	cl := fakeclient.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(kubeconfigSecret("test", "test-abc123")).
+		Build()
+
+	installer := &mockInstaller{}
 	r := &Reconciler{
 		Client:    cl,
 		Scheme:    scheme,
-		Installer: &mockInstaller{},
+		Installer: installer,
 		Recorder:  record.NewFakeRecorder(10),
 	}
 
@@ -121,7 +152,27 @@ func TestReconcileAddonHealth_NilObservedState(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if retryNeeded {
-		t.Error("expected retryNeeded=false with nil ObservedState")
+		t.Error("expected retryNeeded=false when all retries succeed")
+	}
+	// All 4 expected addons should be retried (ingress defaults to enabled).
+	if installer.certManagerCalls != 1 {
+		t.Errorf("expected 1 cert-manager call, got %d", installer.certManagerCalls)
+	}
+	if installer.longhornCalls != 1 {
+		t.Errorf("expected 1 longhorn call, got %d", installer.longhornCalls)
+	}
+	if installer.metalLBCalls != 1 {
+		t.Errorf("expected 1 metallb call, got %d", installer.metalLBCalls)
+	}
+	if installer.traefikCalls != 1 {
+		t.Errorf("expected 1 traefik call, got %d", installer.traefikCalls)
+	}
+	// ObservedState should now contain all 4 addons.
+	if tc.Status.ObservedState == nil {
+		t.Fatal("observedState should not be nil after retry")
+	}
+	if len(tc.Status.ObservedState.Addons) != 4 {
+		t.Errorf("expected 4 addons in observedState, got %d", len(tc.Status.ObservedState.Addons))
 	}
 }
 
@@ -129,18 +180,6 @@ func TestReconcileAddonHealth_RetrySucceeds(t *testing.T) {
 	scheme := runtime.NewScheme()
 	_ = butlerv1alpha1.AddToScheme(scheme)
 	_ = corev1.AddToScheme(scheme)
-
-	// Simulate a cluster where cert-manager and longhorn initially failed.
-	// The kubeconfig secret must exist for getTenantKubeconfig to succeed.
-	kubeconfigSecret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-admin-kubeconfig",
-			Namespace: "test-abc123",
-		},
-		Data: map[string][]byte{
-			"admin.conf": []byte("fake-kubeconfig"),
-		},
-	}
 
 	tc := &butlerv1alpha1.TenantCluster{
 		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "team-a"},
@@ -152,6 +191,7 @@ func TestReconcileAddonHealth_RetrySucceeds(t *testing.T) {
 					{Name: "cert-manager", Version: "v1.16.2", Status: "Failed", ManagedBy: "butler"},
 					{Name: "longhorn", Version: "1.7.2", Status: "Failed", ManagedBy: "butler"},
 					{Name: "metallb", Version: "0.14.9", Status: "Healthy", ManagedBy: "butler"},
+					{Name: "traefik", Version: "34.3.0", Status: "Healthy", ManagedBy: "butler"},
 				},
 			},
 		},
@@ -159,7 +199,7 @@ func TestReconcileAddonHealth_RetrySucceeds(t *testing.T) {
 
 	cl := fakeclient.NewClientBuilder().
 		WithScheme(scheme).
-		WithObjects(kubeconfigSecret).
+		WithObjects(kubeconfigSecret("test", "test-abc123")).
 		Build()
 
 	recorder := record.NewFakeRecorder(10)
@@ -212,24 +252,17 @@ func TestReconcileAddonHealth_RetryPartialFailure(t *testing.T) {
 	_ = butlerv1alpha1.AddToScheme(scheme)
 	_ = corev1.AddToScheme(scheme)
 
-	kubeconfigSecret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-admin-kubeconfig",
-			Namespace: "test-abc123",
-		},
-		Data: map[string][]byte{
-			"admin.conf": []byte("fake-kubeconfig"),
-		},
-	}
-
 	tc := &butlerv1alpha1.TenantCluster{
 		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "team-a"},
 		Status: butlerv1alpha1.TenantClusterStatus{
 			TenantNamespace: "test-abc123",
 			ObservedState: &butlerv1alpha1.ObservedClusterState{
 				Addons: []butlerv1alpha1.AddonStatus{
+					{Name: "cilium", Version: "1.17.0", Status: "Healthy", ManagedBy: "butler"},
 					{Name: "cert-manager", Version: "v1.16.2", Status: "Failed", ManagedBy: "butler"},
 					{Name: "longhorn", Version: "1.7.2", Status: "Failed", ManagedBy: "butler"},
+					{Name: "metallb", Version: "0.14.9", Status: "Healthy", ManagedBy: "butler"},
+					{Name: "traefik", Version: "34.3.0", Status: "Healthy", ManagedBy: "butler"},
 				},
 			},
 		},
@@ -237,7 +270,7 @@ func TestReconcileAddonHealth_RetryPartialFailure(t *testing.T) {
 
 	cl := fakeclient.NewClientBuilder().
 		WithScheme(scheme).
-		WithObjects(kubeconfigSecret).
+		WithObjects(kubeconfigSecret("test", "test-abc123")).
 		Build()
 
 	recorder := record.NewFakeRecorder(10)
@@ -294,16 +327,6 @@ func TestReconcileAddonHealth_MetalLBRetryUsesPoolResolution(t *testing.T) {
 	_ = butlerv1alpha1.AddToScheme(scheme)
 	_ = corev1.AddToScheme(scheme)
 
-	kubeconfigSecret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-admin-kubeconfig",
-			Namespace: "test-abc123",
-		},
-		Data: map[string][]byte{
-			"admin.conf": []byte("fake-kubeconfig"),
-		},
-	}
-
 	// MetalLB failed on initial install. The pool allocation exists.
 	lbAlloc := &butlerv1alpha1.IPAllocation{
 		ObjectMeta: metav1.ObjectMeta{
@@ -326,7 +349,11 @@ func TestReconcileAddonHealth_MetalLBRetryUsesPoolResolution(t *testing.T) {
 			},
 			ObservedState: &butlerv1alpha1.ObservedClusterState{
 				Addons: []butlerv1alpha1.AddonStatus{
+					{Name: "cilium", Version: "1.17.0", Status: "Healthy", ManagedBy: "butler"},
+					{Name: "cert-manager", Version: "v1.16.2", Status: "Healthy", ManagedBy: "butler"},
+					{Name: "longhorn", Version: "1.7.2", Status: "Healthy", ManagedBy: "butler"},
 					{Name: "metallb", Version: "0.14.9", Status: "Failed", ManagedBy: "butler"},
+					{Name: "traefik", Version: "34.3.0", Status: "Healthy", ManagedBy: "butler"},
 				},
 			},
 		},
@@ -334,7 +361,7 @@ func TestReconcileAddonHealth_MetalLBRetryUsesPoolResolution(t *testing.T) {
 
 	cl := fakeclient.NewClientBuilder().
 		WithScheme(scheme).
-		WithObjects(kubeconfigSecret, lbAlloc).
+		WithObjects(kubeconfigSecret("test", "test-abc123"), lbAlloc).
 		Build()
 
 	installer := &mockInstaller{}
@@ -362,33 +389,26 @@ func TestReconcileAddonHealth_SkipsUnknownAddons(t *testing.T) {
 	_ = butlerv1alpha1.AddToScheme(scheme)
 	_ = corev1.AddToScheme(scheme)
 
-	kubeconfigSecret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-admin-kubeconfig",
-			Namespace: "test-abc123",
-		},
-		Data: map[string][]byte{
-			"admin.conf": []byte("fake-kubeconfig"),
-		},
-	}
-
+	// An unexpected addon is present but Failed. It should not be retried
+	// (not in the expected list) and should not be removed from observedState.
 	tc := &butlerv1alpha1.TenantCluster{
 		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "team-a"},
 		Status: butlerv1alpha1.TenantClusterStatus{
 			TenantNamespace: "test-abc123",
 			ObservedState: &butlerv1alpha1.ObservedClusterState{
 				Addons: []butlerv1alpha1.AddonStatus{
+					{Name: "cilium", Version: "1.17.0", Status: "Healthy", ManagedBy: "butler"},
+					{Name: "cert-manager", Version: "v1.16.2", Status: "Healthy", ManagedBy: "butler"},
+					{Name: "longhorn", Version: "1.7.2", Status: "Healthy", ManagedBy: "butler"},
+					{Name: "metallb", Version: "0.14.9", Status: "Healthy", ManagedBy: "butler"},
+					{Name: "traefik", Version: "34.3.0", Status: "Healthy", ManagedBy: "butler"},
 					{Name: "unknown-addon", Version: "1.0.0", Status: "Failed", ManagedBy: "butler"},
 				},
 			},
 		},
 	}
 
-	cl := fakeclient.NewClientBuilder().
-		WithScheme(scheme).
-		WithObjects(kubeconfigSecret).
-		Build()
-
+	cl := fakeclient.NewClientBuilder().WithScheme(scheme).Build()
 	installer := &mockInstaller{}
 	r := &Reconciler{
 		Client:    cl,
@@ -401,9 +421,283 @@ func TestReconcileAddonHealth_SkipsUnknownAddons(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	// Unknown addons are skipped, not counted as still-failed
 	if retryNeeded {
-		t.Error("expected retryNeeded=false for unknown addon")
+		t.Error("expected retryNeeded=false — unknown addons are not retried")
+	}
+
+	// unknown-addon should still be in observedState, untouched
+	found := false
+	for _, a := range tc.Status.ObservedState.Addons {
+		if a.Name == "unknown-addon" {
+			found = true
+			if a.Status != "Failed" {
+				t.Errorf("unknown-addon status = %s, want Failed (untouched)", a.Status)
+			}
+		}
+	}
+	if !found {
+		t.Error("unknown-addon was removed from observedState — it should be left in place")
+	}
+}
+
+func TestReconcileAddonHealth_AbsentAddonRetrySucceeds(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = butlerv1alpha1.AddToScheme(scheme)
+	_ = corev1.AddToScheme(scheme)
+
+	// Traefik is expected (ingress nil -> enabled) but absent from observedState.
+	// This is the tempo-prd scenario: initial install failed silently before
+	// failure tracking existed.
+	tc := &butlerv1alpha1.TenantCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "team-a"},
+		Status: butlerv1alpha1.TenantClusterStatus{
+			TenantNamespace: "test-abc123",
+			ObservedState: &butlerv1alpha1.ObservedClusterState{
+				Addons: []butlerv1alpha1.AddonStatus{
+					{Name: "cilium", Version: "1.17.0", Status: "Healthy", ManagedBy: "butler"},
+					{Name: "cert-manager", Version: "v1.16.2", Status: "Healthy", ManagedBy: "butler"},
+					{Name: "longhorn", Version: "1.7.2", Status: "Healthy", ManagedBy: "butler"},
+					{Name: "metallb", Version: "0.14.9", Status: "Healthy", ManagedBy: "butler"},
+					// traefik absent
+				},
+			},
+		},
+	}
+
+	cl := fakeclient.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(kubeconfigSecret("test", "test-abc123")).
+		Build()
+
+	installer := &mockInstaller{} // traefik install succeeds
+	recorder := record.NewFakeRecorder(10)
+	r := &Reconciler{
+		Client:    cl,
+		Scheme:    scheme,
+		Installer: installer,
+		Recorder:  recorder,
+	}
+
+	retryNeeded, err := r.reconcileAddonHealth(context.Background(), tc, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if retryNeeded {
+		t.Error("expected retryNeeded=false after successful retry of absent addon")
+	}
+	if installer.traefikCalls != 1 {
+		t.Errorf("expected 1 traefik call for absent addon, got %d", installer.traefikCalls)
+	}
+	// Only traefik should be retried, not the healthy addons.
+	if installer.certManagerCalls != 0 {
+		t.Errorf("expected 0 cert-manager calls, got %d", installer.certManagerCalls)
+	}
+
+	// Traefik should now appear in observedState as Healthy.
+	var traefikStatus string
+	for _, a := range tc.Status.ObservedState.Addons {
+		if a.Name == "traefik" {
+			traefikStatus = a.Status
+		}
+	}
+	if traefikStatus != "Healthy" {
+		t.Errorf("traefik status = %q, want Healthy (should be appended to observedState)", traefikStatus)
+	}
+
+	// AddonsReady should be True
+	for _, c := range tc.Status.Conditions {
+		if c.Type == butlerv1alpha1.TenantClusterConditionAddonsReady {
+			if c.Status != metav1.ConditionTrue {
+				t.Errorf("AddonsReady condition = %s, want True", c.Status)
+			}
+			return
+		}
+	}
+	t.Error("AddonsReady condition not found")
+}
+
+func TestReconcileAddonHealth_AbsentAddonRetryFails(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = butlerv1alpha1.AddToScheme(scheme)
+	_ = corev1.AddToScheme(scheme)
+
+	// Traefik absent and retry will fail.
+	tc := &butlerv1alpha1.TenantCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "team-a"},
+		Status: butlerv1alpha1.TenantClusterStatus{
+			TenantNamespace: "test-abc123",
+			ObservedState: &butlerv1alpha1.ObservedClusterState{
+				Addons: []butlerv1alpha1.AddonStatus{
+					{Name: "cilium", Version: "1.17.0", Status: "Healthy", ManagedBy: "butler"},
+					{Name: "cert-manager", Version: "v1.16.2", Status: "Healthy", ManagedBy: "butler"},
+					{Name: "longhorn", Version: "1.7.2", Status: "Healthy", ManagedBy: "butler"},
+					{Name: "metallb", Version: "0.14.9", Status: "Healthy", ManagedBy: "butler"},
+				},
+			},
+		},
+	}
+
+	cl := fakeclient.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(kubeconfigSecret("test", "test-abc123")).
+		Build()
+
+	installer := &mockInstaller{
+		installTraefikErr: fmt.Errorf("chart repo unreachable"),
+	}
+	recorder := record.NewFakeRecorder(10)
+	r := &Reconciler{
+		Client:    cl,
+		Scheme:    scheme,
+		Installer: installer,
+		Recorder:  recorder,
+	}
+
+	retryNeeded, err := r.reconcileAddonHealth(context.Background(), tc, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !retryNeeded {
+		t.Error("expected retryNeeded=true when absent addon retry fails")
+	}
+
+	// Traefik should now appear in observedState as Failed (appended).
+	var traefikStatus string
+	for _, a := range tc.Status.ObservedState.Addons {
+		if a.Name == "traefik" {
+			traefikStatus = a.Status
+		}
+	}
+	if traefikStatus != "Failed" {
+		t.Errorf("traefik status = %q, want Failed (should be appended with failed status)", traefikStatus)
+	}
+
+	// AddonsReady should be False with AddonInstallFailed reason
+	for _, c := range tc.Status.Conditions {
+		if c.Type == butlerv1alpha1.TenantClusterConditionAddonsReady {
+			if c.Status != metav1.ConditionFalse {
+				t.Errorf("AddonsReady condition = %s, want False", c.Status)
+			}
+			if c.Reason != ReasonAddonInstallFailed {
+				t.Errorf("AddonsReady reason = %s, want %s", c.Reason, ReasonAddonInstallFailed)
+			}
+			return
+		}
+	}
+	t.Error("AddonsReady condition not found")
+}
+
+func TestReconcileAddonHealth_IngressDisabledSkipsTraefik(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = butlerv1alpha1.AddToScheme(scheme)
+	_ = corev1.AddToScheme(scheme)
+
+	// Ingress explicitly disabled. Traefik absent from observedState should
+	// NOT trigger a retry.
+	enabled := false
+	tc := &butlerv1alpha1.TenantCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "team-a"},
+		Spec: butlerv1alpha1.TenantClusterSpec{
+			Addons: butlerv1alpha1.AddonsSpec{
+				Ingress: &butlerv1alpha1.IngressSpec{
+					Enabled: &enabled,
+				},
+			},
+		},
+		Status: butlerv1alpha1.TenantClusterStatus{
+			ObservedState: &butlerv1alpha1.ObservedClusterState{
+				Addons: []butlerv1alpha1.AddonStatus{
+					{Name: "cilium", Version: "1.17.0", Status: "Healthy", ManagedBy: "butler"},
+					{Name: "cert-manager", Version: "v1.16.2", Status: "Healthy", ManagedBy: "butler"},
+					{Name: "longhorn", Version: "1.7.2", Status: "Healthy", ManagedBy: "butler"},
+					{Name: "metallb", Version: "0.14.9", Status: "Healthy", ManagedBy: "butler"},
+				},
+			},
+		},
+	}
+
+	cl := fakeclient.NewClientBuilder().WithScheme(scheme).Build()
+	installer := &mockInstaller{}
+	r := &Reconciler{
+		Client:    cl,
+		Scheme:    scheme,
+		Installer: installer,
+		Recorder:  record.NewFakeRecorder(10),
+	}
+
+	retryNeeded, err := r.reconcileAddonHealth(context.Background(), tc, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if retryNeeded {
+		t.Error("expected retryNeeded=false — traefik not expected when ingress disabled")
+	}
+	if installer.traefikCalls != 0 {
+		t.Errorf("expected 0 traefik calls, got %d", installer.traefikCalls)
+	}
+}
+
+func TestReconcileAddonHealth_MixedFailedAndAbsent(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = butlerv1alpha1.AddToScheme(scheme)
+	_ = corev1.AddToScheme(scheme)
+
+	// cert-manager is Failed, traefik is absent. Both should be retried.
+	tc := &butlerv1alpha1.TenantCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "team-a"},
+		Status: butlerv1alpha1.TenantClusterStatus{
+			TenantNamespace: "test-abc123",
+			ObservedState: &butlerv1alpha1.ObservedClusterState{
+				Addons: []butlerv1alpha1.AddonStatus{
+					{Name: "cilium", Version: "1.17.0", Status: "Healthy", ManagedBy: "butler"},
+					{Name: "cert-manager", Version: "v1.16.2", Status: "Failed", ManagedBy: "butler"},
+					{Name: "longhorn", Version: "1.7.2", Status: "Healthy", ManagedBy: "butler"},
+					{Name: "metallb", Version: "0.14.9", Status: "Healthy", ManagedBy: "butler"},
+					// traefik absent
+				},
+			},
+		},
+	}
+
+	cl := fakeclient.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(kubeconfigSecret("test", "test-abc123")).
+		Build()
+
+	installer := &mockInstaller{} // all succeed
+	recorder := record.NewFakeRecorder(10)
+	r := &Reconciler{
+		Client:    cl,
+		Scheme:    scheme,
+		Installer: installer,
+		Recorder:  recorder,
+	}
+
+	retryNeeded, err := r.reconcileAddonHealth(context.Background(), tc, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if retryNeeded {
+		t.Error("expected retryNeeded=false when all retries succeed")
+	}
+	if installer.certManagerCalls != 1 {
+		t.Errorf("expected 1 cert-manager call (Failed), got %d", installer.certManagerCalls)
+	}
+	if installer.traefikCalls != 1 {
+		t.Errorf("expected 1 traefik call (absent), got %d", installer.traefikCalls)
+	}
+	if installer.longhornCalls != 0 {
+		t.Errorf("expected 0 longhorn calls (Healthy), got %d", installer.longhornCalls)
+	}
+
+	// Both should now be Healthy in observedState
+	for _, a := range tc.Status.ObservedState.Addons {
+		if a.Name == "cert-manager" && a.Status != "Healthy" {
+			t.Errorf("cert-manager status = %s, want Healthy", a.Status)
+		}
+		if a.Name == "traefik" && a.Status != "Healthy" {
+			t.Errorf("traefik status = %s, want Healthy", a.Status)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

- reconcileAddonHealth now detects expected addons that are absent from observedState, not just addons with Status=Failed
- Expected addons list is computed from the TenantCluster spec using the same version resolution as reconcileAddons
- On successful retry of an absent addon, the addon is appended to observedState as Healthy
- On failed retry, the addon is appended as Failed so subsequent reconciles can retry it normally

Fixes a gap in butler-controller#93 where addons that failed silently during initial install (before failure tracking was added) were never detected or retried by the steady-state health check.

## Validation

Validated against production cluster. tempo-prd had Traefik absent from observedState since initial provisioning (April 29). The new detection identified Traefik as absent and installed it successfully on first retry (34 seconds). Traefik is now running on tempo-prd with external IP 10.92.90.44.

No false positives on any of the 7 healthy clusters. All remain Ready=True, AddonsReady=True.

## Test plan

- [x] `TestReconcileAddonHealth_AbsentAddonRetrySucceeds` — expected addon absent, retry succeeds, observedState updated
- [x] `TestReconcileAddonHealth_AbsentAddonRetryFails` — expected addon absent, retry fails, condition set to False
- [x] `TestReconcileAddonHealth_IngressDisabledSkipsTraefik` — Traefik not expected when ingress disabled
- [x] `TestReconcileAddonHealth_MixedFailedAndAbsent` — both Failed and absent addons retried in same pass
- [x] `TestReconcileAddonHealth_SkipsUnknownAddons` — unexpected addons in observedState left untouched
- [x] All existing tests updated and passing (13 total)
- [x] `go build`, `go vet` clean
- [x] Local validation against production fleet (8 clusters, tempo-prd self-healed)