### PR TITLE
Propagate observability endpoint changes and inject cluster labels

### DIFF
--- a/internal/controller/tenantaddon/tenantaddon_controller.go
+++ b/internal/controller/tenantaddon/tenantaddon_controller.go
@@ -130,7 +130,8 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	}
 
 	if addon.Status.Phase == butlerv1alpha1.TenantAddonPhaseInstalled &&
-		addon.Status.InstalledVersion == version {
+		addon.Status.InstalledVersion == version &&
+		addon.Status.ObservedGeneration == addon.Generation {
 		logger.V(1).Info("addon already installed", "version", version)
 		return ctrl.Result{RequeueAfter: 5 * time.Minute}, nil
 	}

--- a/internal/controller/tenantcluster/reconcile_addons.go
+++ b/internal/controller/tenantcluster/reconcile_addons.go
@@ -4,6 +4,7 @@
 package tenantcluster
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -412,7 +413,7 @@ func (r *Reconciler) reconcileAutoEnrollObservability(ctx context.Context, tc *b
 	}
 
 	if enroll.Prometheus && obs.Pipeline.MetricEndpoint != "" {
-		if err := r.ensureAutoEnrolledAddon(ctx, tc, "prometheus-operator", buildPrometheusValues(obs.Pipeline)); err != nil {
+		if err := r.ensureAutoEnrolledAddon(ctx, tc, "prometheus-operator", buildPrometheusValues(obs.Pipeline, tc.Name)); err != nil {
 			logger.Error(err, "failed to auto-enroll prometheus-operator")
 		}
 	}
@@ -426,7 +427,9 @@ func (r *Reconciler) reconcileAutoEnrollObservability(ctx context.Context, tc *b
 	return nil
 }
 
-// ensureAutoEnrolledAddon creates a TenantAddon if it doesn't already exist.
+// ensureAutoEnrolledAddon creates a TenantAddon if it doesn't already exist,
+// or updates its values if the desired configuration has changed (e.g., a
+// pipeline endpoint was modified in ButlerConfig).
 func (r *Reconciler) ensureAutoEnrolledAddon(ctx context.Context, tc *butlerv1alpha1.TenantCluster, addonDefName string, values *butlerv1alpha1.ExtensionValues) error {
 	logger := log.FromContext(ctx)
 	addonName := fmt.Sprintf("%s-%s", tc.Name, addonDefName)
@@ -434,7 +437,7 @@ func (r *Reconciler) ensureAutoEnrolledAddon(ctx context.Context, tc *butlerv1al
 	existing := &butlerv1alpha1.TenantAddon{}
 	err := r.Get(ctx, client.ObjectKey{Name: addonName, Namespace: tc.Namespace}, existing)
 	if err == nil {
-		return nil // already exists
+		return r.updateAutoEnrolledAddonIfNeeded(ctx, existing, values)
 	}
 	if !apierrors.IsNotFound(err) {
 		return fmt.Errorf("failed to check TenantAddon %s: %w", addonName, err)
@@ -477,6 +480,39 @@ func (r *Reconciler) ensureAutoEnrolledAddon(ctx context.Context, tc *butlerv1al
 	return nil
 }
 
+// updateAutoEnrolledAddonIfNeeded compares the desired values with the existing
+// TenantAddon and updates if they differ. Only auto-enrolled addons are updated;
+// manually created TenantAddons (missing the auto-enrolled label) are left alone.
+func (r *Reconciler) updateAutoEnrolledAddonIfNeeded(ctx context.Context, existing *butlerv1alpha1.TenantAddon, desired *butlerv1alpha1.ExtensionValues) error {
+	if existing.Labels["butler.butlerlabs.dev/auto-enrolled"] != "true" {
+		return nil
+	}
+
+	existingRaw := rawOrEmpty(existing.Spec.Values)
+	desiredRaw := rawOrEmpty(desired)
+	if bytes.Equal(existingRaw, desiredRaw) {
+		return nil
+	}
+
+	logger := log.FromContext(ctx)
+	logger.Info("updating auto-enrolled addon values",
+		"addon", existing.Name, "cluster", existing.Spec.ClusterRef.Name)
+
+	existing.Spec.Values = desired
+	if err := r.Update(ctx, existing); err != nil {
+		return fmt.Errorf("failed to update TenantAddon %s: %w", existing.Name, err)
+	}
+	return nil
+}
+
+// rawOrEmpty returns the Raw bytes from an ExtensionValues, or an empty slice if nil.
+func rawOrEmpty(v *butlerv1alpha1.ExtensionValues) []byte {
+	if v == nil {
+		return nil
+	}
+	return v.Raw
+}
+
 // buildVectorAgentValues configures the vector-agent sink to forward to the pipeline aggregator.
 func buildVectorAgentValues(pipeline *butlerv1alpha1.ObservabilityPipelineConfig) *butlerv1alpha1.ExtensionValues {
 	if pipeline == nil || pipeline.LogEndpoint == "" {
@@ -500,8 +536,10 @@ func buildVectorAgentValues(pipeline *butlerv1alpha1.ObservabilityPipelineConfig
 	return &butlerv1alpha1.ExtensionValues{Raw: raw}
 }
 
-// buildPrometheusValues configures remote-write to the pipeline metric endpoint.
-func buildPrometheusValues(pipeline *butlerv1alpha1.ObservabilityPipelineConfig) *butlerv1alpha1.ExtensionValues {
+// buildPrometheusValues configures remote-write to the pipeline metric endpoint
+// and sets externalLabels.cluster so metrics are identifiable by source cluster
+// in the backend.
+func buildPrometheusValues(pipeline *butlerv1alpha1.ObservabilityPipelineConfig, clusterName string) *butlerv1alpha1.ExtensionValues {
 	if pipeline == nil || pipeline.MetricEndpoint == "" {
 		return nil
 	}
@@ -509,6 +547,9 @@ func buildPrometheusValues(pipeline *butlerv1alpha1.ObservabilityPipelineConfig)
 	values := map[string]interface{}{
 		"prometheus": map[string]interface{}{
 			"prometheusSpec": map[string]interface{}{
+				"externalLabels": map[string]interface{}{
+					"cluster": clusterName,
+				},
 				"remoteWrite": []map[string]interface{}{
 					{"url": pipeline.MetricEndpoint},
 				},

--- a/internal/controller/tenantcluster/reconcile_addons_test.go
+++ b/internal/controller/tenantcluster/reconcile_addons_test.go
@@ -5,6 +5,7 @@ package tenantcluster
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"testing"
 
@@ -12,6 +13,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	butlerv1alpha1 "github.com/butlerdotdev/butler-api/api/v1alpha1"
@@ -783,5 +785,340 @@ func TestResolveMetalLBPool_NoPool(t *testing.T) {
 	}
 	if end != "" {
 		t.Errorf("poolEnd = %q, want empty", end)
+	}
+}
+
+func makeExtensionValues(t *testing.T, v map[string]interface{}) *butlerv1alpha1.ExtensionValues {
+	t.Helper()
+	raw, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("failed to marshal values: %v", err)
+	}
+	return &butlerv1alpha1.ExtensionValues{Raw: raw}
+}
+
+func TestEnsureAutoEnrolledAddon_CreatesNew(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = butlerv1alpha1.AddToScheme(scheme)
+
+	tc := &butlerv1alpha1.TenantCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-cluster",
+			Namespace: "team-a",
+			UID:       "abc-123",
+			Labels:    map[string]string{butlerv1alpha1.LabelTeam: "team-a"},
+		},
+	}
+
+	cl := fakeclient.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(tc).
+		Build()
+
+	r := &Reconciler{Client: cl, Scheme: scheme}
+
+	values := makeExtensionValues(t, map[string]interface{}{
+		"customConfig": map[string]interface{}{
+			"sinks": map[string]interface{}{
+				"aggregator": map[string]interface{}{"uri": "http://10.0.0.1:8080"},
+			},
+		},
+	})
+
+	err := r.ensureAutoEnrolledAddon(context.Background(), tc, "vector-agent", values)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	created := &butlerv1alpha1.TenantAddon{}
+	err = cl.Get(context.Background(), client.ObjectKey{Name: "test-cluster-vector-agent", Namespace: "team-a"}, created)
+	if err != nil {
+		t.Fatalf("TenantAddon not created: %v", err)
+	}
+	if created.Spec.Addon != "vector-agent" {
+		t.Errorf("addon = %q, want vector-agent", created.Spec.Addon)
+	}
+	if created.Labels["butler.butlerlabs.dev/auto-enrolled"] != "true" {
+		t.Error("missing auto-enrolled label")
+	}
+}
+
+func TestEnsureAutoEnrolledAddon_UpdatesChangedValues(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = butlerv1alpha1.AddToScheme(scheme)
+
+	tc := &butlerv1alpha1.TenantCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-cluster",
+			Namespace: "team-a",
+			UID:       "abc-123",
+			Labels:    map[string]string{butlerv1alpha1.LabelTeam: "team-a"},
+		},
+	}
+
+	oldValues := makeExtensionValues(t, map[string]interface{}{
+		"customConfig": map[string]interface{}{
+			"sinks": map[string]interface{}{
+				"aggregator": map[string]interface{}{"uri": "http://10.0.0.1:8080"},
+			},
+		},
+	})
+
+	existing := &butlerv1alpha1.TenantAddon{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-cluster-vector-agent",
+			Namespace: "team-a",
+			Labels: map[string]string{
+				"butler.butlerlabs.dev/auto-enrolled": "true",
+			},
+		},
+		Spec: butlerv1alpha1.TenantAddonSpec{
+			ClusterRef: butlerv1alpha1.LocalObjectReference{Name: "test-cluster"},
+			Addon:      "vector-agent",
+			Values:     oldValues,
+		},
+	}
+
+	cl := fakeclient.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(tc, existing).
+		Build()
+
+	r := &Reconciler{Client: cl, Scheme: scheme}
+
+	newValues := makeExtensionValues(t, map[string]interface{}{
+		"customConfig": map[string]interface{}{
+			"sinks": map[string]interface{}{
+				"aggregator": map[string]interface{}{"uri": "http://10.0.0.2:8080"},
+			},
+		},
+	})
+
+	err := r.ensureAutoEnrolledAddon(context.Background(), tc, "vector-agent", newValues)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	updated := &butlerv1alpha1.TenantAddon{}
+	err = cl.Get(context.Background(), client.ObjectKey{Name: "test-cluster-vector-agent", Namespace: "team-a"}, updated)
+	if err != nil {
+		t.Fatalf("failed to get TenantAddon: %v", err)
+	}
+
+	var vals map[string]interface{}
+	if err := json.Unmarshal(updated.Spec.Values.Raw, &vals); err != nil {
+		t.Fatalf("failed to unmarshal updated values: %v", err)
+	}
+
+	uri := vals["customConfig"].(map[string]interface{})["sinks"].(map[string]interface{})["aggregator"].(map[string]interface{})["uri"]
+	if uri != "http://10.0.0.2:8080" {
+		t.Errorf("uri = %v, want http://10.0.0.2:8080", uri)
+	}
+}
+
+func TestEnsureAutoEnrolledAddon_SkipsIdenticalValues(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = butlerv1alpha1.AddToScheme(scheme)
+
+	tc := &butlerv1alpha1.TenantCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-cluster",
+			Namespace: "team-a",
+			UID:       "abc-123",
+			Labels:    map[string]string{butlerv1alpha1.LabelTeam: "team-a"},
+		},
+	}
+
+	values := makeExtensionValues(t, map[string]interface{}{
+		"customConfig": map[string]interface{}{
+			"sinks": map[string]interface{}{
+				"aggregator": map[string]interface{}{"uri": "http://10.0.0.1:8080"},
+			},
+		},
+	})
+
+	existing := &butlerv1alpha1.TenantAddon{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-cluster-vector-agent",
+			Namespace: "team-a",
+			Labels: map[string]string{
+				"butler.butlerlabs.dev/auto-enrolled": "true",
+			},
+		},
+		Spec: butlerv1alpha1.TenantAddonSpec{
+			ClusterRef: butlerv1alpha1.LocalObjectReference{Name: "test-cluster"},
+			Addon:      "vector-agent",
+			Values:     values,
+		},
+	}
+
+	cl := fakeclient.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(tc, existing).
+		Build()
+
+	r := &Reconciler{Client: cl, Scheme: scheme}
+
+	// Pass identical values — should not trigger an update.
+	sameValues := makeExtensionValues(t, map[string]interface{}{
+		"customConfig": map[string]interface{}{
+			"sinks": map[string]interface{}{
+				"aggregator": map[string]interface{}{"uri": "http://10.0.0.1:8080"},
+			},
+		},
+	})
+
+	err := r.ensureAutoEnrolledAddon(context.Background(), tc, "vector-agent", sameValues)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Verify the resource version hasn't changed (no update was made).
+	after := &butlerv1alpha1.TenantAddon{}
+	_ = cl.Get(context.Background(), client.ObjectKey{Name: "test-cluster-vector-agent", Namespace: "team-a"}, after)
+	if after.ResourceVersion != existing.ResourceVersion {
+		t.Error("resource version changed — update was triggered for identical values")
+	}
+}
+
+func TestEnsureAutoEnrolledAddon_SkipsManuallyCreated(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = butlerv1alpha1.AddToScheme(scheme)
+
+	tc := &butlerv1alpha1.TenantCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-cluster",
+			Namespace: "team-a",
+			UID:       "abc-123",
+			Labels:    map[string]string{butlerv1alpha1.LabelTeam: "team-a"},
+		},
+	}
+
+	oldValues := makeExtensionValues(t, map[string]interface{}{
+		"customConfig": map[string]interface{}{
+			"sinks": map[string]interface{}{
+				"aggregator": map[string]interface{}{"uri": "http://10.0.0.1:8080"},
+			},
+		},
+	})
+
+	// Manually created TenantAddon (no auto-enrolled label).
+	existing := &butlerv1alpha1.TenantAddon{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-cluster-vector-agent",
+			Namespace: "team-a",
+			Labels:    map[string]string{},
+		},
+		Spec: butlerv1alpha1.TenantAddonSpec{
+			ClusterRef: butlerv1alpha1.LocalObjectReference{Name: "test-cluster"},
+			Addon:      "vector-agent",
+			Values:     oldValues,
+		},
+	}
+
+	cl := fakeclient.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(tc, existing).
+		Build()
+
+	r := &Reconciler{Client: cl, Scheme: scheme}
+
+	newValues := makeExtensionValues(t, map[string]interface{}{
+		"customConfig": map[string]interface{}{
+			"sinks": map[string]interface{}{
+				"aggregator": map[string]interface{}{"uri": "http://10.0.0.2:8080"},
+			},
+		},
+	})
+
+	err := r.ensureAutoEnrolledAddon(context.Background(), tc, "vector-agent", newValues)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Values should NOT be updated on a manually created addon.
+	after := &butlerv1alpha1.TenantAddon{}
+	_ = cl.Get(context.Background(), client.ObjectKey{Name: "test-cluster-vector-agent", Namespace: "team-a"}, after)
+
+	var vals map[string]interface{}
+	_ = json.Unmarshal(after.Spec.Values.Raw, &vals)
+	uri := vals["customConfig"].(map[string]interface{})["sinks"].(map[string]interface{})["aggregator"].(map[string]interface{})["uri"]
+	if uri != "http://10.0.0.1:8080" {
+		t.Errorf("uri was updated to %v — should not update manually created addons", uri)
+	}
+}
+
+func TestBuildPrometheusValues_IncludesExternalLabels(t *testing.T) {
+	pipeline := &butlerv1alpha1.ObservabilityPipelineConfig{
+		MetricEndpoint: "http://10.0.0.1:9000/insert/0/prometheus/api/v1/write",
+	}
+
+	ev := buildPrometheusValues(pipeline, "my-tenant-cluster")
+	if ev == nil {
+		t.Fatal("expected non-nil ExtensionValues")
+	}
+
+	var vals map[string]interface{}
+	if err := json.Unmarshal(ev.Raw, &vals); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+
+	promSpec := vals["prometheus"].(map[string]interface{})["prometheusSpec"].(map[string]interface{})
+
+	// Check externalLabels.cluster
+	extLabels, ok := promSpec["externalLabels"].(map[string]interface{})
+	if !ok {
+		t.Fatal("externalLabels missing from prometheusSpec")
+	}
+	if extLabels["cluster"] != "my-tenant-cluster" {
+		t.Errorf("cluster label = %v, want my-tenant-cluster", extLabels["cluster"])
+	}
+
+	// Check remoteWrite URL is still present
+	rw, ok := promSpec["remoteWrite"].([]interface{})
+	if !ok || len(rw) == 0 {
+		t.Fatal("remoteWrite missing from prometheusSpec")
+	}
+	rwEntry := rw[0].(map[string]interface{})
+	if rwEntry["url"] != "http://10.0.0.1:9000/insert/0/prometheus/api/v1/write" {
+		t.Errorf("remoteWrite url = %v, want the pipeline metric endpoint", rwEntry["url"])
+	}
+}
+
+func TestBuildPrometheusValues_NilPipeline(t *testing.T) {
+	ev := buildPrometheusValues(nil, "cluster-1")
+	if ev != nil {
+		t.Error("expected nil ExtensionValues for nil pipeline")
+	}
+}
+
+func TestBuildPrometheusValues_EmptyEndpoint(t *testing.T) {
+	pipeline := &butlerv1alpha1.ObservabilityPipelineConfig{
+		MetricEndpoint: "",
+	}
+	ev := buildPrometheusValues(pipeline, "cluster-1")
+	if ev != nil {
+		t.Error("expected nil ExtensionValues for empty endpoint")
+	}
+}
+
+func TestBuildVectorAgentValues_HTTPSinkURI(t *testing.T) {
+	pipeline := &butlerv1alpha1.ObservabilityPipelineConfig{
+		LogEndpoint: "http://10.0.0.1:8080",
+	}
+
+	ev := buildVectorAgentValues(pipeline)
+	if ev == nil {
+		t.Fatal("expected non-nil ExtensionValues")
+	}
+
+	var vals map[string]interface{}
+	if err := json.Unmarshal(ev.Raw, &vals); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+
+	uri := vals["customConfig"].(map[string]interface{})["sinks"].(map[string]interface{})["aggregator"].(map[string]interface{})["uri"]
+	if uri != "http://10.0.0.1:8080" {
+		t.Errorf("uri = %v, want http://10.0.0.1:8080", uri)
 	}
 }


