### PR TITLE
fix(webhook): tolerate ClusterCreationPolicy CRD not installed

### DIFF
--- a/internal/webhook/tenantcluster_webhook.go
+++ b/internal/webhook/tenantcluster_webhook.go
@@ -26,6 +26,7 @@ import (
 	admissionv1 "k8s.io/api/admission/v1"
 	authnv1 "k8s.io/api/authentication/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -675,6 +676,19 @@ func (v *TenantClusterValidator) validatePolicy(ctx context.Context, tc *butlerv
 
 	policies := &butlerv1alpha1.ClusterCreationPolicyList{}
 	if err := v.Client.List(ctx, policies); err != nil {
+		// The ClusterCreationPolicy CRD shipped in butler-api v0.21.0
+		// and is distributed via the butler-crds Helm chart. A cluster
+		// that picks up a new butler-controller before the matching
+		// chart upgrade will not have the CRD installed; the list
+		// returns "no matches for kind" instead of an empty list.
+		// Treat that case identically to "no policies installed"
+		// (the len == 0 path below): no policies means no enforcement.
+		// Without this guard, an admission webhook wedge blocks every
+		// TenantCluster apply on the cluster, including the GitOps
+		// reconciles that would deliver the matching CRD.
+		if meta.IsNoMatchError(err) {
+			return errs, nil
+		}
 		return nil, fmt.Errorf("list ClusterCreationPolicy: %w", err)
 	}
 	if len(policies.Items) == 0 {

--- a/internal/webhook/tenantcluster_webhook_test.go
+++ b/internal/webhook/tenantcluster_webhook_test.go
@@ -24,10 +24,13 @@ import (
 
 	admissionv1 "k8s.io/api/admission/v1"
 	authnv1 "k8s.io/api/authentication/v1"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	butlerv1alpha1 "github.com/butlerdotdev/butler-api/api/v1alpha1"
@@ -611,4 +614,50 @@ func TestTCWebhook_Handle_Create_EnvMaxClustersZero_Allowed(t *testing.T) {
 	tc := buildTC("p2", "team-acme", "prod", "", 1)
 	req := newTCAdmissionRequest(t, admissionv1.Create, "any@example.com", tc, nil)
 	assertAllowed(t, v.Handle(context.Background(), req))
+}
+
+// validatePolicy must treat "no matches for kind" on the
+// ClusterCreationPolicyList listing identically to "no policies installed".
+// The CRD ships in butler-api v0.21.0 via the butler-crds chart; a cluster
+// that takes a new butler-controller before the matching chart upgrade
+// has the type referenced in compiled code but not the resource registered
+// in the API server. Without this defensive path, every TenantCluster apply
+// is denied at admission, which wedges any GitOps reconcile that would
+// deliver the CRD. See 2026-05-29 butler-beta investigation in
+// .secrets/butler-beta-vtenantcluster-2026-05-29.md.
+func TestTCWebhook_ValidatePolicy_CRDMissing_TreatedAsNoPolicies(t *testing.T) {
+	s := teamScheme(t)
+
+	// Interceptor returns the same error shape the apiserver produces when
+	// the CRD is not registered: apimeta.NoKindMatchError. Other List calls
+	// fall through to the fake client's normal behavior.
+	noMatchErr := &apimeta.NoKindMatchError{
+		GroupKind: schema.GroupKind{
+			Group: "butler.butlerlabs.dev",
+			Kind:  "ClusterCreationPolicy",
+		},
+		SearchedVersions: []string{"v1alpha1"},
+	}
+	c := fake.NewClientBuilder().
+		WithScheme(s).
+		WithInterceptorFuncs(interceptor.Funcs{
+			List: func(ctx context.Context, inner client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+				if _, ok := list.(*butlerv1alpha1.ClusterCreationPolicyList); ok {
+					return noMatchErr
+				}
+				return inner.List(ctx, list, opts...)
+			},
+		}).
+		Build()
+
+	v := &TenantClusterValidator{Client: c, APIReader: c}
+	tc := buildTC("tc-1", "team-acme", "prod", "", 3)
+
+	errs, err := v.validatePolicy(context.Background(), tc, butlerv1alpha1.ProviderType(""))
+	if err != nil {
+		t.Fatalf("validatePolicy returned error for missing CRD; want nil, got %v", err)
+	}
+	if len(errs) != 0 {
+		t.Fatalf("validatePolicy returned field errors for missing CRD; want none, got %d: %v", len(errs), errs)
+	}
 }


### PR DESCRIPTION
## What this changes

Adds an `apimeta.IsNoMatchError` guard around the `ClusterCreationPolicyList` listing in `TenantClusterValidator.validatePolicy` (`internal/webhook/tenantcluster_webhook.go:677`). When the CRD is not installed in the API server, the admission webhook now treats the situation identically to "no policies installed" (empty-list path) instead of returning an internal error that denies the request.

Four lines of production code plus one focused test case that uses a controller-runtime interceptor to inject the exact `apimeta.NoKindMatchError` the apiserver returns when the CRD is missing.

## Why

The `ClusterCreationPolicy` CRD shipped in `butler-api v0.21.0` and is distributed to clusters via the `butler-crds` Helm chart. butler-controller PR #105 (the same PR that introduced this validation path) bumped to `v0.21.0` and started referencing `ClusterCreationPolicyList` on every `TenantCluster` CREATE and UPDATE admission. The `butler-crds` chart was never updated to ship the new CRD; the chart's templates directory has 20 CRD YAMLs and `clustercreationpolicy-crd.yaml` is not among them.

The result on butler-beta on 2026-05-29: every Flux Kustomization reconcile dry-runs every `TenantCluster` in `clusters/butler-beta`. Each dry-run hits this webhook. The webhook calls `Client.List(ctx, &ClusterCreationPolicyList{})`. The apiserver returns `no matches for kind "ClusterCreationPolicy"`. The webhook returns the wrapped error. The dry-run is denied. The entire Kustomization apply fails. This blocked `butler-server v0.17.0` from rolling out via the standing IUA-driven image patch. Full investigation in `.secrets/butler-beta-vtenantcluster-2026-05-29.md`.

The validation logic at line 683 already short-circuits when `len(policies.Items) == 0` (no policies installed means no enforcement). This change makes "CRD not installed" share that same code path. The semantic is the same. The implementation now matches.

## Verification

`CGO_ENABLED=0 go vet ./...` clean. `go test ./internal/webhook/...` pass including the new `TestTCWebhook_ValidatePolicy_CRDMissing_TreatedAsNoPolicies`. Diff is 63 insertions across two files.

The fix was reasoned about against butler-beta on 2026-05-29 but verified live only via the equivalent kubectl-apply-of-the-CRD short-term unblock; the defensive code path here was not exercised against a running cluster because rolling a new controller image through GitOps requires Flux to be unwedged first, and Flux is currently being unwedged by the direct CRD apply.

## Dependencies and merge order

**Do not merge until the companion `butler-charts` PR lands.** The chart-side fix adds the missing CRD to the `butler-crds` chart. Once the chart is in good shape, this controller fix lands as durability hardening for the next cluster that takes a new controller before the chart upgrade.

The two PRs together close the missed-migration gap from both sides: the chart so the CRD ships, the controller so a future similar gap degrades gracefully instead of wedging admission.

## Not in scope

- Restoring the `butler-crds` chart to include this CRD. That is the companion `butler-charts` PR.
- Auditing the `butler-crds` chart for other out-of-sync CRDs. Worth doing as part of the chart fix; flagged there.
- Resolving butler-beta's Steward webhook outage and etcd-1 crash loop. Separate platform debt, separate session.
