### PR TITLE
feat(ipam): support multi-range tenant allocation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/butlerdotdev/butler-controller
 go 1.24.6
 
 require (
-	github.com/butlerdotdev/butler-api v0.15.0
+	github.com/butlerdotdev/butler-api v0.16.0
 	github.com/onsi/ginkgo/v2 v2.22.0
 	github.com/onsi/gomega v1.36.1
 	github.com/prometheus/client_golang v1.22.0

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
-github.com/butlerdotdev/butler-api v0.15.0 h1:re+6YTS/CbBspGPK2Z6BO/OxNVXZHemOWqZ/pIE4s2U=
-github.com/butlerdotdev/butler-api v0.15.0/go.mod h1:q/RjPFM/r2ELq4DqR78OiAxerKBvH5D4nTGsVLKbjqY=
+github.com/butlerdotdev/butler-api v0.16.0 h1:PQduzfg77N0uMnJEgqqeZYbErF5azIgKTFuvAo9VpGs=
+github.com/butlerdotdev/butler-api v0.16.0/go.mod h1:q/RjPFM/r2ELq4DqR78OiAxerKBvH5D4nTGsVLKbjqY=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/internal/controller/networkpool/networkpool_controller.go
+++ b/internal/controller/networkpool/networkpool_controller.go
@@ -221,13 +221,14 @@ func (r *Reconciler) validatePool(pool *butlerv1alpha1.NetworkPool) []string {
 		reservedCIDRs = append(reservedCIDRs, reserved.CIDR)
 	}
 
-	var allocStart, allocEnd string
+	var ranges []ipam.AllocatedRange
 	if pool.Spec.TenantAllocation != nil {
-		allocStart = pool.Spec.TenantAllocation.Start
-		allocEnd = pool.Spec.TenantAllocation.End
+		for _, r := range pool.Spec.TenantAllocation.GetEffectiveRanges() {
+			ranges = append(ranges, ipam.AllocatedRange{Start: r.Start, End: r.End})
+		}
 	}
 
-	return ipam.ValidatePoolSpec(pool.Spec.CIDR, reservedCIDRs, allocStart, allocEnd)
+	return ipam.ValidatePoolSpec(pool.Spec.CIDR, ranges, reservedCIDRs)
 }
 
 func (r *Reconciler) processPendingAllocations(ctx context.Context, pool *butlerv1alpha1.NetworkPool, allocList *butlerv1alpha1.IPAllocationList) int {
@@ -339,18 +340,25 @@ func (r *Reconciler) processPendingAllocations(ctx context.Context, pool *butler
 func (r *Reconciler) buildPoolState(pool *butlerv1alpha1.NetworkPool, allocated []butlerv1alpha1.IPAllocation) ipam.PoolState {
 	state := ipam.PoolState{}
 
-	// Set allocatable range
+	// Set allocatable ranges from GetEffectiveRanges or fall back to full CIDR.
 	if pool.Spec.TenantAllocation != nil {
-		state.AllocatableStart = pool.Spec.TenantAllocation.Start
-		state.AllocatableEnd = pool.Spec.TenantAllocation.End
-	} else {
+		effectiveRanges := pool.Spec.TenantAllocation.GetEffectiveRanges()
+		for _, r := range effectiveRanges {
+			state.AllocatableRanges = append(state.AllocatableRanges, ipam.AllocatedRange{
+				Start: r.Start,
+				End:   r.End,
+			})
+		}
+	}
+	if len(state.AllocatableRanges) == 0 {
 		// Use full CIDR range
 		start, end, _, err := ipam.ParseCIDR(pool.Spec.CIDR)
 		if err != nil {
 			return state
 		}
-		state.AllocatableStart = start.String()
-		state.AllocatableEnd = end.String()
+		state.AllocatableRanges = []ipam.AllocatedRange{
+			{Start: start.String(), End: end.String()},
+		}
 	}
 
 	// Add reserved CIDRs
@@ -560,6 +568,7 @@ func setCapacityConditions(pool *butlerv1alpha1.NetworkPool, usagePercent float6
 		})
 	}
 }
