### PR TITLE
feat(controller): inject cluster identification into Vector and OTEL builders

### DIFF
--- a/internal/controller/tenantcluster/reconcile_addons.go
+++ b/internal/controller/tenantcluster/reconcile_addons.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
@@ -588,4 +589,51 @@ func buildOtelCollectorValues(pipeline *butlerv1alpha1.ObservabilityPipelineConf
 		return nil
 	}
 	return &butlerv1alpha1.ExtensionValues{Raw: raw}
+}
+
+// resolveProviderType looks up the canonical provider type (e.g., "nutanix",
+// "harvester") from the TenantCluster's ProviderConfigRef. Returns "" if the
+// ref is nil or empty. Uses the controller-runtime cached client, so cost is
+// bounded by informer cache, not API server round-trips.
+func resolveProviderType(ctx context.Context, c client.Reader, tc *butlerv1alpha1.TenantCluster) (string, error) {
+	if tc.Spec.ProviderConfigRef == nil || tc.Spec.ProviderConfigRef.Name == "" {
+		return "", nil
+	}
+
+	ns := tc.Spec.ProviderConfigRef.Namespace
+	if ns == "" {
+		ns = "butler-system"
+	}
+
+	pc := &butlerv1alpha1.ProviderConfig{}
+	if err := c.Get(ctx, client.ObjectKey{Name: tc.Spec.ProviderConfigRef.Name, Namespace: ns}, pc); err != nil {
+		return "", fmt.Errorf("get ProviderConfig %s/%s: %w", ns, tc.Spec.ProviderConfigRef.Name, err)
+	}
+	return string(pc.Spec.Provider), nil
+}
+
+// buildVectorRemapSource produces the VRL source for the Vector agent's
+// enrich_metadata transform. Required fields (host, service, namespace, cluster,
+// tenant_namespace, cluster_uid) are always emitted. Optional fields
+// (environment, provider_type, provider_config) are omitted when their source
+// value is empty, avoiding empty-string Loki labels.
+func buildVectorRemapSource(tc *butlerv1alpha1.TenantCluster, providerType string) string {
+	var b strings.Builder
+	b.WriteString(".host = .kubernetes.pod_node_name\n")
+	b.WriteString(".service = .kubernetes.pod_name\n")
+	b.WriteString(".namespace = .kubernetes.pod_namespace\n")
+	fmt.Fprintf(&b, ".cluster = %s\n", strconv.Quote(tc.Name))
+	fmt.Fprintf(&b, ".tenant_namespace = %s\n", strconv.Quote(tc.Namespace))
+	fmt.Fprintf(&b, ".cluster_uid = %s\n", strconv.Quote(string(tc.UID)))
+
+	if env := tc.Labels[butlerv1alpha1.LabelEnvironment]; env != "" {
+		fmt.Fprintf(&b, ".environment = %s\n", strconv.Quote(env))
+	}
+	if providerType != "" {
+		fmt.Fprintf(&b, ".provider_type = %s\n", strconv.Quote(providerType))
+	}
+	if pc := tc.Labels[butlerv1alpha1.LabelProviderConfig]; pc != "" {
+		fmt.Fprintf(&b, ".provider_config = %s\n", strconv.Quote(pc))
+	}
+	return b.String()
 }

