### PR TITLE
test(controller): add resolution drift protection against butler-api fixtures

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/butlerdotdev/butler-controller
 go 1.24.6
 
 require (
-	github.com/butlerdotdev/butler-api v0.19.0
+	github.com/butlerdotdev/butler-api v0.20.0
 	github.com/onsi/ginkgo/v2 v2.22.0
 	github.com/onsi/gomega v1.36.1
 	github.com/prometheus/client_golang v1.22.0

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
-github.com/butlerdotdev/butler-api v0.19.0 h1:krbd+siaS34SMpdK30Wy6y7J92idh/W4hi+11rtzsUc=
-github.com/butlerdotdev/butler-api v0.19.0/go.mod h1:q/RjPFM/r2ELq4DqR78OiAxerKBvH5D4nTGsVLKbjqY=
+github.com/butlerdotdev/butler-api v0.20.0 h1:dcDDiaejo5YN1a7ZZnsxJZhr/kDQk/IUcmPCYsT/PNA=
+github.com/butlerdotdev/butler-api v0.20.0/go.mod h1:q/RjPFM/r2ELq4DqR78OiAxerKBvH5D4nTGsVLKbjqY=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/internal/controller/user/resolve_drift_test.go
+++ b/internal/controller/user/resolve_drift_test.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2026 The Butler Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package user
+
+import (
+	"testing"
+
+	butlerv1alpha1 "github.com/butlerdotdev/butler-api/api/v1alpha1"
+	"github.com/butlerdotdev/butler-api/testdata/resolution"
+)
+
+// TestResolutionDrift asserts that butler-controller's resolution logic
+// produces output matching the shared fixtures in butler-api. The
+// butler-server has an equivalent test. Drift between the two
+// implementations surfaces as a test failure in whichever component
+// diverged from the fixture expectations.
+func TestResolutionDrift(t *testing.T) {
+	fixtures := resolution.LoadAll()
+	if len(fixtures) == 0 {
+		t.Fatal("no fixtures loaded")
+	}
+
+	for _, f := range fixtures {
+		t.Run(f.Name, func(t *testing.T) {
+			// Build typed Team objects from fixture input.
+			teams := make([]butlerv1alpha1.Team, len(f.Input.Teams))
+			for i, ft := range f.Input.Teams {
+				teams[i].Name = ft.Name
+				for _, u := range ft.Access.Users {
+					teams[i].Spec.Access.Users = append(teams[i].Spec.Access.Users,
+						butlerv1alpha1.TeamUser{
+							Name: u.Name,
+							Role: butlerv1alpha1.TeamRole(u.Role),
+						})
+				}
+				for _, g := range ft.Access.Groups {
+					teams[i].Spec.Access.Groups = append(teams[i].Spec.Access.Groups,
+						butlerv1alpha1.TeamGroup{
+							Name: g.Name,
+							Role: butlerv1alpha1.TeamRole(g.Role),
+						})
+				}
+			}
+
+			// Run resolution.
+			result := resolveTeamMemberships(f.Input.Email, f.Input.LastSeenGroups, teams)
+
+			// Compare against fixture expectations.
+			if len(result) != len(f.Expected) {
+				t.Fatalf("membership count: got %d, want %d\n  got:  %v\n  want: %v",
+					len(result), len(f.Expected), formatResult(result), f.Expected)
+			}
+			for i := range result {
+				if result[i].Name != f.Expected[i].Name || result[i].Role != f.Expected[i].Role {
+					t.Errorf("membership[%d]: got %s(%s), want %s(%s)",
+						i, result[i].Name, result[i].Role,
+						f.Expected[i].Name, f.Expected[i].Role)
+				}
+			}
+		})
+	}
+}
+
+func formatResult(memberships []butlerv1alpha1.UserTeamMembership) []resolution.ExpectedMembership {
+	out := make([]resolution.ExpectedMembership, len(memberships))
+	for i, m := range memberships {
+		out[i] = resolution.ExpectedMembership{Name: m.Name, Role: m.Role}
+	}
+	return out
+}


### PR DESCRIPTION
## Summary

- Add drift protection test importing `butler-api/testdata/resolution` fixtures (13 cases)
- Asserts controller's `resolveTeamMemberships` produces output matching fixture expectations
- butler-api dependency bumped from v0.19.0 to v0.20.0

## Context

Pairs with the equivalent test in butler-server (butlerdotdev/butler-server#72). Both consumers of the resolution logic now assert against the same shared fixtures. Drift between implementations surfaces as a CI failure in whichever component diverged.

## Verification

- `go build ./...` clean
- `go test ./internal/controller/user/ -run TestResolutionDrift -v` passes all 13 fixture cases