+
 // gcOrphanedAllocations deletes IPAllocations whose tenantClusterRef points
 // to a TenantCluster that no longer exists. Returns the number of allocations deleted.
 func (r *Reconciler) gcOrphanedAllocations(ctx context.Context, pool *butlerv1alpha1.NetworkPool, allocList *butlerv1alpha1.IPAllocationList) int {

--- a/internal/controller/networkpool/networkpool_controller_test.go
+++ b/internal/controller/networkpool/networkpool_controller_test.go
@@ -43,8 +43,9 @@ var _ = Describe("NetworkPool Controller", func() {
 	// newStandardTenantAllocation returns the tenantAllocation config used across most tests.
 	newStandardTenantAllocation := func() *butlerv1alpha1.TenantAllocationConfig {
 		return &butlerv1alpha1.TenantAllocationConfig{
-			Start: allocStart,
-			End:   allocEnd,
+			Ranges: []butlerv1alpha1.AllocationRange{
+				{Start: allocStart, End: allocEnd},
+			},
 		}
 	}
 

--- a/internal/ipam/allocator.go
+++ b/internal/ipam/allocator.go
@@ -44,10 +44,11 @@ var (
 // PoolState represents the current state of a network pool for allocation purposes.
 // It decouples the allocator from Kubernetes types.
 type PoolState struct {
-	// AllocatableStart is the first IP available for tenant allocation.
-	AllocatableStart string
-	// AllocatableEnd is the last IP available for tenant allocation.
-	AllocatableEnd string
+	// AllocatableRanges defines the allocatable IP ranges. The bitmap spans
+	// from the minimum start to the maximum end, with inter-range gaps
+	// marked as used. Ranges must be sorted by Start ascending and
+	// non-overlapping.
+	AllocatableRanges []AllocatedRange
 	// ReservedCIDRs are CIDR ranges excluded from allocation (e.g., management cluster IPs).
 	ReservedCIDRs []string
 	// ExistingAllocs are currently allocated ranges.
@@ -79,9 +80,9 @@ type FreeBlock struct {
 // FragmentationInfo contains pool health metrics.
 type FragmentationInfo struct {
 	FragmentationPercent int32
-	LargestFreeBlock    int32
-	FreeBlockCount      int32
-	TotalFreeIPs        int32
+	LargestFreeBlock     int32
+	FreeBlockCount       int32
+	TotalFreeIPs         int32
 }
 
 // IPToUint32 converts a 4-byte IPv4 address to a uint32.
@@ -236,19 +237,34 @@ func ValidateRangeWithinCIDR(cidr, start, end string) (bool, error) {
 	return network.Contains(startIP) && network.Contains(endIP), nil
 }
 
-// BuildBitmap creates a bitmap representing the allocatable range.
-// true = used/reserved, false = free.
+// BuildBitmap creates a bitmap spanning all allocatable ranges.
+// true = used/reserved/gap, false = free. The bitmap spans from the minimum
+// range start to the maximum range end. Inter-range gaps are marked as used
+// so the allocator's free-block scan only finds free space within ranges.
 func BuildBitmap(pool PoolState) ([]bool, uint32, error) {
-	startIP := net.ParseIP(pool.AllocatableStart).To4()
-	endIP := net.ParseIP(pool.AllocatableEnd).To4()
-	if startIP == nil || endIP == nil {
-		return nil, 0, fmt.Errorf("invalid pool range")
+	if len(pool.AllocatableRanges) == 0 {
+		return nil, 0, fmt.Errorf("no allocatable ranges defined")
 	}
 
-	poolStart := IPToUint32(startIP)
-	poolEnd := IPToUint32(endIP)
-	if poolStart > poolEnd {
-		return nil, 0, ErrInvalidRange
+	// Compute spanning bounds across all ranges.
+	var poolStart, poolEnd uint32
+	for i, r := range pool.AllocatableRanges {
+		sIP := net.ParseIP(r.Start).To4()
+		eIP := net.ParseIP(r.End).To4()
+		if sIP == nil || eIP == nil {
+			return nil, 0, fmt.Errorf("invalid IP in range %d: %s-%s", i, r.Start, r.End)
+		}
+		s := IPToUint32(sIP)
+		e := IPToUint32(eIP)
+		if s > e {
+			return nil, 0, fmt.Errorf("%w: range %d start %s is after end %s", ErrInvalidRange, i, r.Start, r.End)
+		}
+		if i == 0 || s < poolStart {
+			poolStart = s
+		}
+		if i == 0 || e > poolEnd {
+			poolEnd = e
+		}
 	}
 
 	size := poolEnd - poolStart + 1
@@ -257,6 +273,18 @@ func BuildBitmap(pool PoolState) ([]bool, uint32, error) {
 	}
 
 	bitmap := make([]bool, size)
+
+	// Mark inter-range gaps as used. Ranges are sorted by start ascending,
+	// so gaps are between ranges[i].End+1 and ranges[i+1].Start-1.
+	for i := 0; i < len(pool.AllocatableRanges)-1; i++ {
+		gapStartIP := net.ParseIP(pool.AllocatableRanges[i].End).To4()
+		gapEndIP := net.ParseIP(pool.AllocatableRanges[i+1].Start).To4()
+		gapStart := IPToUint32(gapStartIP) + 1
+		gapEnd := IPToUint32(gapEndIP) - 1
+		for ip := gapStart; ip <= gapEnd; ip++ {
+			bitmap[ip-poolStart] = true
+		}
+	}
 
 	// Mark reserved CIDRs
 	for _, reserved := range pool.ReservedCIDRs {
@@ -398,18 +426,46 @@ func AllocatePinnedRange(pool PoolState, start, end string) (*AllocationResult, 
 		return nil, fmt.Errorf("%w: pinned start %s is after end %s", ErrInvalidRange, start, end)
 	}
 
-	// Verify the range is within the allocatable pool
-	poolStartIP := net.ParseIP(pool.AllocatableStart).To4()
-	poolEndIP := net.ParseIP(pool.AllocatableEnd).To4()
-	if poolStartIP == nil || poolEndIP == nil {
-		return nil, fmt.Errorf("invalid pool range")
+	// Verify the range falls within at least one allocatable range.
+	withinRange := false
+	var overlappingIndices []int
+	for i, r := range pool.AllocatableRanges {
+		rStartIP := net.ParseIP(r.Start).To4()
+		rEndIP := net.ParseIP(r.End).To4()
+		if rStartIP == nil || rEndIP == nil {
+			continue
+		}
+		rs := IPToUint32(rStartIP)
+		re := IPToUint32(rEndIP)
+		if pinnedStart >= rs && pinnedEnd <= re {
+			withinRange = true
+			break
+		}
+		// Track ranges that partially overlap the pinned range.
+		if pinnedStart <= re && pinnedEnd >= rs {
+			overlappingIndices = append(overlappingIndices, i)
+		}
 	}
-
-	poolStart := IPToUint32(poolStartIP)
-	poolEnd := IPToUint32(poolEndIP)
-	if pinnedStart < poolStart || pinnedEnd > poolEnd {
-		return nil, fmt.Errorf("%w: pinned range %s-%s is outside pool %s-%s",
-			ErrOutOfRange, start, end, pool.AllocatableStart, pool.AllocatableEnd)
+	if !withinRange {
+		if len(overlappingIndices) > 1 {
+			// Pinned range straddles multiple allocatable ranges.
+			var boundaries []string
+			for _, idx := range overlappingIndices {
+				r := pool.AllocatableRanges[idx]
+				boundaries = append(boundaries,
+					fmt.Sprintf("ranges[%d] %s-%s", idx, r.Start, r.End))
+			}
+			return nil, fmt.Errorf("%w: pinned range %s-%s straddles allocatable ranges; "+
+				"must fit entirely within one range. Overlapping ranges: %s",
+				ErrOutOfRange, start, end, strings.Join(boundaries, ", "))
+		}
+		// Completely outside all ranges — list available ranges.
+		var available []string
+		for i, r := range pool.AllocatableRanges {
+			available = append(available, fmt.Sprintf("ranges[%d] %s-%s", i, r.Start, r.End))
+		}
+		return nil, fmt.Errorf("%w: pinned range %s-%s is outside allocatable ranges [%s]",
+			ErrOutOfRange, start, end, strings.Join(available, ", "))
 	}
 
 	// Build bitmap and check for conflicts
@@ -488,7 +544,8 @@ func ComputeFragmentation(pool PoolState) (*FragmentationInfo, error) {
 }
 
 // ValidatePoolSpec validates the internal consistency of a network pool specification.
-func ValidatePoolSpec(cidr string, reservedCIDRs []string, allocStart, allocEnd string) []string {
+// Ranges must be sorted by start IP ascending and non-overlapping.
+func ValidatePoolSpec(cidr string, ranges []AllocatedRange, reservedCIDRs []string) []string {
 	var errs []string
 
 	_, _, _, err := ParseCIDR(cidr)
@@ -507,20 +564,76 @@ func ValidatePoolSpec(cidr string, reservedCIDRs []string, allocStart, allocEnd 
 		}
 	}
 
-	// Validate allocation range is within pool CIDR
-	if allocStart != "" && allocEnd != "" {
-		within, err := ValidateRangeWithinCIDR(cidr, allocStart, allocEnd)
-		if err != nil {
-			errs = append(errs, fmt.Sprintf("invalid allocation range: %v", err))
-		} else if !within {
-			errs = append(errs, fmt.Sprintf("allocation range %s-%s is not within pool CIDR %q", allocStart, allocEnd, cidr))
+	// Validate each allocation range
+	for i, r := range ranges {
+		startIP := net.ParseIP(r.Start).To4()
+		endIP := net.ParseIP(r.End).To4()
+		if startIP == nil {
+			errs = append(errs, fmt.Sprintf("ranges[%d].start %q is not a valid IPv4 address", i, r.Start))
+			continue
+		}
+		if endIP == nil {
+			errs = append(errs, fmt.Sprintf("ranges[%d].end %q is not a valid IPv4 address", i, r.End))
+			continue
 		}
 
-		startIP := net.ParseIP(allocStart).To4()
-		endIP := net.ParseIP(allocEnd).To4()
-		if startIP != nil && endIP != nil {
-			if IPToUint32(startIP) > IPToUint32(endIP) {
-				errs = append(errs, fmt.Sprintf("allocation start %s is after end %s", allocStart, allocEnd))
+		s := IPToUint32(startIP)
+		e := IPToUint32(endIP)
+
+		if s > e {
+			errs = append(errs, fmt.Sprintf("ranges[%d] start %s is after end %s", i, r.Start, r.End))
+			continue
+		}
+
+		within, err := ValidateRangeWithinCIDR(cidr, r.Start, r.End)
+		if err != nil {
+			errs = append(errs, fmt.Sprintf("ranges[%d]: invalid range: %v", i, err))
+		} else if !within {
+			errs = append(errs, fmt.Sprintf("ranges[%d] (%s-%s) falls outside pool CIDR %s", i, r.Start, r.End, cidr))
+		}
+
+		// Sorted order and non-overlap: ranges[i].Start must be > ranges[i-1].End
+		if i > 0 {
+			prevEndIP := net.ParseIP(ranges[i-1].End).To4()
+			if prevEndIP != nil {
+				prevEnd := IPToUint32(prevEndIP)
+				if s <= prevEnd {
+					errs = append(errs, fmt.Sprintf(
+						"ranges must be sorted by start IP and non-overlapping; ranges[%d].start (%s) must be greater than ranges[%d].end (%s)",
+						i, r.Start, i-1, ranges[i-1].End))
+				}
+			}
+		}
+	}
+
+	// Validate reserved CIDRs do not straddle range boundaries.
+	// A reserved CIDR can be fully inside a range or fully outside all ranges,
+	// but must not span across a range boundary.
+	for _, reserved := range reservedCIDRs {
+		rStart, rEnd, _, parseErr := ParseCIDR(reserved)
+		if parseErr != nil {
+			continue // already reported above
+		}
+		rs := IPToUint32(rStart.To4())
+		re := IPToUint32(rEnd.To4())
+
+		for i, r := range ranges {
+			rangeStartIP := net.ParseIP(r.Start).To4()
+			rangeEndIP := net.ParseIP(r.End).To4()
+			if rangeStartIP == nil || rangeEndIP == nil {
+				continue
+			}
+			rangeStart := IPToUint32(rangeStartIP)
+			rangeEnd := IPToUint32(rangeEndIP)
+
+			// Check if reserved straddles the range boundary:
+			// partially inside and partially outside.
+			startsInside := rs >= rangeStart && rs <= rangeEnd
+			endsInside := re >= rangeStart && re <= rangeEnd
+			if startsInside != endsInside {
+				errs = append(errs, fmt.Sprintf(
+					"reserved CIDR %s straddles ranges[%d] boundary (%s-%s)",
+					reserved, i, r.Start, r.End))
 			}
 		}
 	}
@@ -529,21 +642,15 @@ func ValidatePoolSpec(cidr string, reservedCIDRs []string, allocStart, allocEnd 
 }
 
 // PoolCapacityInfo computes capacity information for a pool.
+// Total is the sum of all range sizes (not the spanning bitmap size).
+// Reserved and allocated counts are computed only within allocatable ranges.
 func PoolCapacityInfo(pool PoolState) (totalIPs int32, allocatedIPs int32, availableIPs int32, err error) {
-	bitmap, _, err := BuildBitmap(pool)
+	bitmap, bitmapStart, err := BuildBitmap(pool)
 	if err != nil {
 		return 0, 0, 0, err
 	}
 
-	total := int32(len(bitmap))
-	reserved := int32(0)
-	allocated := int32(0)
-
-	// Count reserved IPs (from reserved CIDRs — always marked, even if no allocations exist)
-	// We need to distinguish reserved from allocated. Build a separate bitmap for just reserved.
-	startIP := net.ParseIP(pool.AllocatableStart).To4()
-	poolStartUint := IPToUint32(startIP)
-
+	// Build reserved bitmap to distinguish reserved from allocated.
 	reservedBitmap := make([]bool, len(bitmap))
 	for _, cidr := range pool.ReservedCIDRs {
 		rStart, rEnd, _, parseErr := ParseCIDR(cidr)
@@ -552,18 +659,37 @@ func PoolCapacityInfo(pool PoolState) (totalIPs int32, allocatedIPs int32, avail
 		}
 		rs := IPToUint32(rStart.To4())
 		re := IPToUint32(rEnd.To4())
+		bitmapEnd := bitmapStart + uint32(len(bitmap)) - 1
 		for i := rs; i <= re; i++ {
-			if i >= poolStartUint && i <= poolStartUint+uint32(len(bitmap))-1 {
-				reservedBitmap[i-poolStartUint] = true
+			if i >= bitmapStart && i <= bitmapEnd {
+				reservedBitmap[i-bitmapStart] = true
 			}
 		}
 	}
 
-	for i, used := range bitmap {
-		if reservedBitmap[i] {
-			reserved++
-		} else if used {
-			allocated++
+	// Count total, reserved, and allocated within allocatable ranges only.
+	// Inter-range gaps are excluded from all counts.
+	total := int32(0)
+	reserved := int32(0)
+	allocated := int32(0)
+
+	for _, r := range pool.AllocatableRanges {
+		rStartIP := net.ParseIP(r.Start).To4()
+		rEndIP := net.ParseIP(r.End).To4()
+		if rStartIP == nil || rEndIP == nil {
+			continue
+		}
+		rs := IPToUint32(rStartIP)
+		re := IPToUint32(rEndIP)
+
+		for ip := rs; ip <= re; ip++ {
+			offset := ip - bitmapStart
+			total++
+			if reservedBitmap[offset] {
+				reserved++
+			} else if bitmap[offset] {
+				allocated++
+			}
 		}
 	}
 

--- a/internal/ipam/allocator_test.go
+++ b/internal/ipam/allocator_test.go
@@ -322,8 +322,7 @@ func TestValidateRangeWithinCIDR(t *testing.T) {
 func TestBuildBitmap(t *testing.T) {
 	t.Run("empty pool", func(t *testing.T) {
 		pool := PoolState{
-			AllocatableStart: "10.0.0.0",
-			AllocatableEnd:   "10.0.0.7",
+			AllocatableRanges: []AllocatedRange{{Start: "10.0.0.0", End: "10.0.0.7"}},
 		}
 		bitmap, startUint, err := BuildBitmap(pool)
 		if err != nil {
@@ -344,9 +343,8 @@ func TestBuildBitmap(t *testing.T) {
 
 	t.Run("with reserved CIDR", func(t *testing.T) {
 		pool := PoolState{
-			AllocatableStart: "10.0.0.0",
-			AllocatableEnd:   "10.0.0.15",
-			ReservedCIDRs:    []string{"10.0.0.0/30"}, // reserves .0-.3
+			AllocatableRanges: []AllocatedRange{{Start: "10.0.0.0", End: "10.0.0.15"}},
+			ReservedCIDRs:     []string{"10.0.0.0/30"}, // reserves .0-.3
 		}
 		bitmap, _, err := BuildBitmap(pool)
 		if err != nil {
@@ -367,8 +365,7 @@ func TestBuildBitmap(t *testing.T) {
 
 	t.Run("with existing allocation", func(t *testing.T) {
 		pool := PoolState{
-			AllocatableStart: "10.0.0.0",
-			AllocatableEnd:   "10.0.0.15",
+			AllocatableRanges: []AllocatedRange{{Start: "10.0.0.0", End: "10.0.0.15"}},
 			ExistingAllocs: []AllocatedRange{
 				{Start: "10.0.0.4", End: "10.0.0.7"},
 			},
@@ -396,9 +393,8 @@ func TestBuildBitmap(t *testing.T) {
 
 	t.Run("reserved outside allocatable range ignored", func(t *testing.T) {
 		pool := PoolState{
-			AllocatableStart: "10.0.0.128",
-			AllocatableEnd:   "10.0.0.135",
-			ReservedCIDRs:    []string{"10.0.0.0/25"}, // entirely before allocatable range
+			AllocatableRanges: []AllocatedRange{{Start: "10.0.0.128", End: "10.0.0.135"}},
+			ReservedCIDRs:     []string{"10.0.0.0/25"}, // entirely before allocatable range
 		}
 		bitmap, _, err := BuildBitmap(pool)
 		if err != nil {
@@ -413,8 +409,7 @@ func TestBuildBitmap(t *testing.T) {
 
 	t.Run("invalid range", func(t *testing.T) {
 		pool := PoolState{
-			AllocatableStart: "10.0.0.10",
-			AllocatableEnd:   "10.0.0.5",
+			AllocatableRanges: []AllocatedRange{{Start: "10.0.0.10", End: "10.0.0.5"}},
 		}
 		_, _, err := BuildBitmap(pool)
 		if err == nil {
@@ -424,8 +419,7 @@ func TestBuildBitmap(t *testing.T) {
 
 	t.Run("pool too large", func(t *testing.T) {
 		pool := PoolState{
-			AllocatableStart: "10.0.0.0",
-			AllocatableEnd:   "10.255.255.255", // ~16M IPs
+			AllocatableRanges: []AllocatedRange{{Start: "10.0.0.0", End: "10.255.255.255"}}, // ~16M IPs
 		}
 		_, _, err := BuildBitmap(pool)
 		if err == nil {
@@ -448,8 +442,7 @@ func TestAllocateRange(t *testing.T) {
 		{
 			name: "empty pool first allocation",
 			pool: PoolState{
-				AllocatableStart: "10.0.0.0",
-				AllocatableEnd:   "10.0.0.255",
+				AllocatableRanges: []AllocatedRange{{Start: "10.0.0.0", End: "10.0.0.255"}},
 			},
 			requestedCount: 8,
 			wantStart:      "10.0.0.0",
@@ -458,8 +451,7 @@ func TestAllocateRange(t *testing.T) {
 		{
 			name: "single IP allocation",
 			pool: PoolState{
-				AllocatableStart: "10.0.0.0",
-				AllocatableEnd:   "10.0.0.255",
+				AllocatableRanges: []AllocatedRange{{Start: "10.0.0.0", End: "10.0.0.255"}},
 			},
 			requestedCount: 1,
 			wantStart:      "10.0.0.0",
@@ -468,8 +460,7 @@ func TestAllocateRange(t *testing.T) {
 		{
 			name: "skips existing allocation",
 			pool: PoolState{
-				AllocatableStart: "10.0.0.0",
-				AllocatableEnd:   "10.0.0.31",
+				AllocatableRanges: []AllocatedRange{{Start: "10.0.0.0", End: "10.0.0.31"}},
 				ExistingAllocs: []AllocatedRange{
 					{Start: "10.0.0.0", End: "10.0.0.7"},
 				},
@@ -481,9 +472,8 @@ func TestAllocateRange(t *testing.T) {
 		{
 			name: "skips reserved range",
 			pool: PoolState{
-				AllocatableStart: "10.0.0.0",
-				AllocatableEnd:   "10.0.0.31",
-				ReservedCIDRs:    []string{"10.0.0.0/29"}, // .0-.7
+				AllocatableRanges: []AllocatedRange{{Start: "10.0.0.0", End: "10.0.0.31"}},
+				ReservedCIDRs:     []string{"10.0.0.0/29"}, // .0-.7
 			},
 			requestedCount: 4,
 			wantStart:      "10.0.0.8",
@@ -492,8 +482,7 @@ func TestAllocateRange(t *testing.T) {
 		{
 			name: "fills gap between allocations",
 			pool: PoolState{
-				AllocatableStart: "10.0.0.0",
-				AllocatableEnd:   "10.0.0.31",
+				AllocatableRanges: []AllocatedRange{{Start: "10.0.0.0", End: "10.0.0.31"}},
 				ExistingAllocs: []AllocatedRange{
 					{Start: "10.0.0.0", End: "10.0.0.3"},
 					{Start: "10.0.0.12", End: "10.0.0.15"},
@@ -508,13 +497,12 @@ func TestAllocateRange(t *testing.T) {
 		{
 			name: "best-fit picks smallest fitting gap",
 			pool: PoolState{
-				AllocatableStart: "10.0.0.0",
-				AllocatableEnd:   "10.0.0.63",
+				AllocatableRanges: []AllocatedRange{{Start: "10.0.0.0", End: "10.0.0.63"}},
 				ExistingAllocs: []AllocatedRange{
 					{Start: "10.0.0.0", End: "10.0.0.2"},   // uses .0-.2
-					{Start: "10.0.0.13", End: "10.0.0.14"},  // uses .13-.14 → gap .3-.12 = 10 IPs
-					{Start: "10.0.0.15", End: "10.0.0.17"},  // gap = 0 after .14
-					{Start: "10.0.0.68", End: "10.0.0.68"},  // outside pool, ignored
+					{Start: "10.0.0.13", End: "10.0.0.14"}, // uses .13-.14 → gap .3-.12 = 10 IPs
+					{Start: "10.0.0.15", End: "10.0.0.17"}, // gap = 0 after .14
+					{Start: "10.0.0.68", End: "10.0.0.68"}, // outside pool, ignored
 				},
 			},
 			// Free blocks: .3-.12 (10 IPs), .18-.63 (46 IPs)
@@ -526,8 +514,7 @@ func TestAllocateRange(t *testing.T) {
 		{
 			name: "best-fit with gaps of 10, 50, 3 - request 5 picks 10",
 			pool: PoolState{
-				AllocatableStart: "10.0.0.0",
-				AllocatableEnd:   "10.0.0.99",
+				AllocatableRanges: []AllocatedRange{{Start: "10.0.0.0", End: "10.0.0.99"}},
 				ExistingAllocs: []AllocatedRange{
 					// Layout: [10 free][5 alloc][3 free][2 alloc][50 free][30 alloc]
 					// .0-.9 free (10)
@@ -547,8 +534,7 @@ func TestAllocateRange(t *testing.T) {
 		{
 			name: "exhausted pool",
 			pool: PoolState{
-				AllocatableStart: "10.0.0.0",
-				AllocatableEnd:   "10.0.0.7",
+				AllocatableRanges: []AllocatedRange{{Start: "10.0.0.0", End: "10.0.0.7"}},
 				ExistingAllocs: []AllocatedRange{
 					{Start: "10.0.0.0", End: "10.0.0.7"},
 				},
@@ -559,8 +545,7 @@ func TestAllocateRange(t *testing.T) {
 		{
 			name: "no block large enough",
 			pool: PoolState{
-				AllocatableStart: "10.0.0.0",
-				AllocatableEnd:   "10.0.0.31",
+				AllocatableRanges: []AllocatedRange{{Start: "10.0.0.0", End: "10.0.0.31"}},
 				ExistingAllocs: []AllocatedRange{
 					{Start: "10.0.0.4", End: "10.0.0.7"},
 					{Start: "10.0.0.12", End: "10.0.0.15"},
@@ -576,8 +561,7 @@ func TestAllocateRange(t *testing.T) {
 		{
 			name: "full pool minus one",
 			pool: PoolState{
-				AllocatableStart: "10.0.0.0",
-				AllocatableEnd:   "10.0.0.7",
+				AllocatableRanges: []AllocatedRange{{Start: "10.0.0.0", End: "10.0.0.7"}},
 				ExistingAllocs: []AllocatedRange{
 					{Start: "10.0.0.0", End: "10.0.0.6"},
 				},
@@ -589,8 +573,7 @@ func TestAllocateRange(t *testing.T) {
 		{
 			name: "entire pool as one allocation",
 			pool: PoolState{
-				AllocatableStart: "10.0.0.0",
-				AllocatableEnd:   "10.0.0.255",
+				AllocatableRanges: []AllocatedRange{{Start: "10.0.0.0", End: "10.0.0.255"}},
 			},
 			requestedCount: 256,
 			wantStart:      "10.0.0.0",
@@ -628,8 +611,7 @@ func TestAllocateRange(t *testing.T) {
 
 func TestAllocateRange_InvalidCount(t *testing.T) {
 	pool := PoolState{
-		AllocatableStart: "10.0.0.0",
-		AllocatableEnd:   "10.0.0.255",
+		AllocatableRanges: []AllocatedRange{{Start: "10.0.0.0", End: "10.0.0.255"}},
 	}
 
 	_, err := AllocateRange(pool, 0)
@@ -646,8 +628,7 @@ func TestAllocateRange_InvalidCount(t *testing.T) {
 func TestAllocateRange_NoOverlap(t *testing.T) {
 	// Simulate sequential allocations and verify no overlap
 	pool := PoolState{
-		AllocatableStart: "10.0.0.0",
-		AllocatableEnd:   "10.0.0.255",
+		AllocatableRanges: []AllocatedRange{{Start: "10.0.0.0", End: "10.0.0.255"}},
 	}
 
 	allocations := make([]AllocationResult, 0)
@@ -688,9 +669,8 @@ func TestAllocateRange_NoOverlap(t *testing.T) {
 func TestAllocateRange_WithReservedAndAllocated(t *testing.T) {
 	// Complex scenario: reserved range in the middle, existing allocations around it
 	pool := PoolState{
-		AllocatableStart: "10.0.0.0",
-		AllocatableEnd:   "10.0.0.63",
-		ReservedCIDRs:    []string{"10.0.0.16/28"}, // .16-.31 reserved
+		AllocatableRanges: []AllocatedRange{{Start: "10.0.0.0", End: "10.0.0.63"}},
+		ReservedCIDRs:     []string{"10.0.0.16/28"}, // .16-.31 reserved
 		ExistingAllocs: []AllocatedRange{
 			{Start: "10.0.0.0", End: "10.0.0.7"}, // .0-.7 allocated
 		},
@@ -710,8 +690,7 @@ func TestAllocateRange_WithReservedAndAllocated(t *testing.T) {
 func TestAllocateRange_LargePool(t *testing.T) {
 	// /16 = 65536 IPs — verify it doesn't OOM and completes quickly
 	pool := PoolState{
-		AllocatableStart: "10.40.0.0",
-		AllocatableEnd:   "10.40.255.255",
+		AllocatableRanges: []AllocatedRange{{Start: "10.40.0.0", End: "10.40.255.255"}},
 	}
 
 	start := time.Now()
@@ -732,8 +711,7 @@ func TestAllocateRange_LargePool(t *testing.T) {
 func TestAllocateRange_LargePoolFragmented(t *testing.T) {
 	// /16 pool with every other 8-block allocated (severe fragmentation)
 	pool := PoolState{
-		AllocatableStart: "10.40.0.0",
-		AllocatableEnd:   "10.40.255.255",
+		AllocatableRanges: []AllocatedRange{{Start: "10.40.0.0", End: "10.40.255.255"}},
 	}
 
 	// Allocate every other 8-IP block for first 1024 IPs
@@ -777,8 +755,7 @@ func TestComputeFragmentation(t *testing.T) {
 		{
 			name: "empty pool - no fragmentation",
 			pool: PoolState{
-				AllocatableStart: "10.0.0.0",
-				AllocatableEnd:   "10.0.0.31",
+				AllocatableRanges: []AllocatedRange{{Start: "10.0.0.0", End: "10.0.0.31"}},
 			},
 			wantFragPercent:    0,
 			wantLargestFree:    32,
@@ -788,8 +765,7 @@ func TestComputeFragmentation(t *testing.T) {
 		{
 			name: "full pool - no fragmentation",
 			pool: PoolState{
-				AllocatableStart: "10.0.0.0",
-				AllocatableEnd:   "10.0.0.31",
+				AllocatableRanges: []AllocatedRange{{Start: "10.0.0.0", End: "10.0.0.31"}},
 				ExistingAllocs: []AllocatedRange{
 					{Start: "10.0.0.0", End: "10.0.0.31"},
 				},
@@ -802,8 +778,7 @@ func TestComputeFragmentation(t *testing.T) {
 		{
 			name: "one allocation in middle - two free blocks",
 			pool: PoolState{
-				AllocatableStart: "10.0.0.0",
-				AllocatableEnd:   "10.0.0.31",
+				AllocatableRanges: []AllocatedRange{{Start: "10.0.0.0", End: "10.0.0.31"}},
 				ExistingAllocs: []AllocatedRange{
 					{Start: "10.0.0.8", End: "10.0.0.15"},
 				},
@@ -818,8 +793,7 @@ func TestComputeFragmentation(t *testing.T) {
 		{
 			name: "alternating allocated/free - high fragmentation",
 			pool: PoolState{
-				AllocatableStart: "10.0.0.0",
-				AllocatableEnd:   "10.0.0.31",
+				AllocatableRanges: []AllocatedRange{{Start: "10.0.0.0", End: "10.0.0.31"}},
 				ExistingAllocs: []AllocatedRange{
 					{Start: "10.0.0.2", End: "10.0.0.3"},
 					{Start: "10.0.0.6", End: "10.0.0.7"},
@@ -841,8 +815,7 @@ func TestComputeFragmentation(t *testing.T) {
 		{
 			name: "single contiguous free block at end",
 			pool: PoolState{
-				AllocatableStart: "10.0.0.0",
-				AllocatableEnd:   "10.0.0.31",
+				AllocatableRanges: []AllocatedRange{{Start: "10.0.0.0", End: "10.0.0.31"}},
 				ExistingAllocs: []AllocatedRange{
 					{Start: "10.0.0.0", End: "10.0.0.15"},
 				},
@@ -883,23 +856,48 @@ func TestValidatePoolSpec(t *testing.T) {
 		name         string
 		cidr         string
 		reserved     []string
-		allocStart   string
-		allocEnd     string
+		ranges       []AllocatedRange
 		wantErrCount int
 	}{
-		{"valid spec", "10.40.0.0/24", []string{"10.40.0.0/26"}, "10.40.0.128", "10.40.0.255", 0},
-		{"invalid CIDR", "bad", nil, "", "", 1},
-		{"reserved outside pool", "10.40.0.0/24", []string{"10.41.0.0/24"}, "", "", 1},
-		{"alloc range outside pool", "10.40.0.0/24", nil, "10.41.0.0", "10.41.0.255", 1},
-		{"alloc start after end", "10.40.0.0/24", nil, "10.40.0.200", "10.40.0.100", 1},
-		{"multiple errors", "10.40.0.0/24", []string{"10.41.0.0/24"}, "10.42.0.0", "10.42.0.255", 2},
-		{"no alloc range", "10.40.0.0/24", []string{"10.40.0.0/26"}, "", "", 0},
-		{"invalid reserved CIDR", "10.40.0.0/24", []string{"bad"}, "", "", 1},
+		{"valid single range", "10.40.0.0/24", []string{"10.40.0.0/26"}, []AllocatedRange{{Start: "10.40.0.128", End: "10.40.0.255"}}, 0},
+		{"invalid CIDR", "bad", nil, nil, 1},
+		{"reserved outside pool", "10.40.0.0/24", []string{"10.41.0.0/24"}, nil, 1},
+		{"range outside pool", "10.40.0.0/24", nil, []AllocatedRange{{Start: "10.41.0.0", End: "10.41.0.255"}}, 1},
+		{"range start after end", "10.40.0.0/24", nil, []AllocatedRange{{Start: "10.40.0.200", End: "10.40.0.100"}}, 1},
+		{"multiple errors", "10.40.0.0/24", []string{"10.41.0.0/24"}, []AllocatedRange{{Start: "10.42.0.0", End: "10.42.0.255"}}, 2},
+		{"no ranges", "10.40.0.0/24", []string{"10.40.0.0/26"}, nil, 0},
+		{"invalid reserved CIDR", "10.40.0.0/24", []string{"bad"}, nil, 1},
+		// Multi-range validation
+		{"valid multi-range sorted", "10.40.0.0/24", nil, []AllocatedRange{
+			{Start: "10.40.0.0", End: "10.40.0.63"},
+			{Start: "10.40.0.128", End: "10.40.0.255"},
+		}, 0},
+		{"multi-range unsorted", "10.40.0.0/24", nil, []AllocatedRange{
+			{Start: "10.40.0.128", End: "10.40.0.255"},
+			{Start: "10.40.0.0", End: "10.40.0.63"},
+		}, 1},
+		{"multi-range overlapping", "10.40.0.0/24", nil, []AllocatedRange{
+			{Start: "10.40.0.0", End: "10.40.0.100"},
+			{Start: "10.40.0.50", End: "10.40.0.200"},
+		}, 1},
+		{"multi-range one outside CIDR", "10.40.0.0/24", nil, []AllocatedRange{
+			{Start: "10.40.0.0", End: "10.40.0.63"},
+			{Start: "10.40.1.0", End: "10.40.1.50"},
+		}, 1},
+		{"reserved within range", "10.40.0.0/24", []string{"10.40.0.8/29"}, []AllocatedRange{
+			{Start: "10.40.0.0", End: "10.40.0.63"},
+		}, 0},
+		{"reserved outside all ranges", "10.40.0.0/24", []string{"10.40.0.200/29"}, []AllocatedRange{
+			{Start: "10.40.0.0", End: "10.40.0.63"},
+		}, 0},
+		{"reserved straddles range boundary", "10.40.0.0/24", []string{"10.40.0.0/26"}, []AllocatedRange{
+			{Start: "10.40.0.0", End: "10.40.0.31"},
+		}, 1},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			errs := ValidatePoolSpec(tt.cidr, tt.reserved, tt.allocStart, tt.allocEnd)
+			errs := ValidatePoolSpec(tt.cidr, tt.ranges, tt.reserved)
 			if len(errs) != tt.wantErrCount {
 				t.Errorf("got %d errors, want %d: %v", len(errs), tt.wantErrCount, errs)
 			}
@@ -920,26 +918,23 @@ func TestPoolCapacityInfo(t *testing.T) {
 		{
 			name: "empty pool no reserved",
 			pool: PoolState{
-				AllocatableStart: "10.0.0.0",
-				AllocatableEnd:   "10.0.0.31",
+				AllocatableRanges: []AllocatedRange{{Start: "10.0.0.0", End: "10.0.0.31"}},
 			},
 			wantTotal: 32, wantAllocated: 0, wantAvailable: 32,
 		},
 		{
 			name: "with reserved IPs",
 			pool: PoolState{
-				AllocatableStart: "10.0.0.0",
-				AllocatableEnd:   "10.0.0.31",
-				ReservedCIDRs:    []string{"10.0.0.0/29"}, // 8 reserved
+				AllocatableRanges: []AllocatedRange{{Start: "10.0.0.0", End: "10.0.0.31"}},
+				ReservedCIDRs:     []string{"10.0.0.0/29"}, // 8 reserved
 			},
 			wantTotal: 24, wantAllocated: 0, wantAvailable: 24,
 		},
 		{
 			name: "with reserved and allocated",
 			pool: PoolState{
-				AllocatableStart: "10.0.0.0",
-				AllocatableEnd:   "10.0.0.31",
-				ReservedCIDRs:    []string{"10.0.0.0/29"}, // 8 reserved
+				AllocatableRanges: []AllocatedRange{{Start: "10.0.0.0", End: "10.0.0.31"}},
+				ReservedCIDRs:     []string{"10.0.0.0/29"}, // 8 reserved
 				ExistingAllocs: []AllocatedRange{
 					{Start: "10.0.0.8", End: "10.0.0.15"}, // 8 allocated
 				},
@@ -949,9 +944,8 @@ func TestPoolCapacityInfo(t *testing.T) {
 		{
 			name: "fully allocated (non-reserved)",
 			pool: PoolState{
-				AllocatableStart: "10.0.0.0",
-				AllocatableEnd:   "10.0.0.15",
-				ReservedCIDRs:    []string{"10.0.0.0/29"}, // 8 reserved
+				AllocatableRanges: []AllocatedRange{{Start: "10.0.0.0", End: "10.0.0.15"}},
+				ReservedCIDRs:     []string{"10.0.0.0/29"}, // 8 reserved
 				ExistingAllocs: []AllocatedRange{
 					{Start: "10.0.0.8", End: "10.0.0.15"}, // 8 allocated
 				},
@@ -1105,8 +1099,7 @@ func TestAllocateAndRelease_Workflow(t *testing.T) {
 	// 4. Allocate 8 IPs — should use remaining space
 
 	pool := PoolState{
-		AllocatableStart: "10.0.0.0",
-		AllocatableEnd:   "10.0.0.63",
+		AllocatableRanges: []AllocatedRange{{Start: "10.0.0.0", End: "10.0.0.63"}},
 	}
 
 	// Step 1: 4 allocations of 8
@@ -1166,8 +1159,7 @@ func TestAllocateAndRelease_Workflow(t *testing.T) {
 func TestAllocateRange_CIDRNotation(t *testing.T) {
 	// Verify power-of-2 aligned allocations produce CIDR notation
 	pool := PoolState{
-		AllocatableStart: "10.0.0.0",
-		AllocatableEnd:   "10.0.0.255",
+		AllocatableRanges: []AllocatedRange{{Start: "10.0.0.0", End: "10.0.0.255"}},
 	}
 
 	// Allocate 8 IPs starting at .0 — should be 10.0.0.0/29
@@ -1194,8 +1186,7 @@ func TestAllocateRange_CIDRNotation(t *testing.T) {
 
 func TestAllocatePinnedRange(t *testing.T) {
 	pool := PoolState{
-		AllocatableStart: "10.40.0.0",
-		AllocatableEnd:   "10.40.0.255",
+		AllocatableRanges: []AllocatedRange{{Start: "10.40.0.0", End: "10.40.0.255"}},
 	}
 
 	tests := []struct {
@@ -1231,26 +1222,38 @@ func TestAllocatePinnedRange(t *testing.T) {
 		},
 		{
 			name:        "outside pool - before",
-			pool:        PoolState{AllocatableStart: "10.40.0.64", AllocatableEnd: "10.40.0.127"},
+			pool:        PoolState{AllocatableRanges: []AllocatedRange{{Start: "10.40.0.64", End: "10.40.0.127"}}},
 			start:       "10.40.0.10",
 			end:         "10.40.0.17",
 			wantErr:     true,
-			errContains: "outside pool",
+			errContains: "outside allocatable ranges",
 		},
 		{
 			name:        "outside pool - after",
-			pool:        PoolState{AllocatableStart: "10.40.0.0", AllocatableEnd: "10.40.0.127"},
+			pool:        PoolState{AllocatableRanges: []AllocatedRange{{Start: "10.40.0.0", End: "10.40.0.127"}}},
 			start:       "10.40.0.200",
 			end:         "10.40.0.207",
 			wantErr:     true,
-			errContains: "outside pool",
+			errContains: "outside allocatable ranges",
+		},
+		{
+			name: "straddles two ranges",
+			pool: PoolState{
+				AllocatableRanges: []AllocatedRange{
+					{Start: "10.92.90.32", End: "10.92.90.63"},
+					{Start: "10.92.91.51", End: "10.92.91.191"},
+				},
+			},
+			start:       "10.92.90.62",
+			end:         "10.92.91.55",
+			wantErr:     true,
+			errContains: "straddles allocatable ranges",
 		},
 		{
 			name: "conflicts with reserved",
 			pool: PoolState{
-				AllocatableStart: "10.40.0.0",
-				AllocatableEnd:   "10.40.0.255",
-				ReservedCIDRs:    []string{"10.40.0.0/28"},
+				AllocatableRanges: []AllocatedRange{{Start: "10.40.0.0", End: "10.40.0.255"}},
+				ReservedCIDRs:     []string{"10.40.0.0/28"},
 			},
 			start:       "10.40.0.10",
 			end:         "10.40.0.17",
@@ -1260,9 +1263,8 @@ func TestAllocatePinnedRange(t *testing.T) {
 		{
 			name: "conflicts with existing allocation",
 			pool: PoolState{
-				AllocatableStart: "10.40.0.0",
-				AllocatableEnd:   "10.40.0.255",
-				ExistingAllocs:   []AllocatedRange{{Start: "10.40.0.10", End: "10.40.0.17"}},
+				AllocatableRanges: []AllocatedRange{{Start: "10.40.0.0", End: "10.40.0.255"}},
+				ExistingAllocs:    []AllocatedRange{{Start: "10.40.0.10", End: "10.40.0.17"}},
 			},
 			start:       "10.40.0.14",
 			end:         "10.40.0.21",
@@ -1272,9 +1274,8 @@ func TestAllocatePinnedRange(t *testing.T) {
 		{
 			name: "adjacent to existing - no conflict",
 			pool: PoolState{
-				AllocatableStart: "10.40.0.0",
-				AllocatableEnd:   "10.40.0.255",
-				ExistingAllocs:   []AllocatedRange{{Start: "10.40.0.10", End: "10.40.0.17"}},
+				AllocatableRanges: []AllocatedRange{{Start: "10.40.0.0", End: "10.40.0.255"}},
+				ExistingAllocs:    []AllocatedRange{{Start: "10.40.0.10", End: "10.40.0.17"}},
 			},
 			start:     "10.40.0.18",
 			end:       "10.40.0.25",
@@ -1316,8 +1317,7 @@ func TestAllocatePinnedRange(t *testing.T) {
 func TestAllocatePinnedRange_MigrationWorkflow(t *testing.T) {
 	// Simulate migrating 3 existing TCs with manual LB pools into IPAM
 	pool := PoolState{
-		AllocatableStart: "10.40.6.0",
-		AllocatableEnd:   "10.40.6.255",
+		AllocatableRanges: []AllocatedRange{{Start: "10.40.6.0", End: "10.40.6.255"}},
 	}
 
 	// Import existing assignments
@@ -1325,8 +1325,8 @@ func TestAllocatePinnedRange_MigrationWorkflow(t *testing.T) {
 		start string
 		end   string
 	}{
-		{"10.40.6.10", "10.40.6.30"},  // butlerlabs-site-dev
-		{"10.40.6.50", "10.40.6.55"},  // gateway-test
+		{"10.40.6.10", "10.40.6.30"},   // butlerlabs-site-dev
+		{"10.40.6.50", "10.40.6.55"},   // gateway-test
 		{"10.40.6.100", "10.40.6.115"}, // another cluster
 	}
 
@@ -1363,9 +1363,8 @@ func TestAllocateRange_RealisticDatacenter(t *testing.T) {
 	// Simulate a realistic datacenter scenario:
 	// /24 pool (256 IPs), reserved .0-.15 for management, 5 nodes + 8 LB per tenant
 	pool := PoolState{
-		AllocatableStart: "10.40.0.0",
-		AllocatableEnd:   "10.40.0.255",
-		ReservedCIDRs:    []string{"10.40.0.0/28"}, // .0-.15 reserved for management
+		AllocatableRanges: []AllocatedRange{{Start: "10.40.0.0", End: "10.40.0.255"}},
+		ReservedCIDRs:     []string{"10.40.0.0/28"}, // .0-.15 reserved for management
 	}
 
 	// Allocate for 10 tenants (5 node IPs + 8 LB IPs each = 13 per tenant)
@@ -1396,7 +1395,7 @@ func TestAllocateRange_RealisticDatacenter(t *testing.T) {
 	}
 
 	expectedAllocated := int32(10 * 13) // 130 IPs allocated
-	expectedTotal := int32(240)          // 256 - 16 reserved
+	expectedTotal := int32(240)         // 256 - 16 reserved
 	expectedAvailable := expectedTotal - expectedAllocated
 
 	if total != expectedTotal {
@@ -1408,4 +1407,300 @@ func TestAllocateRange_RealisticDatacenter(t *testing.T) {
 	if available != expectedAvailable {
 		t.Errorf("available = %d, want %d", available, expectedAvailable)
 	}
+}
+
+// --- Multi-Range Tests ---
+
+func TestBuildBitmap_MultiRange(t *testing.T) {
+	t.Run("two ranges with gap", func(t *testing.T) {
+		pool := PoolState{
+			AllocatableRanges: []AllocatedRange{
+				{Start: "10.0.0.0", End: "10.0.0.7"},
+				{Start: "10.0.0.16", End: "10.0.0.23"},
+			},
+		}
+		bitmap, startUint, err := BuildBitmap(pool)
+		if err != nil {
+			t.Fatal(err)
+		}
+		// Bitmap spans .0 to .23 = 24 entries
+		if len(bitmap) != 24 {
+			t.Fatalf("bitmap length = %d, want 24", len(bitmap))
+		}
+		if startUint != IPToUint32(net.ParseIP("10.0.0.0")) {
+			t.Errorf("startUint mismatch")
+		}
+		// .0-.7 free (range 1), .8-.15 used (gap), .16-.23 free (range 2)
+		for i := 0; i < 8; i++ {
+			if bitmap[i] {
+				t.Errorf("bitmap[%d] should be free (range 1)", i)
+			}
+		}
+		for i := 8; i < 16; i++ {
+			if !bitmap[i] {
+				t.Errorf("bitmap[%d] should be used (gap)", i)
+			}
+		}
+		for i := 16; i < 24; i++ {
+			if bitmap[i] {
+				t.Errorf("bitmap[%d] should be free (range 2)", i)
+			}
+		}
+	})
+
+	t.Run("three ranges with reserved in gap", func(t *testing.T) {
+		pool := PoolState{
+			AllocatableRanges: []AllocatedRange{
+				{Start: "10.0.0.0", End: "10.0.0.7"},
+				{Start: "10.0.0.16", End: "10.0.0.23"},
+				{Start: "10.0.0.32", End: "10.0.0.39"},
+			},
+			ReservedCIDRs: []string{"10.0.0.4/30"}, // .4-.7 reserved within range 1
+		}
+		bitmap, _, err := BuildBitmap(pool)
+		if err != nil {
+			t.Fatal(err)
+		}
+		// .4-.7 reserved
+		for i := 4; i < 8; i++ {
+			if !bitmap[i] {
+				t.Errorf("bitmap[%d] should be reserved", i)
+			}
+		}
+		// .8-.15 gap
+		for i := 8; i < 16; i++ {
+			if !bitmap[i] {
+				t.Errorf("bitmap[%d] should be used (gap between range 1 and 2)", i)
+			}
+		}
+		// .16-.23 free (range 2)
+		for i := 16; i < 24; i++ {
+			if bitmap[i] {
+				t.Errorf("bitmap[%d] should be free (range 2)", i)
+			}
+		}
+	})
+}
+
+func TestAllocateRange_MultiRange(t *testing.T) {
+	t.Run("allocates across two ranges", func(t *testing.T) {
+		pool := PoolState{
+			AllocatableRanges: []AllocatedRange{
+				{Start: "10.0.0.0", End: "10.0.0.3"},   // 4 IPs
+				{Start: "10.0.0.16", End: "10.0.0.23"}, // 8 IPs
+			},
+		}
+		// Request 6 IPs — won't fit in range 1 (4 IPs), must use range 2 (8 IPs)
+		result, err := AllocateRange(pool, 6)
+		if err != nil {
+			t.Fatal(err)
+		}
+		// Best-fit selects range 2 (8 >= 6, and range 1 is too small)
+		if result.Start != "10.0.0.16" {
+			t.Errorf("start = %s, want 10.0.0.16", result.Start)
+		}
+		if result.End != "10.0.0.21" {
+			t.Errorf("end = %s, want 10.0.0.21", result.End)
+		}
+	})
+
+	t.Run("fills first range then second", func(t *testing.T) {
+		pool := PoolState{
+			AllocatableRanges: []AllocatedRange{
+				{Start: "10.0.0.0", End: "10.0.0.3"},   // 4 IPs
+				{Start: "10.0.0.16", End: "10.0.0.23"}, // 8 IPs
+			},
+		}
+		// Request 4 IPs — fits exactly in range 1 (best fit)
+		result1, err := AllocateRange(pool, 4)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if result1.Start != "10.0.0.0" {
+			t.Errorf("first allocation start = %s, want 10.0.0.0", result1.Start)
+		}
+
+		// Add to existing allocs, request 4 more — must use range 2
+		pool.ExistingAllocs = append(pool.ExistingAllocs, AllocatedRange{
+			Start: result1.Start, End: result1.End,
+		})
+		result2, err := AllocateRange(pool, 4)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if result2.Start != "10.0.0.16" {
+			t.Errorf("second allocation start = %s, want 10.0.0.16", result2.Start)
+		}
+	})
+}
+
+// TestAllocateRange_FullCIDRFallback verifies that a single range covering the
+// full CIDR (the shape produced by buildPoolState when TenantAllocation is nil)
+// behaves identically to the legacy single-range path.
+func TestAllocateRange_FullCIDRFallback(t *testing.T) {
+	// Simulates the controller's buildPoolState fallback: TenantAllocation is nil,
+	// so AllocatableRanges gets a single entry spanning the full CIDR.
+	pool := PoolState{
+		AllocatableRanges: []AllocatedRange{
+			{Start: "10.40.0.0", End: "10.40.0.255"},
+		},
+		ReservedCIDRs: []string{"10.40.0.0/28"}, // .0-.15 reserved
+	}
+
+	// Allocate 8 IPs — should skip reserved block and allocate .16-.23
+	result, err := AllocateRange(pool, 8)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Start != "10.40.0.16" {
+		t.Errorf("start = %s, want 10.40.0.16", result.Start)
+	}
+	if result.End != "10.40.0.23" {
+		t.Errorf("end = %s, want 10.40.0.23", result.End)
+	}
+
+	// Capacity should report 240 usable (256 - 16 reserved), 8 allocated, 232 available
+	pool.ExistingAllocs = []AllocatedRange{{Start: result.Start, End: result.End}}
+	total, allocated, available, err := PoolCapacityInfo(pool)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if total != 240 {
+		t.Errorf("total = %d, want 240", total)
+	}
+	if allocated != 8 {
+		t.Errorf("allocated = %d, want 8", allocated)
+	}
+	if available != 232 {
+		t.Errorf("available = %d, want 232", available)
+	}
+}
+
+func TestPoolCapacityInfo_MultiRange(t *testing.T) {
+	t.Run("total is sum of range sizes not span", func(t *testing.T) {
+		pool := PoolState{
+			AllocatableRanges: []AllocatedRange{
+				{Start: "10.0.0.0", End: "10.0.0.7"},   // 8 IPs
+				{Start: "10.0.0.32", End: "10.0.0.39"}, // 8 IPs
+			},
+		}
+		total, allocated, available, err := PoolCapacityInfo(pool)
+		if err != nil {
+			t.Fatal(err)
+		}
+		// Total should be 16 (8+8), not 40 (span from .0 to .39)
+		if total != 16 {
+			t.Errorf("total = %d, want 16", total)
+		}
+		if allocated != 0 {
+			t.Errorf("allocated = %d, want 0", allocated)
+		}
+		if available != 16 {
+			t.Errorf("available = %d, want 16", available)
+		}
+	})
+
+	t.Run("reserved counted only within ranges", func(t *testing.T) {
+		pool := PoolState{
+			AllocatableRanges: []AllocatedRange{
+				{Start: "10.0.0.0", End: "10.0.0.15"},  // 16 IPs
+				{Start: "10.0.0.32", End: "10.0.0.47"}, // 16 IPs
+			},
+			ReservedCIDRs: []string{
+				"10.0.0.0/30",  // .0-.3 reserved within range 1
+				"10.0.0.20/30", // .20-.23 reserved in gap (not in any range)
+			},
+		}
+		total, _, available, err := PoolCapacityInfo(pool)
+		if err != nil {
+			t.Fatal(err)
+		}
+		// Total = 32 - 4 (reserved in range 1) = 28. Gap reserved doesn't count.
+		if total != 28 {
+			t.Errorf("total = %d, want 28", total)
+		}
+		if available != 28 {
+			t.Errorf("available = %d, want 28", available)
+		}
+	})
+
+	t.Run("crop cluster scenario", func(t *testing.T) {
+		// Mirrors the actual crop cluster configuration:
+		// Range 1: .32-.63 (32 IPs), Range 2: .91.51-.91.191 (141 IPs)
+		pool := PoolState{
+			AllocatableRanges: []AllocatedRange{
+				{Start: "10.92.90.32", End: "10.92.90.63"},  // 32 IPs
+				{Start: "10.92.91.51", End: "10.92.91.191"}, // 141 IPs
+			},
+		}
+		total, allocated, available, err := PoolCapacityInfo(pool)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if total != 173 {
+			t.Errorf("total = %d, want 173", total)
+		}
+		if allocated != 0 {
+			t.Errorf("allocated = %d, want 0", allocated)
+		}
+		if available != 173 {
+			t.Errorf("available = %d, want 173", available)
+		}
+	})
+}
+
+func TestComputeFragmentation_MultiRange(t *testing.T) {
+	t.Run("two ranges no allocations", func(t *testing.T) {
+		pool := PoolState{
+			AllocatableRanges: []AllocatedRange{
+				{Start: "10.0.0.0", End: "10.0.0.7"},
+				{Start: "10.0.0.16", End: "10.0.0.23"},
+			},
+		}
+		info, err := ComputeFragmentation(pool)
+		if err != nil {
+			t.Fatal(err)
+		}
+		// Two separate free blocks (one per range), so fragmentation > 0
+		if info.FreeBlockCount != 2 {
+			t.Errorf("FreeBlockCount = %d, want 2", info.FreeBlockCount)
+		}
+		if info.TotalFreeIPs != 16 {
+			t.Errorf("TotalFreeIPs = %d, want 16", info.TotalFreeIPs)
+		}
+	})
+
+	t.Run("crop cluster scenario with partial allocation", func(t *testing.T) {
+		// Crop cluster: ranges[0] .32-.63 (32 IPs), ranges[1] .51-.191 (141 IPs)
+		// 28 IPs allocated in ranges[0] (.32-.59), 0 in ranges[1]
+		pool := PoolState{
+			AllocatableRanges: []AllocatedRange{
+				{Start: "10.92.90.32", End: "10.92.90.63"},
+				{Start: "10.92.91.51", End: "10.92.91.191"},
+			},
+			ExistingAllocs: []AllocatedRange{
+				{Start: "10.92.90.32", End: "10.92.90.59"},
+			},
+		}
+		info, err := ComputeFragmentation(pool)
+		if err != nil {
+			t.Fatal(err)
+		}
+		// Free space: 4 IPs in ranges[0] (.60-.63) + 141 IPs in ranges[1] (.51-.191) = 145
+		if info.TotalFreeIPs != 145 {
+			t.Errorf("TotalFreeIPs = %d, want 145", info.TotalFreeIPs)
+		}
+		// Two free blocks: tail of ranges[0] and all of ranges[1]
+		if info.FreeBlockCount != 2 {
+			t.Errorf("FreeBlockCount = %d, want 2", info.FreeBlockCount)
+		}
+		// Largest free block is ranges[1] = 141 IPs
+		if info.LargestFreeBlock != 141 {
+			t.Errorf("LargestFreeBlock = %d, want 141", info.LargestFreeBlock)
+		}
+		// Fragmentation: 1 - (141/145) = ~2.7% — low, which is operationally correct
+		if info.FragmentationPercent > 5 {
+			t.Errorf("FragmentationPercent = %d, want <= 5 (healthy multi-range pool)", info.FragmentationPercent)
+		}
+	})
 }

--- a/internal/webhook/networkpool_webhook.go
+++ b/internal/webhook/networkpool_webhook.go
@@ -103,32 +103,47 @@ func (v *NetworkPoolValidator) ValidateUpdate(ctx context.Context, oldObj, newOb
 }
 
 // validateTenantAllocationNarrowing rejects narrowing of the tenant allocation
-// range when existing IPAllocations have addresses outside the proposed range.
+// ranges when existing IPAllocations have addresses outside the proposed ranges.
+// Handles all narrowing shapes: range removal, range shrink, range split,
+// and Start/End-to-Ranges migration.
 func (v *NetworkPoolValidator) validateTenantAllocationNarrowing(ctx context.Context, oldPool, newPool *butlerv1alpha1.NetworkPool) error {
-	if oldPool.Spec.TenantAllocation == nil || newPool.Spec.TenantAllocation == nil {
+	if newPool.Spec.TenantAllocation == nil {
 		return nil
 	}
 
-	oldStart := oldPool.Spec.TenantAllocation.Start
-	oldEnd := oldPool.Spec.TenantAllocation.End
-	newStart := newPool.Spec.TenantAllocation.Start
-	newEnd := newPool.Spec.TenantAllocation.End
-
-	// If the range didn't change, nothing to validate
-	if oldStart == newStart && oldEnd == newEnd {
-		return nil
+	newRanges := newPool.Spec.TenantAllocation.GetEffectiveRanges()
+	if len(newRanges) == 0 {
+		return nil // no ranges = entire CIDR, can't narrow
 	}
 
-	// Parse new range boundaries
-	newStartIP := net.ParseIP(newStart).To4()
-	newEndIP := net.ParseIP(newEnd).To4()
-	if newStartIP == nil || newEndIP == nil {
-		return nil // validation of IPs themselves is done by validatePoolSpec
+	// Parse new ranges into uint32 pairs for fast lookup.
+	type rangeBounds struct {
+		start, end uint32
 	}
-	newStartUint := ipam.IPToUint32(newStartIP)
-	newEndUint := ipam.IPToUint32(newEndIP)
+	newBounds := make([]rangeBounds, 0, len(newRanges))
+	for _, r := range newRanges {
+		sIP := net.ParseIP(r.Start).To4()
+		eIP := net.ParseIP(r.End).To4()
+		if sIP == nil || eIP == nil {
+			return nil // IP validation is done by validatePoolSpec
+		}
+		newBounds = append(newBounds, rangeBounds{
+			start: ipam.IPToUint32(sIP),
+			end:   ipam.IPToUint32(eIP),
+		})
+	}
 
-	// List all IPAllocations referencing this pool
+	// ipWithinRanges checks if an IP falls within any of the new ranges.
+	ipWithinRanges := func(ipUint uint32) bool {
+		for _, b := range newBounds {
+			if ipUint >= b.start && ipUint <= b.end {
+				return true
+			}
+		}
+		return false
+	}
+
+	// List all IPAllocations referencing this pool.
 	var allocList butlerv1alpha1.IPAllocationList
 	if err := v.Client.List(ctx, &allocList, client.MatchingLabels{
 		butlerv1alpha1.LabelNetworkPool: newPool.Name,
@@ -143,19 +158,18 @@ func (v *NetworkPoolValidator) validateTenantAllocationNarrowing(ctx context.Con
 			continue
 		}
 
-		// Check each address in the allocation
+		// Check each address in the allocation.
 		for _, addr := range alloc.Status.Addresses {
 			ip := net.ParseIP(addr).To4()
 			if ip == nil {
 				continue
 			}
-			ipUint := ipam.IPToUint32(ip)
-			if ipUint < newStartUint || ipUint > newEndUint {
+			if !ipWithinRanges(ipam.IPToUint32(ip)) {
 				allErrs = append(allErrs, field.Forbidden(
 					field.NewPath("spec", "tenantAllocation"),
 					fmt.Sprintf(
-						"cannot narrow tenant allocation range: IPAllocation %q has address %s outside the proposed range %s-%s. Migrate or delete affected allocations first",
-						alloc.Name, addr, newStart, newEnd,
+						"cannot narrow tenant allocation ranges: IPAllocation %q has address %s outside the proposed ranges. Migrate or delete affected allocations first",
+						alloc.Name, addr,
 					),
 				))
 				break // one violation per allocation is enough
@@ -170,12 +184,12 @@ func (v *NetworkPoolValidator) validateTenantAllocationNarrowing(ctx context.Con
 			if startIP != nil && endIP != nil {
 				sUint := ipam.IPToUint32(startIP)
 				eUint := ipam.IPToUint32(endIP)
-				if sUint < newStartUint || eUint > newEndUint {
+				if !ipWithinRanges(sUint) || !ipWithinRanges(eUint) {
 					allErrs = append(allErrs, field.Forbidden(
 						field.NewPath("spec", "tenantAllocation"),
 						fmt.Sprintf(
-							"cannot narrow tenant allocation range: IPAllocation %q has addresses %s-%s outside the proposed range %s-%s. Migrate or delete affected allocations first",
-							alloc.Name, alloc.Status.StartAddress, alloc.Status.EndAddress, newStart, newEnd,
+							"cannot narrow tenant allocation ranges: IPAllocation %q has addresses %s-%s outside the proposed ranges. Migrate or delete affected allocations first",
+							alloc.Name, alloc.Status.StartAddress, alloc.Status.EndAddress,
 						),
 					))
 				}
@@ -223,6 +237,7 @@ func (v *NetworkPoolValidator) ValidateDelete(ctx context.Context, obj runtime.O
 }
 
 // validatePoolSpec validates the internal consistency of a NetworkPool spec using the ipam package.
+// Returns deprecation warnings when Start/End are used instead of Ranges.
 func (v *NetworkPoolValidator) validatePoolSpec(pool *butlerv1alpha1.NetworkPool) (admission.Warnings, error) {
 	// Collect reserved CIDRs.
 	reservedCIDRs := make([]string, 0, len(pool.Spec.Reserved))
@@ -230,15 +245,32 @@ func (v *NetworkPoolValidator) validatePoolSpec(pool *butlerv1alpha1.NetworkPool
 		reservedCIDRs = append(reservedCIDRs, r.CIDR)
 	}
 
-	// Determine allocation range.
-	allocStart := ""
-	allocEnd := ""
+	// Resolve effective ranges and build deprecation warnings.
+	var warnings admission.Warnings
+	var ranges []ipam.AllocatedRange
 	if pool.Spec.TenantAllocation != nil {
-		allocStart = pool.Spec.TenantAllocation.Start
-		allocEnd = pool.Spec.TenantAllocation.End
+		ta := pool.Spec.TenantAllocation
+		hasStartEnd := ta.Start != "" && ta.End != ""
+		hasRanges := len(ta.Ranges) > 0
+
+		if hasStartEnd && hasRanges {
+			warnings = append(warnings,
+				"Start/End are ignored when Ranges is present; remove them")
+		} else if hasStartEnd && !hasRanges {
+			warnings = append(warnings, fmt.Sprintf(
+				"Start/End fields are deprecated; migrate to Ranges. Equivalent configuration:\n"+
+					"  tenantAllocation:\n"+
+					"    ranges:\n"+
+					"    - start: %s\n"+
+					"      end: %s", ta.Start, ta.End))
+		}
+
+		for _, r := range ta.GetEffectiveRanges() {
+			ranges = append(ranges, ipam.AllocatedRange{Start: r.Start, End: r.End})
+		}
 	}
 
-	errs := ipam.ValidatePoolSpec(pool.Spec.CIDR, reservedCIDRs, allocStart, allocEnd)
+	errs := ipam.ValidatePoolSpec(pool.Spec.CIDR, ranges, reservedCIDRs)
 	if len(errs) > 0 {
 		var allErrs field.ErrorList
 		for _, errMsg := range errs {
@@ -248,10 +280,10 @@ func (v *NetworkPoolValidator) validatePoolSpec(pool *butlerv1alpha1.NetworkPool
 				errMsg,
 			))
 		}
-		return nil, allErrs.ToAggregate()
+		return warnings, allErrs.ToAggregate()
 	}
 
-	return nil, nil
+	return warnings, nil
 }
 
 // SetupWebhookWithManager registers the NetworkPool validating webhook with the manager.


### PR DESCRIPTION
## Summary

- Consume butler-api v0.16.0 (`AllocationRange` type, `Ranges` field, `GetEffectiveRanges()` helper) and update the allocator, controller, and webhook to support non-contiguous allocatable IP ranges within a single NetworkPool
- Spanning bitmap approach marks inter-range gaps as used so allocation, capacity, and fragmentation calculations work correctly across disjoint ranges
- Informative error messages for pinned range straddle and out-of-bounds cases name the exact range boundaries the operator should reconcile
- Webhook emits deprecation warnings with suggested migration YAML when Start/End are used without Ranges, and anti-narrowing validation handles all four narrowing shapes (range removal, shrink, split, Start/End-to-Ranges migration)

## Backwards compatibility

- Existing NetworkPool manifests with Start/End continue working unchanged via `GetEffectiveRanges()` precedence
- Existing IPAllocations remain valid through the controller upgrade
- The webhook accepts both old and new manifest shapes
- Deprecation warnings inform operators without rejecting manifests
- When TenantAllocation is nil, the controller falls back to full CIDR allocation (same as before)

## Test plan

- [x] 80 existing ipam test references mechanically converted to AllocatableRanges, all passing
- [x] ValidatePoolSpec tests expanded with 7 multi-range cases (sorted valid, unsorted rejection, overlapping rejection, outside CIDR, reserved within range, reserved outside ranges, reserved straddles boundary)
- [x] TestBuildBitmap_MultiRange: two ranges with gap, three ranges with reserved in gap
- [x] TestAllocateRange_MultiRange: allocates across two ranges, fills first then second
- [x] TestAllocateRange_FullCIDRFallback: verifies nil-TenantAllocation fallback path produces correct allocation and capacity
- [x] TestAllocatePinnedRange: straddles two ranges (informative error), outside pool with range listing
- [x] TestPoolCapacityInfo_MultiRange: total is sum not span, reserved only within ranges, crop cluster scenario (173 IPs)
- [x] TestComputeFragmentation_MultiRange: two ranges no allocations, crop cluster scenario with 28 allocations (3% fragmentation, operationally correct)
- [x] Build clean, vet clean, gofmt clean

## References

- butler-api#39 (design), butler-api#40 (API types, merged as v0.16.0)