--- a/internal/controller/tenantcluster/reconcile_addons.go
+++ b/internal/controller/tenantcluster/reconcile_addons.go
@@ -523,6 +523,12 @@ func rawOrEmpty(v *butlerv1alpha1.ExtensionValues) []byte {
 // buildVectorAgentValues configures the vector-agent sink to forward to the
 // pipeline aggregator and injects cluster identification fields into the VRL
 // remap transform so log events carry source cluster metadata.
+//
+// Only transforms and sink URI are set here. The remaining sink fields (type,
+// inputs, encoding) come from the AddonDefinition default via recursive deep
+// merge in tenantaddon_controller.go. The default's sinks.aggregator.inputs
+// references ["enrich_metadata"], ensuring events flow through the transform
+// before reaching the sink.
 func buildVectorAgentValues(pipeline *butlerv1alpha1.ObservabilityPipelineConfig, tc *butlerv1alpha1.TenantCluster, providerType string) *butlerv1alpha1.ExtensionValues {
 	if pipeline == nil || pipeline.LogEndpoint == "" {
 		return nil
@@ -654,6 +660,9 @@ func buildOtelResourceAttributes(tc *butlerv1alpha1.TenantCluster, providerType 
 // "harvester") from the TenantCluster's ProviderConfigRef. Returns "" if the
 // ref is nil or empty. Uses the controller-runtime cached client, so cost is
 // bounded by informer cache, not API server round-trips.
+//
+// Accepts client.Reader (not client.Client) to signal read-only intent and
+// simplify test setup with fake.NewClientBuilder.
 func resolveProviderType(ctx context.Context, c client.Reader, tc *butlerv1alpha1.TenantCluster) (string, error) {
 	if tc.Spec.ProviderConfigRef == nil || tc.Spec.ProviderConfigRef.Name == "" {
 		return "", nil

--- a/internal/controller/tenantcluster/reconcile_addons.go
+++ b/internal/controller/tenantcluster/reconcile_addons.go
@@ -426,7 +426,7 @@ func (r *Reconciler) reconcileAutoEnrollObservability(ctx context.Context, tc *b
 	}
 
 	if enroll.OtelCollector && obs.Pipeline.TraceEndpoint != "" {
-		if err := r.ensureAutoEnrolledAddon(ctx, tc, "otel-collector", buildOtelCollectorValues(obs.Pipeline)); err != nil {
+		if err := r.ensureAutoEnrolledAddon(ctx, tc, "otel-collector", buildOtelCollectorValues(obs.Pipeline, tc, providerType)); err != nil {
 			logger.Error(err, "failed to auto-enroll otel-collector")
 		}
 	}
@@ -580,11 +580,15 @@ func buildPrometheusValues(pipeline *butlerv1alpha1.ObservabilityPipelineConfig,
 	return &butlerv1alpha1.ExtensionValues{Raw: raw}
 }
 
-// buildOtelCollectorValues configures the OTLP exporter to the pipeline trace endpoint.
-func buildOtelCollectorValues(pipeline *butlerv1alpha1.ObservabilityPipelineConfig) *butlerv1alpha1.ExtensionValues {
+// buildOtelCollectorValues configures the OTLP exporter to the pipeline trace
+// endpoint and injects cluster identification as OTLP resource attributes via
+// a resource processor.
+func buildOtelCollectorValues(pipeline *butlerv1alpha1.ObservabilityPipelineConfig, tc *butlerv1alpha1.TenantCluster, providerType string) *butlerv1alpha1.ExtensionValues {
 	if pipeline == nil || pipeline.TraceEndpoint == "" {
 		return nil
 	}
+
+	attrs := buildOtelResourceAttributes(tc, providerType)
 
 	values := map[string]interface{}{
 		"config": map[string]interface{}{
@@ -596,6 +600,20 @@ func buildOtelCollectorValues(pipeline *butlerv1alpha1.ObservabilityPipelineConf
 					},
 				},
 			},
+			"processors": map[string]interface{}{
+				"resource": map[string]interface{}{
+					"attributes": attrs,
+				},
+			},
+			"service": map[string]interface{}{
+				"pipelines": map[string]interface{}{
+					"traces": map[string]interface{}{
+						"receivers":  []string{"otlp"},
+						"processors": []string{"resource", "memory_limiter", "batch"},
+						"exporters":  []string{"otlp"},
+					},
+				},
+			},
 		},
 	}
 
@@ -604,6 +622,32 @@ func buildOtelCollectorValues(pipeline *butlerv1alpha1.ObservabilityPipelineConf
 		return nil
 	}
 	return &butlerv1alpha1.ExtensionValues{Raw: raw}
+}
+
+// buildOtelResourceAttributes produces the OTLP resource attribute upsert list
+// for cluster identification. Uses semconv keys where applicable.
+func buildOtelResourceAttributes(tc *butlerv1alpha1.TenantCluster, providerType string) []map[string]interface{} {
+	attrs := []map[string]interface{}{
+		{"key": "k8s.cluster.name", "value": tc.Name, "action": "upsert"},
+		{"key": "k8s.namespace.name", "value": tc.Namespace, "action": "upsert"},
+		{"key": "k8s.cluster.uid", "value": string(tc.UID), "action": "upsert"},
+	}
+	if env := tc.Labels[butlerv1alpha1.LabelEnvironment]; env != "" {
+		attrs = append(attrs, map[string]interface{}{
+			"key": "butler.environment", "value": env, "action": "upsert",
+		})
+	}
+	if providerType != "" {
+		attrs = append(attrs, map[string]interface{}{
+			"key": "butler.provider_type", "value": providerType, "action": "upsert",
+		})
+	}
+	if pc := tc.Labels[butlerv1alpha1.LabelProviderConfig]; pc != "" {
+		attrs = append(attrs, map[string]interface{}{
+			"key": "butler.provider_config", "value": pc, "action": "upsert",
+		})
+	}
+	return attrs
 }
 
 // resolveProviderType looks up the canonical provider type (e.g., "nutanix",

--- a/internal/controller/tenantcluster/reconcile_addons.go
+++ b/internal/controller/tenantcluster/reconcile_addons.go
@@ -407,8 +407,14 @@ func (r *Reconciler) reconcileAutoEnrollObservability(ctx context.Context, tc *b
 
 	enroll := obs.Collection.AutoEnroll
 
+	// Resolve provider type once for all builders that need cluster identification.
+	providerType, err := resolveProviderType(ctx, r.Client, tc)
+	if err != nil {
+		logger.Error(err, "failed to resolve provider type", "cluster", tc.Name)
+	}
+
 	if enroll.VectorAgent && obs.Pipeline.LogEndpoint != "" {
-		if err := r.ensureAutoEnrolledAddon(ctx, tc, "vector-agent", buildVectorAgentValues(obs.Pipeline)); err != nil {
+		if err := r.ensureAutoEnrolledAddon(ctx, tc, "vector-agent", buildVectorAgentValues(obs.Pipeline, tc, providerType)); err != nil {
 			logger.Error(err, "failed to auto-enroll vector-agent")
 		}
 	}
@@ -514,14 +520,23 @@ func rawOrEmpty(v *butlerv1alpha1.ExtensionValues) []byte {
 	return v.Raw
 }
 
-// buildVectorAgentValues configures the vector-agent sink to forward to the pipeline aggregator.
-func buildVectorAgentValues(pipeline *butlerv1alpha1.ObservabilityPipelineConfig) *butlerv1alpha1.ExtensionValues {
+// buildVectorAgentValues configures the vector-agent sink to forward to the
+// pipeline aggregator and injects cluster identification fields into the VRL
+// remap transform so log events carry source cluster metadata.
+func buildVectorAgentValues(pipeline *butlerv1alpha1.ObservabilityPipelineConfig, tc *butlerv1alpha1.TenantCluster, providerType string) *butlerv1alpha1.ExtensionValues {
 	if pipeline == nil || pipeline.LogEndpoint == "" {
 		return nil
 	}
 
 	values := map[string]interface{}{
 		"customConfig": map[string]interface{}{
+			"transforms": map[string]interface{}{
+				"enrich_metadata": map[string]interface{}{
+					"type":   "remap",
+					"inputs": []string{"kubernetes_logs"},
+					"source": buildVectorRemapSource(tc, providerType),
+				},
+			},
 			"sinks": map[string]interface{}{
 				"aggregator": map[string]interface{}{
 					"uri": pipeline.LogEndpoint,

--- a/internal/controller/tenantcluster/reconcile_addons_identification_test.go
+++ b/internal/controller/tenantcluster/reconcile_addons_identification_test.go
@@ -1,0 +1,423 @@
+// Copyright 2026 The Butler Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package tenantcluster
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	butlerv1alpha1 "github.com/butlerdotdev/butler-api/api/v1alpha1"
+)
+
+func TestBuildVectorRemapSource(t *testing.T) {
+	tests := []struct {
+		name         string
+		tc           *butlerv1alpha1.TenantCluster
+		providerType string
+		wantPresent  []string
+		wantAbsent   []string
+	}{
+		{
+			name: "all optional fields populated",
+			tc: &butlerv1alpha1.TenantCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "my-cluster", Namespace: "team-x", UID: "uid-999",
+					Labels: map[string]string{
+						butlerv1alpha1.LabelEnvironment:    "prd",
+						butlerv1alpha1.LabelProviderConfig: "nutanix-corp",
+					},
+				},
+			},
+			providerType: "nutanix",
+			wantPresent: []string{
+				`.cluster = "my-cluster"`,
+				`.tenant_namespace = "team-x"`,
+				`.cluster_uid = "uid-999"`,
+				`.environment = "prd"`,
+				`.provider_type = "nutanix"`,
+				`.provider_config = "nutanix-corp"`,
+			},
+		},
+		{
+			name: "environment absent",
+			tc: &butlerv1alpha1.TenantCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "c1", Namespace: "ns1", UID: "u1",
+					Labels: map[string]string{
+						butlerv1alpha1.LabelProviderConfig: "harvester-lab",
+					},
+				},
+			},
+			providerType: "harvester",
+			wantPresent:  []string{`.cluster = "c1"`, `.provider_type = "harvester"`},
+			wantAbsent:   []string{".environment"},
+		},
+		{
+			name: "provider type empty",
+			tc: &butlerv1alpha1.TenantCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "c2", Namespace: "ns2", UID: "u2",
+					Labels: map[string]string{
+						butlerv1alpha1.LabelEnvironment: "dev",
+					},
+				},
+			},
+			providerType: "",
+			wantPresent:  []string{`.environment = "dev"`},
+			wantAbsent:   []string{".provider_type", ".provider_config"},
+		},
+		{
+			name: "all optional fields absent",
+			tc: &butlerv1alpha1.TenantCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "bare", Namespace: "default", UID: "u3",
+				},
+			},
+			providerType: "",
+			wantPresent: []string{
+				`.cluster = "bare"`,
+				`.tenant_namespace = "default"`,
+				`.cluster_uid = "u3"`,
+				".host = .kubernetes.pod_node_name",
+			},
+			wantAbsent: []string{".environment", ".provider_type", ".provider_config"},
+		},
+		{
+			name: "special characters in cluster name",
+			tc: &butlerv1alpha1.TenantCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: `cluster-with-"quotes"`, Namespace: "ns", UID: "u4",
+				},
+			},
+			providerType: "",
+			wantPresent:  []string{`"cluster-with-\"quotes\""`},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildVectorRemapSource(tt.tc, tt.providerType)
+			for _, s := range tt.wantPresent {
+				if !strings.Contains(got, s) {
+					t.Errorf("expected VRL to contain %q\ngot:\n%s", s, got)
+				}
+			}
+			for _, s := range tt.wantAbsent {
+				if strings.Contains(got, s) {
+					t.Errorf("expected VRL to NOT contain %q\ngot:\n%s", s, got)
+				}
+			}
+		})
+	}
+}
+
+func TestResolveProviderType(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = butlerv1alpha1.AddToScheme(scheme)
+
+	nutanixPC := &butlerv1alpha1.ProviderConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "nutanix-jhh",
+			Namespace: "butler-system",
+		},
+		Spec: butlerv1alpha1.ProviderConfigSpec{
+			Provider: butlerv1alpha1.ProviderTypeNutanix,
+			CredentialsRef: butlerv1alpha1.SecretReference{
+				Name:      "nutanix-creds",
+				Namespace: "butler-system",
+			},
+		},
+	}
+
+	tests := []struct {
+		name    string
+		tc      *butlerv1alpha1.TenantCluster
+		objects []client.Object
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "nil ProviderConfigRef",
+			tc: &butlerv1alpha1.TenantCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "c", Namespace: "ns"},
+			},
+			want: "",
+		},
+		{
+			name: "empty ProviderConfigRef name",
+			tc: &butlerv1alpha1.TenantCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "c", Namespace: "ns"},
+				Spec: butlerv1alpha1.TenantClusterSpec{
+					ProviderConfigRef: &butlerv1alpha1.ProviderReference{Name: ""},
+				},
+			},
+			want: "",
+		},
+		{
+			name: "valid ref resolves to nutanix",
+			tc: &butlerv1alpha1.TenantCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "c", Namespace: "ns"},
+				Spec: butlerv1alpha1.TenantClusterSpec{
+					ProviderConfigRef: &butlerv1alpha1.ProviderReference{
+						Name:      "nutanix-jhh",
+						Namespace: "butler-system",
+					},
+				},
+			},
+			objects: []client.Object{nutanixPC},
+			want:    "nutanix",
+		},
+		{
+			name: "defaults namespace to butler-system",
+			tc: &butlerv1alpha1.TenantCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "c", Namespace: "ns"},
+				Spec: butlerv1alpha1.TenantClusterSpec{
+					ProviderConfigRef: &butlerv1alpha1.ProviderReference{
+						Name: "nutanix-jhh",
+					},
+				},
+			},
+			objects: []client.Object{nutanixPC},
+			want:    "nutanix",
+		},
+		{
+			name: "missing ProviderConfig returns error",
+			tc: &butlerv1alpha1.TenantCluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "c", Namespace: "ns"},
+				Spec: butlerv1alpha1.TenantClusterSpec{
+					ProviderConfigRef: &butlerv1alpha1.ProviderReference{
+						Name:      "does-not-exist",
+						Namespace: "butler-system",
+					},
+				},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			builder := fakeclient.NewClientBuilder().WithScheme(scheme)
+			if len(tt.objects) > 0 {
+				builder = builder.WithObjects(tt.objects...)
+			}
+			cl := builder.Build()
+
+			got, err := resolveProviderType(context.Background(), cl, tt.tc)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("providerType = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBuildVectorAgentValues_IncludesTransform(t *testing.T) {
+	pipeline := &butlerv1alpha1.ObservabilityPipelineConfig{
+		LogEndpoint: "http://10.0.0.1:8080",
+	}
+	tc := &butlerv1alpha1.TenantCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "obs-perf-dev",
+			Namespace: "team-obs",
+			UID:       "abc-def-123",
+			Labels: map[string]string{
+				butlerv1alpha1.LabelEnvironment:    "dev",
+				butlerv1alpha1.LabelProviderConfig: "nutanix-jhh",
+			},
+		},
+	}
+
+	ev := buildVectorAgentValues(pipeline, tc, "nutanix")
+	if ev == nil {
+		t.Fatal("expected non-nil ExtensionValues")
+	}
+
+	var vals map[string]interface{}
+	if err := json.Unmarshal(ev.Raw, &vals); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+
+	cfg := vals["customConfig"].(map[string]interface{})
+	transform := cfg["transforms"].(map[string]interface{})["enrich_metadata"].(map[string]interface{})
+	if transform["type"] != "remap" {
+		t.Errorf("transform type = %v, want remap", transform["type"])
+	}
+
+	source := transform["source"].(string)
+	for _, want := range []string{
+		`.cluster = "obs-perf-dev"`,
+		`.tenant_namespace = "team-obs"`,
+		`.cluster_uid = "abc-def-123"`,
+		`.environment = "dev"`,
+		`.provider_type = "nutanix"`,
+		`.provider_config = "nutanix-jhh"`,
+		`.host = .kubernetes.pod_node_name`,
+		`.service = .kubernetes.pod_name`,
+		`.namespace = .kubernetes.pod_namespace`,
+	} {
+		if !strings.Contains(source, want) {
+			t.Errorf("VRL source missing %q\ngot: %s", want, source)
+		}
+	}
+}
+
+func TestBuildVectorAgentValues_NilPipelineReturnsNil(t *testing.T) {
+	tc := &butlerv1alpha1.TenantCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "c", Namespace: "ns", UID: "u"},
+	}
+	if ev := buildVectorAgentValues(nil, tc, ""); ev != nil {
+		t.Error("expected nil for nil pipeline")
+	}
+}
+
+func TestBuildVectorAgentValues_EmptyEndpointReturnsNil(t *testing.T) {
+	tc := &butlerv1alpha1.TenantCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "c", Namespace: "ns", UID: "u"},
+	}
+	if ev := buildVectorAgentValues(&butlerv1alpha1.ObservabilityPipelineConfig{}, tc, ""); ev != nil {
+		t.Error("expected nil for empty log endpoint")
+	}
+}
+
+func TestBuildOtelCollectorValues_WithClusterIdentification(t *testing.T) {
+	pipeline := &butlerv1alpha1.ObservabilityPipelineConfig{
+		TraceEndpoint: "10.0.0.5:4317",
+	}
+	tc := &butlerv1alpha1.TenantCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "trace-cluster", Namespace: "team-t", UID: "uid-t",
+			Labels: map[string]string{
+				butlerv1alpha1.LabelEnvironment:    "prd",
+				butlerv1alpha1.LabelProviderConfig: "nutanix-jhh",
+			},
+		},
+	}
+
+	ev := buildOtelCollectorValues(pipeline, tc, "nutanix")
+	if ev == nil {
+		t.Fatal("expected non-nil ExtensionValues")
+	}
+
+	var vals map[string]interface{}
+	if err := json.Unmarshal(ev.Raw, &vals); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+
+	cfg := vals["config"].(map[string]interface{})
+
+	endpoint := cfg["exporters"].(map[string]interface{})["otlp"].(map[string]interface{})["endpoint"]
+	if endpoint != "10.0.0.5:4317" {
+		t.Errorf("endpoint = %v, want 10.0.0.5:4317", endpoint)
+	}
+
+	proc := cfg["processors"].(map[string]interface{})["resource"].(map[string]interface{})
+	attrs := proc["attributes"].([]interface{})
+
+	attrMap := make(map[string]string)
+	for _, a := range attrs {
+		m := a.(map[string]interface{})
+		attrMap[m["key"].(string)] = m["value"].(string)
+	}
+
+	expected := map[string]string{
+		"k8s.cluster.name":       "trace-cluster",
+		"k8s.namespace.name":     "team-t",
+		"k8s.cluster.uid":        "uid-t",
+		"butler.environment":     "prd",
+		"butler.provider_type":   "nutanix",
+		"butler.provider_config": "nutanix-jhh",
+	}
+	for k, v := range expected {
+		if attrMap[k] != v {
+			t.Errorf("attribute %q = %q, want %q", k, attrMap[k], v)
+		}
+	}
+
+	tracesPipeline := cfg["service"].(map[string]interface{})["pipelines"].(map[string]interface{})["traces"].(map[string]interface{})
+	procs := tracesPipeline["processors"].([]interface{})
+	found := false
+	for _, p := range procs {
+		if p == "resource" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("traces pipeline missing 'resource' processor")
+	}
+}
+
+func TestBuildOtelCollectorValues_OptionalFieldsOmitted(t *testing.T) {
+	pipeline := &butlerv1alpha1.ObservabilityPipelineConfig{
+		TraceEndpoint: "10.0.0.5:4317",
+	}
+	tc := &butlerv1alpha1.TenantCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "bare-cluster", Namespace: "ns", UID: "uid-bare",
+		},
+	}
+
+	ev := buildOtelCollectorValues(pipeline, tc, "")
+	if ev == nil {
+		t.Fatal("expected non-nil ExtensionValues")
+	}
+
+	var vals map[string]interface{}
+	if err := json.Unmarshal(ev.Raw, &vals); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+
+	cfg := vals["config"].(map[string]interface{})
+	proc := cfg["processors"].(map[string]interface{})["resource"].(map[string]interface{})
+	attrs := proc["attributes"].([]interface{})
+
+	if len(attrs) != 3 {
+		t.Errorf("expected 3 attributes, got %d", len(attrs))
+		for _, a := range attrs {
+			m := a.(map[string]interface{})
+			t.Logf("  %s = %s", m["key"], m["value"])
+		}
+	}
+
+	for _, a := range attrs {
+		m := a.(map[string]interface{})
+		key := m["key"].(string)
+		if strings.HasPrefix(key, "butler.") {
+			t.Errorf("optional attribute %q should not be present when source is empty", key)
+		}
+	}
+}
+
+func TestBuildOtelCollectorValues_NilPipelineReturnsNil(t *testing.T) {
+	tc := &butlerv1alpha1.TenantCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "c", Namespace: "ns", UID: "u"},
+	}
+	if ev := buildOtelCollectorValues(nil, tc, ""); ev != nil {
+		t.Error("expected nil for nil pipeline")
+	}
+}
+
+func TestBuildOtelCollectorValues_EmptyEndpointReturnsNil(t *testing.T) {
+	tc := &butlerv1alpha1.TenantCluster{
+		ObjectMeta: metav1.ObjectMeta{Name: "c", Namespace: "ns", UID: "u"},
+	}
+	if ev := buildOtelCollectorValues(&butlerv1alpha1.ObservabilityPipelineConfig{}, tc, ""); ev != nil {
+		t.Error("expected nil for empty trace endpoint")
+	}
+}