### PR DESCRIPTION
## Summary

Auto-enrolled observability addons were create-only — changing a pipeline endpoint in ButlerConfig had no effect on existing TenantAddons. This left operators with no way to migrate backends (e.g., moving Loki to a new IP) without manually editing every TenantAddon across every tenant namespace.

Additionally, `buildPrometheusValues` was only setting `remoteWrite[].url` without any cluster identifier, making metrics from all tenants indistinguishable in the backend.

A third issue surfaced during review: the TenantAddon controller's early return checked only version, not generation. Values-only updates (no version change) were silently skipped — the controller considered the addon already installed.

This PR fixes all three:

- **Update propagation**: `ensureAutoEnrolledAddon` now compares desired values with the existing TenantAddon and updates if they differ. Only auto-enrolled addons (labeled `butler.butlerlabs.dev/auto-enrolled: true`) are touched — manually created TenantAddons are left alone.
- **Cluster label injection**: `buildPrometheusValues` now sets `externalLabels.cluster` to the TenantCluster name, so metrics arriving at VictoriaMetrics carry their source cluster identity.
- **Generation check**: TenantAddon controller early return now includes `ObservedGeneration == Generation`, so spec changes (including values updates) trigger re-installation.

## Test plan

- [x] `TestEnsureAutoEnrolledAddon_CreatesNew` — creates TenantAddon on first run
- [x] `TestEnsureAutoEnrolledAddon_UpdatesChangedValues` — updates values when endpoint changes
- [x] `TestEnsureAutoEnrolledAddon_SkipsIdenticalValues` — no update when values match
- [x] `TestEnsureAutoEnrolledAddon_SkipsManuallyCreated` — does not touch addons without auto-enrolled label
- [x] `TestBuildPrometheusValues_IncludesExternalLabels` — externalLabels.cluster present in output
- [x] `TestBuildPrometheusValues_NilPipeline` — nil safety
- [x] `TestBuildPrometheusValues_EmptyEndpoint` — empty endpoint returns nil
- [x] `TestBuildVectorAgentValues_HTTPSinkURI` — confirms HTTP sink URI structure
- [x] All existing reconcileAddonHealth tests pass unchanged