### PR TITLE
fix(ipam): deduct in-flight growth from demand assessment

### DIFF
--- a/internal/controller/tenantcluster/reconcile_ipam.go
+++ b/internal/controller/tenantcluster/reconcile_ipam.go
@@ -249,6 +249,42 @@ func (r *Reconciler) reconcileElasticIPAM(ctx context.Context, tc *butlerv1alpha
 		}
 	}
 
+	// Deduct in-flight growth allocations whose IPs haven't been consumed
+	// by any tenant LB Service yet. A Pending growth allocation means the
+	// NetworkPool controller hasn't fulfilled it. An Allocated growth
+	// allocation with no matching Service IP means the IPs reached the pool
+	// but MetalLB hasn't assigned them to a Service. Both represent supply
+	// already committed to satisfy demand — counting them prevents redundant
+	// growth when a watch-triggered reconcile fires before MetalLB
+	// propagation completes.
+	var inFlightSupply int32
+	for i := range allocs {
+		alloc := &allocs[i]
+		if alloc.Labels[LabelAllocationRole] != AllocationRoleGrowth {
+			continue
+		}
+		if alloc.Spec.Count == nil {
+			continue
+		}
+		switch alloc.Status.Phase {
+		case butlerv1alpha1.IPAllocationPhasePending:
+			inFlightSupply += *alloc.Spec.Count
+		case butlerv1alpha1.IPAllocationPhaseAllocated:
+			if !allocationHasServiceIP(alloc, serviceIPs) {
+				inFlightSupply += *alloc.Spec.Count
+			}
+		}
+	}
+	qualifiedPending -= inFlightSupply
+	if qualifiedPending < 0 {
+		qualifiedPending = 0
+	}
+	if inFlightSupply > 0 {
+		logger.V(1).Info("elastic IPAM: in-flight growth supply deducted from demand",
+			"rawPending", qualifiedPending+inFlightSupply, "inFlightSupply", inFlightSupply,
+			"netPending", qualifiedPending)
+	}
+
 	if qualifiedPending > 0 {
 		// Batch assessment: allocate enough IPs for all qualified Pending services,
 		// but at least growthIncrement to avoid undersized allocations.

--- a/internal/controller/tenantcluster/reconcile_ipam_test.go
+++ b/internal/controller/tenantcluster/reconcile_ipam_test.go
@@ -2026,3 +2026,221 @@ func TestMapIPAllocationToTenantCluster(t *testing.T) {
 		})
 	}
 }