--- a/internal/controller/tenantcluster/reconcile_addons_test.go
+++ b/internal/controller/tenantcluster/reconcile_addons_test.go
@@ -1106,8 +1106,15 @@ func TestBuildVectorAgentValues_HTTPSinkURI(t *testing.T) {
 	pipeline := &butlerv1alpha1.ObservabilityPipelineConfig{
 		LogEndpoint: "http://10.0.0.1:8080",
 	}
+	tc := &butlerv1alpha1.TenantCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-cluster",
+			Namespace: "team-a",
+			UID:       "uid-123",
+		},
+	}
 
-	ev := buildVectorAgentValues(pipeline)
+	ev := buildVectorAgentValues(pipeline, tc, "")
 	if ev == nil {
 		t.Fatal("expected non-nil ExtensionValues")
 	}


### PR DESCRIPTION
## Summary

- Add `resolveProviderType` to derive the canonical provider type (nutanix, harvester, etc.) from `TenantCluster.Spec.ProviderConfigRef` via the controller-runtime cached client
- Extend `buildVectorAgentValues` to inject cluster identification fields (cluster, tenant_namespace, cluster_uid, environment, provider_type, provider_config) into the VRL remap transform
- Extend `buildOtelCollectorValues` to inject the same fields as OTLP resource attributes via a resource processor, using semconv keys where applicable
- Optional fields (environment, provider_type, provider_config) are conditionally omitted when their source value is empty, avoiding empty-string labels in Loki/Tempo
- Values are escaped via `strconv.Quote` to handle special characters in cluster names
- Provider type resolution is non-fatal: if the ProviderConfig GET fails, the field is omitted and retried on the next 5-minute reconcile

## Coordinated deploy

Aggregator-side changes (Loki sink label templates) are in separate MRs on butler-observability-pipeline-reference and the Corteva crop GitOps repo. Those MRs should be merged in the same window as this PR to avoid a gap where events carry fields that are not promoted to Loki labels or vice versa. See `.secrets/vector-cluster-identification-tags.md` (local audit doc) for the full design context.

## Test plan

- [x] `resolveProviderType`: nil ref, empty name, valid ref, namespace default, missing ProviderConfig error
- [x] `buildVectorRemapSource`: all fields populated, individual absent, all absent, special characters
- [x] `buildVectorAgentValues`: transform structure, nil/empty pipeline guards
- [x] `buildOtelCollectorValues`: resource attributes, pipeline includes resource processor, optional fields omitted, nil/empty guards
- [x] `go vet ./...` clean
- [ ] CI envtest suite (requires kubebuilder binaries, not available locally)
- [ ] End-to-end: verify rendered VRL on a test tenant after controller deploy