+
+func TestInFlightGrowthDeduction(t *testing.T) {
+	// Validates the in-flight growth supply deduction that prevents redundant
+	// growth allocations when a watch-triggered reconcile fires before MetalLB
+	// propagation completes.
+	//
+	// The growth path computes qualifiedPending (Services stuck Pending long
+	// enough) and then subtracts in-flight supply: growth allocations that are
+	// Pending (awaiting fulfillment) or Allocated but unconsumed (no tenant
+	// Service is using any IP from the allocation's range).
+
+	int32Ptr := func(v int32) *int32 { return &v }
+
+	tests := []struct {
+		name           string
+		pendingServices []LBServiceSummary
+		allocs         []butlerv1alpha1.IPAllocation
+		serviceIPs     map[string]bool
+		wantNetPending int32
+	}{
+		{
+			name: "no in-flight allocations: growth fires normally",
+			pendingServices: []LBServiceSummary{
+				{Name: "stuck-svc", Namespace: "default", CreatedAt: time.Now().Add(-2 * time.Minute)},
+			},
+			allocs: []butlerv1alpha1.IPAllocation{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{LabelAllocationRole: AllocationRoleInitial},
+					},
+					Spec:   butlerv1alpha1.IPAllocationSpec{Count: int32Ptr(2)},
+					Status: butlerv1alpha1.IPAllocationStatus{Phase: butlerv1alpha1.IPAllocationPhaseAllocated, StartAddress: "10.0.0.1", EndAddress: "10.0.0.2"},
+				},
+			},
+			serviceIPs:     map[string]bool{"10.0.0.1": true, "10.0.0.2": true},
+			wantNetPending: 1,
+		},
+		{
+			name: "pending growth allocation covers demand: growth suppressed",
+			pendingServices: []LBServiceSummary{
+				{Name: "stuck-svc", Namespace: "default", CreatedAt: time.Now().Add(-2 * time.Minute)},
+			},
+			allocs: []butlerv1alpha1.IPAllocation{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{LabelAllocationRole: AllocationRoleInitial},
+					},
+					Spec:   butlerv1alpha1.IPAllocationSpec{Count: int32Ptr(2)},
+					Status: butlerv1alpha1.IPAllocationStatus{Phase: butlerv1alpha1.IPAllocationPhaseAllocated, StartAddress: "10.0.0.1", EndAddress: "10.0.0.2"},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{LabelAllocationRole: AllocationRoleGrowth},
+					},
+					Spec:   butlerv1alpha1.IPAllocationSpec{Count: int32Ptr(1)},
+					Status: butlerv1alpha1.IPAllocationStatus{Phase: butlerv1alpha1.IPAllocationPhasePending},
+				},
+			},
+			serviceIPs:     map[string]bool{"10.0.0.1": true, "10.0.0.2": true},
+			wantNetPending: 0,
+		},
+		{
+			name: "allocated unconsumed growth covers demand: growth suppressed",
+			pendingServices: []LBServiceSummary{
+				{Name: "stuck-svc", Namespace: "default", CreatedAt: time.Now().Add(-2 * time.Minute)},
+			},
+			allocs: []butlerv1alpha1.IPAllocation{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{LabelAllocationRole: AllocationRoleInitial},
+					},
+					Spec:   butlerv1alpha1.IPAllocationSpec{Count: int32Ptr(2)},
+					Status: butlerv1alpha1.IPAllocationStatus{Phase: butlerv1alpha1.IPAllocationPhaseAllocated, StartAddress: "10.0.0.1", EndAddress: "10.0.0.2"},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{LabelAllocationRole: AllocationRoleGrowth},
+					},
+					Spec:   butlerv1alpha1.IPAllocationSpec{Count: int32Ptr(1)},
+					Status: butlerv1alpha1.IPAllocationStatus{Phase: butlerv1alpha1.IPAllocationPhaseAllocated, StartAddress: "10.0.0.3", EndAddress: "10.0.0.3"},
+				},
+			},
+			serviceIPs:     map[string]bool{"10.0.0.1": true, "10.0.0.2": true},
+			wantNetPending: 0,
+		},
+		{
+			name: "consumed growth allocation not counted as in-flight: growth fires",
+			pendingServices: []LBServiceSummary{
+				{Name: "stuck-svc", Namespace: "default", CreatedAt: time.Now().Add(-2 * time.Minute)},
+			},
+			allocs: []butlerv1alpha1.IPAllocation{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{LabelAllocationRole: AllocationRoleInitial},
+					},
+					Spec:   butlerv1alpha1.IPAllocationSpec{Count: int32Ptr(2)},
+					Status: butlerv1alpha1.IPAllocationStatus{Phase: butlerv1alpha1.IPAllocationPhaseAllocated, StartAddress: "10.0.0.1", EndAddress: "10.0.0.2"},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{LabelAllocationRole: AllocationRoleGrowth},
+					},
+					Spec:   butlerv1alpha1.IPAllocationSpec{Count: int32Ptr(1)},
+					Status: butlerv1alpha1.IPAllocationStatus{Phase: butlerv1alpha1.IPAllocationPhaseAllocated, StartAddress: "10.0.0.3", EndAddress: "10.0.0.3"},
+				},
+			},
+			serviceIPs:     map[string]bool{"10.0.0.1": true, "10.0.0.2": true, "10.0.0.3": true},
+			wantNetPending: 1,
+		},
+		{
+			name: "two pending services with one in-flight: partial coverage, growth fires for remainder",
+			pendingServices: []LBServiceSummary{
+				{Name: "svc-a", Namespace: "default", CreatedAt: time.Now().Add(-2 * time.Minute)},
+				{Name: "svc-b", Namespace: "default", CreatedAt: time.Now().Add(-3 * time.Minute)},
+			},
+			allocs: []butlerv1alpha1.IPAllocation{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{LabelAllocationRole: AllocationRoleInitial},
+					},
+					Spec:   butlerv1alpha1.IPAllocationSpec{Count: int32Ptr(2)},
+					Status: butlerv1alpha1.IPAllocationStatus{Phase: butlerv1alpha1.IPAllocationPhaseAllocated, StartAddress: "10.0.0.1", EndAddress: "10.0.0.2"},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{LabelAllocationRole: AllocationRoleGrowth},
+					},
+					Spec:   butlerv1alpha1.IPAllocationSpec{Count: int32Ptr(1)},
+					Status: butlerv1alpha1.IPAllocationStatus{Phase: butlerv1alpha1.IPAllocationPhasePending},
+				},
+			},
+			serviceIPs:     map[string]bool{"10.0.0.1": true, "10.0.0.2": true},
+			wantNetPending: 1,
+		},
+		{
+			name: "initial allocation never counted as in-flight",
+			pendingServices: []LBServiceSummary{
+				{Name: "stuck-svc", Namespace: "default", CreatedAt: time.Now().Add(-2 * time.Minute)},
+			},
+			allocs: []butlerv1alpha1.IPAllocation{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{LabelAllocationRole: AllocationRoleInitial},
+					},
+					Spec:   butlerv1alpha1.IPAllocationSpec{Count: int32Ptr(2)},
+					Status: butlerv1alpha1.IPAllocationStatus{Phase: butlerv1alpha1.IPAllocationPhaseAllocated, StartAddress: "10.0.0.1", EndAddress: "10.0.0.2"},
+				},
+			},
+			serviceIPs:     map[string]bool{},
+			wantNetPending: 1,
+		},
+		{
+			name: "in-flight supply exceeds demand: clamps to zero",
+			pendingServices: []LBServiceSummary{
+				{Name: "stuck-svc", Namespace: "default", CreatedAt: time.Now().Add(-2 * time.Minute)},
+			},
+			allocs: []butlerv1alpha1.IPAllocation{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{LabelAllocationRole: AllocationRoleInitial},
+					},
+					Spec:   butlerv1alpha1.IPAllocationSpec{Count: int32Ptr(2)},
+					Status: butlerv1alpha1.IPAllocationStatus{Phase: butlerv1alpha1.IPAllocationPhaseAllocated, StartAddress: "10.0.0.1", EndAddress: "10.0.0.2"},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{LabelAllocationRole: AllocationRoleGrowth},
+					},
+					Spec:   butlerv1alpha1.IPAllocationSpec{Count: int32Ptr(2)},
+					Status: butlerv1alpha1.IPAllocationStatus{Phase: butlerv1alpha1.IPAllocationPhasePending},
+				},
+			},
+			serviceIPs:     map[string]bool{"10.0.0.1": true, "10.0.0.2": true},
+			wantNetPending: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Count qualified pending services (same as reconcileElasticIPAM).
+			var qualifiedPending int32
+			for _, svc := range tt.pendingServices {
+				if time.Since(svc.CreatedAt) >= pendingServiceMinAge {
+					qualifiedPending++
+				}
+			}
+
+			// Deduct in-flight growth supply (the code under test).
+			var inFlightSupply int32
+			for i := range tt.allocs {
+				alloc := &tt.allocs[i]
+				if alloc.Labels[LabelAllocationRole] != AllocationRoleGrowth {
+					continue
+				}
+				if alloc.Spec.Count == nil {
+					continue
+				}
+				switch alloc.Status.Phase {
+				case butlerv1alpha1.IPAllocationPhasePending:
+					inFlightSupply += *alloc.Spec.Count
+				case butlerv1alpha1.IPAllocationPhaseAllocated:
+					if !allocationHasServiceIP(alloc, tt.serviceIPs) {
+						inFlightSupply += *alloc.Spec.Count
+					}
+				}
+			}
+			qualifiedPending -= inFlightSupply
+			if qualifiedPending < 0 {
+				qualifiedPending = 0
+			}
+
+			if qualifiedPending != tt.wantNetPending {
+				t.Errorf("net qualifiedPending = %d, want %d (raw pending minus %d in-flight)",
+					qualifiedPending, tt.wantNetPending, inFlightSupply)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Demand-driven growth was racing across back-to-back reconciles when the IPAllocation watch triggered a second reconcile before MetalLB propagation (~37s) completed. The second reconcile saw the same Pending Service and created a redundant growth allocation.
- The `qualifiedPending` count now subtracts in-flight growth allocations: those in Pending phase (awaiting fulfillment) or in Allocated phase but unconsumed (no tenant Service using any IP from the range).
- Adds 7 test cases covering: normal growth, Pending in-flight suppression, Allocated-unconsumed suppression, consumed allocation passthrough, partial coverage with batch demand, initial allocation exclusion, and supply-exceeds-demand clamping.

## Context

Bug surfaced during e2e validation of Traefik disablement. A single Pending Service produced 2 growth allocations on consecutive reconciles 1 second apart. Root cause: the IPAllocation watch (added in #89) triggers a TenantCluster reconcile when a growth allocation is created, and the growth logic had no awareness of in-flight supply.

## Test plan

- [ ] Unit tests pass: `go test ./internal/controller/tenantcluster/ -run TestInFlightGrowthDeduction -v`
- [ ] Full unit test suite passes (excluding envtest): `go test ./internal/controller/tenantcluster/ -run "^Test[^T]" -v`
- [ ] Local controller run against production cluster: no spurious growth allocations, all 8 tenants stable
- [ ] Post-deploy: watch for 15 minutes, confirm zero growth allocation churn on steady-state clusters